### PR TITLE
Add documentation, linting and CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = true
+
+[*.swift]
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# This file is synced from `MikeMcQuaid/.github`, do not modify it directly.
+---
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: friday
+    time: '08:00'
+    timezone: Etc/UTC
+  groups:
+    github-actions:
+      patterns:
+      - "*"
+  allow:
+  - dependency-type: all
+  cooldown:
+    default-days: 7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,60 @@
+name: GitHub Actions CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  style:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
+        with:
+          core: false
+          cask: false
+          test-bot: false
+
+      - name: Cache Homebrew prefix
+        uses: Homebrew/actions/cache-homebrew-prefix@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
+        with:
+          brewfile: true
+          uninstall: true
+
+      - name: Bootstrap
+        run: script/bootstrap
+
+      - name: Check style
+        run: script/style
+
+  check:
+    if: always()
+    needs:
+      - style
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Verify all jobs succeeded
+        uses: re-actors/alls-green@afee1c1eac2a506084c274e9c02c8e0687b48d9e # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,9 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# XcodeGen
+*.xcodeproj
+
+# Sandboxed builds
+.DerivedData/

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,12 @@
+# Suggest adding a default case in case statements.
+enable=add-default-case
+# Suggest [ -n "$var" ] over ! [ -z "$var" ].
+enable=avoid-nullary-conditions
+# Warn when uppercase variables are referenced but never assigned.
+enable=check-unassigned-uppercase
+# Suggest command -v over which.
+enable=deprecate-which
+# Suggest quoting variables even where safe.
+enable=quote-safe-variables
+# Require [[ ]] over [ ] in Bash scripts.
+enable=require-double-brackets

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,4 @@
+# Rule disagreements are disabled per line with a reason, never here.
+--enable all
+--swiftversion 6.4
+--indent 4

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,6 @@
+# Every rule is enabled; disable per line with a reason, never here.
+opt_in_rules:
+  - all
+excluded:
+  - .build
+  - .DerivedData

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# Agent Instructions for MikeMcQuaid/AgentIDE
+
+Most importantly: run `script/style --fix` before finishing any change,
+read `README.md` and `ARCHITECTURE.md` before changing anything and
+update them in the same commit when behaviour they describe changes.
+This repository is readme-driven: documentation leads, code follows.
+
+AgentIDE is a native SwiftUI macOS app for running, steering and
+reviewing sandboxed AI coding agents. Nothing builds yet; see the
+Status section of `README.md` for the slice order.
+
+Write sentence-case imperative commit messages without
+conventional-commit prefixes such as `feat:`, `fix:` or `chore:`.
+
+## Commands
+
+- `script/bootstrap`: install `Brewfile` dependencies (and generate
+  `AgentIDE.xcodeproj` with XcodeGen once the skeleton slice lands)
+- `script/style`: run all linters; `--fix` also applies safe fixes
+- `script/attach <session>`: attach this terminal to a sandboxed
+  tmux session (works as the host user or inside the sandbox)
+
+## Repository Structure
+
+- `README.md`: user workflow and features; the product specification
+- `ARCHITECTURE.md`: system design, packages and data flows
+- `AGENTS.md`: this file; `CLAUDE.md` is a symlink to it
+- `script/`: development tasks
+- `Brewfile`: development dependencies
+- `.github/workflows/tests.yml`: CI
+- Planned: `project.yml` (XcodeGen; the generated `.xcodeproj` stays
+  gitignored), `App/` and `Packages/` with Domain, DataAccess and
+  Feature targets
+
+## Code Standards
+
+- Swift 6.4 with strict concurrency: App and Feature targets use
+  MainActor default isolation; Domain and DataAccess are nonisolated
+- Every SwiftLint and SwiftFormat rule is enabled; disable per line
+  with a comment explaining why, never in configuration
+- UK English (organised, colour) in documentation, comments and UI
+  strings; proper nouns keep their official spellings
+- Keep comments minimal; prefer self-documenting code
+- Two-space indentation, four-space for Swift (see `.editorconfig`)
+
+### Required Before Each Commit
+
+- Run `script/style --fix` and resolve anything it cannot fix
+- Reread changed documentation for UK English, working links and
+  72-column wrapping of this file
+- Confirm `README.md` and `ARCHITECTURE.md` still describe behaviour
+  after your change
+
+## Key Guidelines
+
+1. Documentation first: update `README.md` and `ARCHITECTURE.md`
+   before writing code whose behaviour they describe.
+2. Never widen the sandvault sudoers rules or otherwise weaken the
+   sandbox; treat all agent output as untrusted input.
+3. Never run `gh` or any host-credentialled command inside the
+   sandbox. The host fetches GitHub data and passes it into prompts;
+   sandboxed pushes use per-repository deploy keys only.
+4. Derive state from tmux, git and `gh` on demand rather than caching
+   it. AgentIDE must be killable at any moment losing nothing, and
+   closed sessions and deleted worktrees must stay restorable and
+   resumable.
+5. Keep dependency directions clean: Domain depends on nothing,
+   DataAccess and Features depend on Domain and App composes them.
+6. Keep agent-specific logic inside its adapter; everything else
+   speaks one agent interface.
+7. Describe third-party apps this project replaces by category, never
+   by product name, in every committed file.
+8. Keep diffs minimal and follow existing structure.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,515 @@
+# AgentIDE Architecture
+
+How AgentIDE works under the hood. [README.md](README.md) owns what it does
+and why; this document owns the system design. The feature groups referenced
+here (Start work, Watch and steer, Review, Ship, Tidy up and Resilience) are
+the README's Features subsections.
+
+## Overview
+
+AgentIDE is a native SwiftUI macOS app (macOS 27 or later, Swift 6.4,
+AGPL-3.0) that runs, steers and reviews sandboxed AI coding agents in
+parallel git worktrees. It is developed readme-first: this document describes
+the target system and slices of it land in the order given in the README's
+Status section.
+
+The architectural thesis, referenced throughout: **AgentIDE holds no
+session-critical state**. Agents run as the sandvault sandbox user inside a
+tmux server that AgentIDE introduces. The app derives its entire view of the
+world from tmux, `ps`, git, agent transcripts and GitHub, and persists only
+its own metadata in SQLite. Killing, crashing or updating the app therefore
+loses nothing (Resilience).
+
+## System context
+
+```mermaid
+flowchart LR
+    ios["iOS SSH client"]
+    subgraph mac["Mac"]
+        subgraph host["Host user"]
+            app["AgentIDE.app<br/>gh token in memory only"]
+        end
+        subgraph sandbox["Sandbox user (sandvault-&lt;user&gt;)"]
+            tmux["tmux server"]
+            agents["Agent sessions:<br/>Claude Code, Codex CLI"]
+        end
+        shared[("Shared workspace<br/>/Users/Shared/sv-&lt;user&gt;")]
+    end
+    github["GitHub"]
+
+    app -->|"sudo, env -i, sandbox-exec, zsh:<br/>the only privilege crossing"| tmux
+    tmux --- agents
+    app -.->|"read-only observation:<br/>FSEvents, transcripts, ps"| sandbox
+    app <--> shared
+    agents <--> shared
+    app -->|"GraphQL and REST via URLSession,<br/>gh CLI for one-shots"| github
+    agents -.->|"no credentials by default;<br/>optional read-only deploy key"| github
+    ios -->|"SSH as host user,<br/>then tmux attach"| tmux
+```
+
+Boundary facts the design relies on:
+
+- The sandbox may write only to the shared workspace, its own home, `/tmp`,
+  `/var/folders` and `/dev`. The host user's home is unreadable from inside
+  and keychains are denied.
+- The shared workspace is writable by both users through inheriting ACLs; it
+  is the data plane for code, prompts and events.
+- The sandbox has no GitHub credentials: `gh` is unauthenticated there, agent
+  settings deny `git push` and the only remote access is an optional
+  per-repository read-only deploy key. Pushing and everything credentialled
+  happens host-side.
+- Credentials never cross the boundary in either direction.
+
+## Guiding principles
+
+1. **P1: Derive, don't own.** tmux, git, `ps`, transcripts and GitHub are the
+   sources of truth. The app reconciles from them on every launch.
+2. **P2: Unprivileged glue.** The only privilege crossing is the sudoers path
+   sandvault already configured. AgentIDE never widens it.
+3. **P3: Compiler-enforced boundaries.** Clean architecture mapped onto SPM
+   targets; an illegal dependency is a build failure, not a review comment.
+4. **P4: Approachable strict concurrency.** MainActor by default in UI
+   targets, nonisolated core, `@concurrent` for heavy leaf work, structured
+   tasks everywhere.
+5. **P5: Agents are pluggable.** One `AgentRunner` seam; agent-specific logic
+   lives only in adapters. Sessions created elsewhere are still shown.
+6. **P6: Native for state, shell for one-shots.** Anything polled or rendered
+   uses native URLSession clients; fire-and-forget conveniences shell out.
+7. **P7: Agent output is hostile input.** Every host-side touch of
+   guest-writable data is hardened accordingly.
+
+## Process model and lifecycles
+
+Two independent lifecycles:
+
+- **The app process** is ephemeral. It can quit, crash or update at any time
+  and holds nothing that cannot be rebuilt (P1).
+- **Sessions** are tmux sessions owned by the sandbox user. They survive app
+  restarts, app updates and host-user logout, but not reboot. Reboot recovery
+  is worktree plus transcript plus resume (see State and persistence).
+
+### Launching into the sandbox
+
+sandvault's sudoers rules let the host user run exactly `/bin/zsh`,
+`/usr/bin/env` and `/usr/bin/true` as the sandbox user without a password, so
+every sandbox interaction is built on one launch shape, assembled in exactly
+one place (`SandvaultLauncher`):
+
+```bash
+sudo --login --set-home --user="sandvault-${USER}" /usr/bin/env -i \
+  HOME="/Users/sandvault-${USER}" USER="sandvault-${USER}" SHELL=/bin/zsh \
+  TERM=xterm-256color COLORTERM=truecolor \
+  INITIAL_DIR="${WORKTREE}" SHARED_WORKSPACE="/Users/Shared/sv-${USER}" \
+  SV_SESSION_ID="$(uuidgen)" AGENTIDE_SESSION="${SESSION_NAME}" \
+  PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+  GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.directory \
+  GIT_CONFIG_VALUE_0="/Users/Shared/sv-${USER}/*" \
+  /usr/bin/sandbox-exec -f "/var/sandvault/sandbox-sandvault-${USER}.sb" \
+  /bin/zsh -c "${PAYLOAD}"
+```
+
+This is byte-compatible with how sandvault launches sessions; AgentIDE only
+substitutes the payload. Notable parts: `env -i` gives a clean environment,
+the `GIT_CONFIG_*` variables inject `safe.directory` (shared repositories are
+owned by the other user) and `sandbox-exec` applies sandvault's generated
+profile to everything downstream, including the tmux server.
+
+### tmux
+
+tmux is installed by the Brewfile and introduced by AgentIDE; sandvault does
+not use it itself. There is no daemon and no launchd unit: the tmux server
+starts lazily inside the sandbox the first time a session is created, with a
+payload of:
+
+```bash
+export TMPDIR="$(mktemp -d)" TMUX_TMPDIR=/tmp
+cd ~ && ~/configure
+source ~/.zshenv && source ~/.zprofile && source ~/.zshrc
+exec tmux new-session -A -d -s "${SESSION_NAME}" "${AGENT_COMMAND}"
+```
+
+- `TMUX_TMPDIR` is pinned to `/tmp` (writable inside the sandbox) so every
+  later invocation finds the same server socket despite the randomised
+  `TMPDIR`.
+- Sessions set `remain-on-exit on`, so a finished agent leaves a dead pane
+  whose exit status and scrollback remain inspectable.
+- Session names follow `agentide--<repo>--<branch-slug>--<agent>` with `--2`
+  suffixes on collision (tmux forbids `.` and `:` in names). Names are a
+  human-readable fallback for `tmux ls` over SSH; the authoritative record is
+  the app's metadata store. Anything not matching `agentide--*` is treated as
+  foreign.
+
+### Terminals
+
+Two visually unmistakable flavours, both rendered by SwiftTerm on a local
+PTY:
+
+- **Sandbox terminal**: the launch shape with payload
+  `exec tmux attach-session -t <name>`. The attaching client runs inside the
+  sandbox too; tmux sockets are owner-only, so no attach path can skip sudo.
+  Closing the view detaches and never kills the session.
+- **Host terminal** (Review): plain `/bin/zsh -il` as the host user in the
+  worktree, no sudo, no sandbox, full `gh` credentials.
+
+Remote access is SSH to the Mac as the host user from an iOS client, then
+`script/attach <session>` (which also works from inside sandbox sessions).
+Remote Login must be enabled in macOS settings first. An SSH session is
+isolated by user permissions rather than sandbox-exec whichever account it
+targets, but attaching connects it to the sandboxed tmux server, so agent
+processes stay confined either way.
+
+### Reconciliation and notifications
+
+On every launch the app rebuilds state, in order, from: `tmux ls` (through
+the launch shape, tolerating "no server running"), a `ps` scan for session
+ids in process arguments, `git worktree list` across tracked repositories,
+transcript directory scans and finally its own metadata store. Unmatched
+sessions surface as foreign rather than being hidden.
+
+There is no separate notification daemon in v1. The app switches to accessory
+activation policy when its last window closes, staying resident in the menu
+bar with file watchers and `UNUserNotificationCenter` delivery alive. Because
+the event spool is durable files, a fully quit app delays notifications
+rather than losing them. A login-item helper via `SMAppService` is the
+documented later option if delayed notifications prove annoying.
+
+## Package architecture
+
+One root `Package.swift` defines every library target; a thin app shell in
+`App/` is generated into an Xcode project by XcodeGen (`project.yml` is
+committed, the `.xcodeproj` is gitignored).
+
+```mermaid
+flowchart TD
+    App["AgentIDEApp<br/>(composition root)"]
+    Dashboard["DashboardFeature"]
+    Session["SessionFeature"]
+    Review["ReviewFeature"]
+    PR["PRFeature"]
+    Terminal["TerminalUI"]
+    Data["AgentIDEData<br/>(ports and adapters)"]
+    Domain["AgentIDEDomain<br/>(pure)"]
+
+    App --> Dashboard & Session & Review & PR & Data
+    Dashboard --> Domain
+    Session --> Domain
+    Review --> Domain
+    PR --> Domain
+    Session --> Terminal
+    Dashboard -.->|ports| Data
+    Session -.->|ports| Data
+    Review -.->|ports| Data
+    PR -.->|ports| Data
+    Data --> Domain
+```
+
+- **AgentIDEDomain**: entities (`Repository`, `Worktree`, `AgentSession`,
+  `AgentKind`, `SessionEvent`, `PullRequest`, `CheckRun`, `ReviewThread`,
+  `DiffFile`, `DiffHunk` and `DiffLine`) and pure logic (`DiffParser`,
+  `PatchBuilder`, `SessionName` and transcript event decoding). Foundation
+  value types (Date, URL and Data) are allowed; process, file, network and
+  database APIs are banned.
+- **AgentIDEData**: protocol ports with adapter implementations: `GitClient`,
+  `GitHubClient` (URLSession GraphQL and REST), `SandvaultLauncher`,
+  `TmuxControl`, `TranscriptReader`, `EventSpool`, `MetadataStore` (GRDB),
+  `ProcessRunner` (Subprocess) and `AgentRunner` with `ClaudeCodeRunner` and
+  `CodexRunner`. One module with ports and adapters in separate directories,
+  split into two modules only if boundary violations appear.
+- **Feature targets** (`DashboardFeature`, `SessionFeature`, `ReviewFeature`
+  and `PRFeature`): SwiftUI views and `@Observable` view models, MainActor by
+  default, given ports via injection. `SessionFeature` owns the WKWebView
+  preview; `ReviewFeature` owns the diff and editor surfaces.
+- **TerminalUI**: a dumb SwiftTerm wrapper (command specification in, PTY
+  view out), used by `SessionFeature` for both terminal flavours. A
+  component, not a feature.
+- **AgentIDEApp**: builds adapters, injects ports, owns navigation and the
+  activation-policy switch. No logic.
+
+Third-party imports are confined (P3):
+
+| Dependency | Only importable in |
+|---|---|
+| GRDB, Subprocess | AgentIDEData |
+| SwiftTerm | TerminalUI |
+| STTextView, SwiftTreeSitter and grammars | ReviewFeature |
+| Sparkle | AgentIDEApp |
+| WebKit | SessionFeature |
+
+### The AgentRunner seam
+
+`AgentRunner` (P5) covers exactly: building the launch payload for a
+worktree, prompt file and optional resume token; locating and decoding the
+agent's transcript into `SessionEvent` values; detecting completion and
+stalls (capability flags `supportsHooks` and `supportsResume` select
+hook-based or polling strategies); building the resume command; and
+extracting the final message for review. `ClaudeCodeRunner` uses hooks and
+cwd-keyed JSONL transcripts; `CodexRunner` proves the seam with
+directory-based transcripts and silence-based detection. Discovering foreign
+sessions is reconciliation logic in `AgentIDEData`, deliberately outside the
+protocol.
+
+## Concurrency model
+
+| Target | Default isolation | Notes |
+|---|---|---|
+| AgentIDEDomain | nonisolated | Sendable value types by construction |
+| AgentIDEData | nonisolated | `@concurrent` on parsing and subprocess work |
+| Features, TerminalUI | MainActor | `@Observable` MainActor view models |
+| AgentIDEApp | MainActor | wiring only |
+
+All targets build with `SWIFT_DEFAULT_ACTOR_ISOLATION` set per the table,
+`SWIFT_APPROACHABLE_CONCURRENCY=YES` and the Swift 6 language mode.
+
+The nuance that matters most: under approachable concurrency, `nonisolated
+async` functions run on the caller's actor. Quick awaited I/O (URLSession and
+GRDB's async API) therefore stays plain `nonisolated async`; only CPU-bound
+or blocking leaf work (JSONL decoding, diff parsing and subprocess output
+pumping) is marked `@concurrent` to move off the caller.
+
+Events flow as `AsyncStream`s (file watches, transcript tails, poll ticks and
+GitHub results) consumed by view models via `.task`, so cancellation follows
+view lifetime. Fan-out uses task groups. Unstructured `Task {}` appears only
+at enumerated app-lifecycle roots. Exactly one actor is sanctioned:
+`ProcessRegistry` in `AgentIDEData`, owning live PTY and child-process
+handles; any further actor needs a written justification here. `@unchecked
+Sendable` and `nonisolated(unsafe)` are banned.
+
+## Key data flows
+
+### Create a worktree and launch an agent (Start work)
+
+1. Input: a typed prompt, or an issue or pull request reference, plus a
+   target repository.
+2. The branch name comes from a per-repository template, default
+   `agent/<slug>`.
+3. Host-side `GitClient` fetches, then runs `git worktree add` under
+   `/Users/Shared/sv-<user>/worktrees/<uuid>/<branch>`. This layout is kept
+   byte-compatible with what existing tooling already creates: the
+   repository's existing `<uuid>` directory is discovered via
+   `git worktree list` and reused; a new one is minted only when the
+   repository has none. The uuid map is cached in the metadata store and
+   always re-derivable.
+4. A human-friendly symlink
+   `/Users/Shared/sv-<user>/agentide/worktrees/<repo>/<branch>` points at the
+   canonical path. Sessions always launch from the resolved real path because
+   agent transcripts are keyed by cwd; UUIDs appear nowhere else in
+   user-visible naming.
+5. The prompt is written to
+   `/Users/Shared/sv-<user>/agentide/prompts/<session>.md`, readable in the
+   sandbox through the workspace ACLs.
+6. Deploy keys: none by default; the agent works offline against the local
+   clone. A per-repository opt-in provisions a read-only key through
+   sandvault's `sv-clone -k` mechanism. Write keys are never provisioned;
+   pushing is host-side.
+7. `AgentRunner` builds the agent command (sandvault's wrappers add the
+   agent's permission-skipping flag inside the sandbox) and the session
+   launches through the tmux payload above.
+8. The session is recorded in the metadata store, with the agent-native
+   resume id captured as soon as the transcript appears.
+
+### Event pipeline (Watch and steer)
+
+1. AgentIDE manages the Claude Code settings template at
+   `/Users/Shared/sv-<user>/user/.claude/settings.json`, which sandvault
+   rsyncs into the sandbox home at each session start. AgentIDE adds its hook
+   entries alongside any existing notifier hooks (removing others only when
+   their app is retired), covering UserPromptSubmit, Stop, StopFailure,
+   PostToolUse, PostToolUseFailure, PermissionRequest, SessionStart and
+   SessionEnd, each in the defensive `[ -x ... ] && ... || true` shape.
+2. The hook command is a small script shipped through the same template
+   directory. It appends one JSON line to
+   `/Users/Shared/sv-<user>/agentide/events/<session>.jsonl`, keyed by
+   `AGENTIDE_SESSION` with `SV_SESSION_ID` as fallback so sessions launched
+   outside AgentIDE feed the dashboard too, and it no-ops when neither is
+   set. Appends are single-writer and small; the reader tolerates a torn
+   last line.
+3. Host-side, `EventSpool` watches the events directory with FSEvents and
+   tails each file from its stored offset, emitting `SessionEvent` values
+   that drive unread counts and notifications (on Stop and
+   PermissionRequest).
+4. Agents without hooks, and foreign sessions, fall back to tmux dead-pane
+   detection for completion and a transcript-mtime timeout on a 30 second
+   tick for stalls. `tmux monitor-silence` is a documented later refinement.
+5. If the app is fully quit, events accumulate in the spool and notifications
+   arrive on next launch.
+
+### Review and per-line rejection (Review)
+
+1. `GitClient` produces diffs (`git diff`, `git diff --cached` and ranges)
+   with rename detection; the pure `DiffParser` turns them into file, hunk
+   and line values.
+2. Generated files are hidden by default via
+   `git check-attr linguist-generated` plus heuristics (lockfiles and
+   per-repository generated globs), one click to reveal.
+3. Rendering uses STTextView with tree-sitter highlighting. Initial grammars:
+   Swift, Ruby, JavaScript, TypeScript, Markdown, JSON, YAML and Bash.
+4. Rejecting selected lines builds a minimal reverse patch with
+   `PatchBuilder` (pure, with recalculated hunk offsets), validates it with
+   `git apply --check`, applies it with `git apply -R --index` so index and
+   worktree stay consistent, then runs `git commit --amend` (with `-m` when
+   the message was edited too). Failed validation degrades to whole-hunk
+   rejection. Uncommitted changes skip the amend.
+5. Manual edits happen in the same editor surface; saves trigger a diff
+   refresh via file watches.
+6. The pre-amend commit remains in the reflog and is surfaced as "revert last
+   rejection".
+
+### Pull request dashboard (Ship)
+
+1. The token comes from a one-shot `gh auth token`, held in memory only and
+   refreshed on 401 (P6).
+2. One aliased GraphQL query batches every tracked repository: open pull
+   requests with mergeable state, merge-state status, review decision, check
+   rollup, unresolved review threads, draft state and automerge state.
+3. Poll cadence: 60 seconds for the focused repository, 5 minutes in the
+   background, jittered; the API point budget bounds how many repositories
+   can be tracked.
+4. Native versus shell: polling, dashboards and review threads are native
+   URLSession; `gh pr create` (templates and stacking), `gh pr merge --auto`
+   and other one-shots shell out as the host user.
+5. One-click remediation composes existing flows: fetch failing check logs
+   and review comments natively, write them into a prompt file and launch a
+   fix agent in the same worktree.
+
+### Cleanup and undelete (Tidy up)
+
+1. A merged pull request offers cleanup (or per-repository auto-clean).
+2. An archive is written to
+   `~/Library/Application Support/AgentIDE/Archives/<id>/`, deliberately
+   outside the guest-writable workspace so recovery state cannot be tampered
+   with: a git bundle of the branch, a tar of untracked and modified files,
+   copies of transcript, prompt and event spool, and a self-describing
+   `metadata.json` recording the canonical worktree path, branch, repository
+   uuid and agent-native resume ids.
+3. Then: kill the tmux session, `git worktree remove`, `git branch -d` and
+   remove the friendly symlink. Canonical transcripts in the sandbox home are
+   never deleted.
+4. Undelete restores from the bundle at the same canonical path (so cwd-keyed
+   conversation state lines up), untars, recreates the symlink and restores
+   metadata; the session can then resume.
+5. Archives are kept until manually purged; total size is shown in settings.
+
+### Close and reopen a session
+
+Closing a session kills only the tmux session. The worktree, transcripts and
+metadata (including the resume id) remain. Reopening builds the agent's
+resume command (`claude --resume <id>`, or the Codex equivalent) through the
+normal launch shape in the same canonical cwd, restoring the full prior
+conversation. Deleting and undeleting a worktree composes with this, so even
+a fully cleaned-up session is restorable and resumable.
+
+## State and persistence
+
+| Fact | Source of truth | The app's role |
+|---|---|---|
+| Session liveness, scrollback, exit codes | tmux | observe via the launch shape |
+| Code, branches, diffs, worktrees | git in the shared workspace | operate host-side, hardened |
+| Conversation history, final message | agent transcripts | read-only tail |
+| Pull request, CI and review state | GitHub | poll, cache in memory |
+| Agent process existence | `ps` | scan |
+| Unread markers, spool offsets, prompt history, per-repository settings, repository-to-uuid map, archive index, window state | metadata store (GRDB) | sole owner |
+
+The metadata store lives at
+`~/Library/Application Support/AgentIDE/agentide.sqlite` (WAL mode, migrated
+with `DatabaseMigrator`), deliberately outside the shared workspace so agents
+can neither read nor corrupt it. Deleting it loses only unread state, prompt
+history and settings; everything else re-derives from the system or from
+archive metadata (P1).
+
+## Security model
+
+Trust boundaries, numbered:
+
+1. **Host to sandbox**: the sudoers surface is exactly `/bin/zsh`,
+   `/usr/bin/env` and `/usr/bin/true` as the sandbox user, plus root-level
+   whole-user teardown (`launchctl bootout` of the sandbox uid and `pkill -9`
+   of the sandbox user). AgentIDE uses the zsh path for everything; the
+   teardown pair backs a confirmed "Emergency stop all agents" action only.
+2. **Sandbox to network**: no GitHub credentials, `git push` denied by agent
+   settings and optional read-only per-repository deploy keys as the only
+   remote path.
+3. **App to GitHub**: token from `gh auth token`, in memory only, never on
+   disk and never in any launch environment.
+4. **Host to guest-written data** (P7): every host git invocation goes
+   through `GitClient`, which always prepends
+   `-c core.fsmonitor= -c core.sshCommand= -c core.hooksPath=/dev/null -c
+   core.pager=cat -c protocol.ext.allow=never` so a compromised repository
+   cannot execute code as the host user. Raw `git` outside `GitClient` is
+   banned.
+5. **Transcript exposure**: sandvault's session export applies inheriting
+   group-read ACLs to agent transcript directories; AgentIDE relies on read
+   access and never widens it.
+
+WKWebView previews use a non-persistent data store and are restricted to file
+and localhost origins; agent-authored HTML is untrusted content.
+
+Never-do list:
+
+- Never modify sudoers or the sandbox profile.
+- Never run credentialled commands inside the sandbox.
+- Never write secrets or app-critical state into the shared workspace.
+- Never execute agent-suggested commands as the host user without an explicit
+  user action.
+- Never bypass `GitClient` hardening.
+- Never widen transcript ACLs beyond read.
+
+## Dependencies and toolchain
+
+Dependency admission rule: more than 1,000 GitHub stars and a stable release
+in 2026, or an explicitly recorded exception for packages owned by an
+official language or project organisation.
+
+| Package | Role | Note |
+|---|---|---|
+| SwiftTerm | terminal emulator views | |
+| GRDB | metadata store | |
+| STTextView | diff and editor text surface | TextKit 2 |
+| swift-tree-sitter and language grammars | syntax highlighting | official-organisation exception; each grammar is its own package under the same exception |
+| swift-subprocess | process spawning | official-organisation exception (swiftlang) |
+| Sparkle | app updates | later slice |
+
+System frameworks (WebKit, UserNotifications and FSEvents) and runtime tools
+(tmux, installed by Homebrew and never linked) sit outside the table.
+Versions are pinned by `Package.resolved`; the two exceptions are pinned
+exactly.
+
+Toolchain: Xcode 27, the macOS 27 SDK and Swift 6.4. XcodeGen generates the
+app project from `project.yml`; the `.xcodeproj` is gitignored. SwiftLint and
+SwiftFormat run with every rule enabled; disagreements are disabled per line
+with a reason, never in configuration.
+
+Scripts follow the `script/` convention: `bootstrap` (Homebrew dependencies,
+then project generation once the skeleton lands), `style [--fix]` (all
+linters; Swift linters no-op until Swift files exist) and
+`attach <session>` (attach the current terminal to a sandboxed tmux
+session), with `test` to follow. Agent-driven builds inside the sandbox cannot nest macOS
+sandboxes, so build scripts gate on `SV_SESSION_ID` and pass
+`SWIFTPM_DISABLE_SANDBOX=1`, `SWIFT_BUILD_USE_SANDBOX=0` and the
+`-IDEPackageSupportDisable*Sandbox` xcodebuild flags, letting agents build
+AgentIDE itself.
+
+CI ("GitHub Actions CI" in `.github/workflows/tests.yml`) runs the style
+checks from this slice onward; build and test jobs join with the skeleton
+slice, pinned to the newest macOS image (with a documented risk while macOS
+27 runners are in beta). Tests use Swift Testing: near-total coverage of
+Domain's pure functions over recorded fixtures, Data adapters against fakes
+and scrubbed fixtures captured from a real machine, view models against fake
+ports and a single launch smoke test for UI.
+
+## Risks and open questions
+
+| # | Risk | Mitigation |
+|---|---|---|
+| R1 | tmux is validated under sandbox-exec on this machine: daemonised server, /tmp socket, separate clients, capture, dead panes with exit statuses, sudo-launched bring-up shared with in-sandbox clients and interactive attach and detach via `script/attach`; only long-run stability remains unobserved | watch stability through the core loop slice; fallback ladder is screen then a minimal PTY-holder process; app-owned PTYs are not acceptable because they forfeit Resilience |
+| R2 | macOS 27 GitHub runners may lag the beta | style-only CI first; self-hosted runner fallback |
+| R3 | per-line selection and diff gutters on STTextView are non-trivial | prototype early in the Review slice; interim read-only diff |
+| R4 | agent transcript formats drift across releases | tolerant decoders, per-release fixtures and adapter capability flags |
+| R5 | sandvault updates could change paths, profile or sudoers | pin the sandvault version; `SandvaultLauncher` is the single construction point; bootstrap asserts the expected shape |
+| R6 | event spool append atomicity | small single-writer lines; readers tolerate a torn tail |
+| R7 | the worktree uuid layout is a compatibility choice, not ours | keep byte-compatibility while other tooling uses it; the friendly symlinks isolate everything user-facing; own the layout later |
+| R8 | resume ids depend on transcript internals | record defensively; fall back to a fresh session in the same worktree pointing at the old transcript |
+
+Open questions: the iOS SSH account model (host user with a wrapper versus
+SSH directly to the sandbox user), the default branch template, archive
+retention policy, notification preference granularity and how deep stacked
+pull request support goes in v1.

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,8 @@
+brew "actionlint"
+brew "gh"
+brew "shellcheck"
+brew "shfmt"
+brew "swiftformat"
+brew "swiftlint"
+brew "tmux"
+brew "zizmor"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,2 +1,152 @@
 # AgentIDE
+
 🪪 IDE for Agents
+
+A native macOS app for running, steering and reviewing sandboxed AI coding
+agents in parallel git worktrees, from problem statement to merged pull
+request. Built with SwiftUI on top of
+[sandvault](https://github.com/webcoyote/sandvault),
+[tmux](https://github.com/tmux/tmux/wiki) and the [gh](https://cli.github.com)
+CLI.
+
+## Motivation
+
+My agentic coding setup, described in
+[Sandboxes and Worktrees: My secure Agentic AI Setup](https://mikemcquaid.com/sandboxed-agent-worktrees-my-coding-and-ai-setup-in-2026/),
+previously spanned four apps: an agent manager to run agents in worktrees, a
+git client to review their work, a code editor to fix it and a terminal for
+everything else. AgentIDE replaces all four with a single native app designed
+around that workflow rather than four apps adapted to it, with no web-tech
+wrappers. Agents run inside a sandvault sandbox with no GitHub credentials so
+they can run wild without babysitting permission prompts or endangering the
+rest of my machine. Sessions live in tmux owned by the sandbox user so nothing
+is lost when the app quits, crashes or updates.
+
+## Features
+
+In workflow order; the loop from prompt to review repeats as often as needed
+before shipping.
+
+### Start work
+
+- Creates or clones repositories into the sandvault shared workspace, symlinks
+  them into your home directory and bootstraps them (so your user and the
+  sandbox share one checkout with nothing to keep in sync)
+- Creates a worktree and branch from a typed problem statement or an existing
+  issue or pull request (so starting work is one prompt, not a git ritual)
+- Starts the agent of your choice in tmux inside the sandvault sandbox, with
+  Claude Code and Codex CLI supported first and more pluggable later (so
+  agents run unattended with no permission prompts and no access to your
+  credentials)
+
+### Watch and steer
+
+- Shows every agent's state on one dashboard, including sessions started
+  outside AgentIDE (so one window tells you who needs attention)
+- Groups worktrees by repository, showing unread agent output, open pull
+  requests, mergeability and uncommitted or unpushed work (so you always know
+  where you are needed)
+- Notifies you when an agent finishes or its output stalls (so you never sit
+  polling a terminal)
+- Commits work the agent forgot to commit, clearly authored as such (so
+  nothing is stranded in a worktree and review still sees everything)
+- Lets you SSH into any session from an iOS SSH client (so you can steer or
+  add context away from your Mac)
+
+### Review
+
+- Presents the agent's final message beside a pull-request-style review of its
+  diff, syntax highlighted with generated files hidden (so you review what
+  matters the way you would on GitHub)
+- Rejects individual lines to amend the commit, edits commit messages and
+  edits files directly in a built-in syntax-highlighted editor (so small fixes
+  need no other app)
+- Previews web pages and rendered Markdown in an embedded browser and opens an
+  embedded terminal running as your own user (so you can verify behaviour and
+  use git, gh and other CLI tools without leaving the window)
+
+### Ship
+
+- Pushes branches and opens one or more pull requests, stacked if needed,
+  across public and private repositories using their templates (so shipping
+  matches how each project already works)
+- Addresses automated and human review comments, fixes failing CI, resolves
+  merge conflicts and enables automerge or merges, each with one click (so
+  the last mile is not the slowest)
+
+### Tidy up
+
+- Deletes the worktree and its state when the pull request merges, with
+  undelete restoring the branch, files and resumable agent conversation (so
+  finished work disappears but nothing is ever truly lost)
+
+### Resilience
+
+- Keeps sessions in a tmux server owned by the sandbox user rather than the
+  app (so agents and terminals survive AgentIDE quitting, crashing or
+  updating, expectedly or not)
+
+## Out of Scope Features
+
+- Being a general-purpose IDE (the built-in editor is for review-time fixes;
+  use your preferred editor for long editing sessions)
+- Windows or Linux support (being a native macOS app is the point)
+- Replacing sandvault (AgentIDE drives sandvault; sandboxing policy stays
+  there)
+- Running agents outside the sandbox (the agents' own dangerous flags exist if
+  you must)
+- Team, multi-user or hosted features (one developer, one Mac)
+- An agent marketplace or bundled models (bring your own Claude Code, Codex
+  CLI or other supported agent)
+- A native iOS app (remote access is SSH into tmux from any iOS SSH client)
+
+## Requirements
+
+- macOS 27 or later
+- [Homebrew](https://brew.sh) (installs the dependencies below)
+- [sandvault](https://github.com/webcoyote/sandvault) (creates the sandbox
+  user and shared workspace)
+- [gh](https://cli.github.com) authenticated as you (it stays with your user;
+  agents never see it)
+- tmux (installed by `script/bootstrap` via the `Brewfile`)
+- Xcode 27 or later (only needed to build from source)
+
+## Usage
+
+Nothing builds yet; see [Status](#status). Once the app skeleton lands:
+
+```bash
+git clone https://github.com/MikeMcQuaid/AgentIDE
+cd AgentIDE
+script/bootstrap
+open AgentIDE.xcodeproj
+```
+
+`script/bootstrap` installs the `Brewfile` dependencies and will generate the
+gitignored Xcode project with XcodeGen. A prebuilt app with automatic updates
+will come later.
+
+## Status
+
+Readme-driven development: this README describes the complete intended
+workflow before any of it exists. Slices land in order, each one usable when
+done:
+
+1. Documentation and guardrails: these documents, linting and CI (this pull
+   request)
+2. Skeleton: XcodeGen project, Swift packages and an empty dashboard app
+3. Core loop: create worktrees, launch and attach to sandboxed agents
+4. Monitoring: notifications, unread tracking and resumable sessions
+5. Review: syntax-highlighted diffs, per-line rejection and editing
+6. Embedded terminal and browser
+7. GitHub pull request creation, dashboards and one-click fixes
+8. Lifecycle: cleanup on merge, undelete and foreign session discovery
+9. Automatic updates and polish
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for how AgentIDE is designed and
+[AGENTS.md](AGENTS.md) if you are working on this repository, human or agent.
+
+## Licence
+
+[GNU Affero General Public License v3.0](LICENSE). If you reuse or adapt the
+source the AGPL terms apply, including the network-use clause.

--- a/script/attach
+++ b/script/attach
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: ${0} <session>" >&2
+  exit 1
+fi
+
+if [[ -n "${SV_SESSION_ID:-}" ]]; then
+  export TMUX_TMPDIR=/tmp
+  exec /opt/homebrew/bin/tmux attach-session -t "$1"
+fi
+
+exec sudo --login --set-home --user="sandvault-${USER}" /usr/bin/env -i \
+  HOME="/Users/sandvault-${USER}" \
+  USER="sandvault-${USER}" \
+  SHELL=/bin/zsh \
+  TERM="${TERM:-xterm-256color}" \
+  PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+  /usr/bin/sandbox-exec -f "/var/sandvault/sandbox-sandvault-${USER}.sb" \
+  /bin/zsh -c 'export TMUX_TMPDIR=/tmp; exec /opt/homebrew/bin/tmux attach-session -t "$1"' attach "$1"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! brew bundle check &>/dev/null; then
+  brew bundle
+fi

--- a/script/style
+++ b/script/style
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+STYLE_FIX=""
+[[ "${1-}" == "--fix" ]] && STYLE_FIX="1"
+
+shell_style() {
+  shellcheck script/*
+  if [[ -n "${STYLE_FIX}" ]]; then
+    shfmt -i 2 -ci -w script/*
+  else
+    shfmt -i 2 -ci -d script/*
+  fi
+}
+
+github_actions_style() {
+  actionlint
+  zizmor --no-online-audits .github/workflows
+}
+
+docs_style() {
+  awk 'length > 72 { print FILENAME ":" FNR ": longer than 72 characters"; failed = 1 } END { exit failed }' AGENTS.md
+  if [[ "$(readlink CLAUDE.md)" != "AGENTS.md" ]]; then
+    echo "CLAUDE.md must be a symlink to AGENTS.md" >&2
+    return 1
+  fi
+}
+
+swift_style() {
+  [[ -z "$(git ls-files "*.swift")" ]] && return 0
+  if [[ -n "${STYLE_FIX}" ]]; then
+    swiftformat .
+    swiftlint --fix --strict --quiet
+  else
+    swiftformat --lint .
+  fi
+  swiftlint --strict --quiet
+}
+
+shell_style
+github_actions_style
+docs_style
+swift_style


### PR DESCRIPTION
- `README.md` describes the full workflow before any code exists so the product is reviewable first (readme-driven development)
- `ARCHITECTURE.md` records the system design, sandbox integration contract and dependency rules the code slices will follow
- `AGENTS.md` (with `CLAUDE.md` symlink) guides agents and humans working on this repository
- `script/style` and GitHub Actions enforce shell, workflow and documentation guardrails from the first commit
- `.github/dependabot.yml` is seeded because the shared-config sync only adopts repositories that already have it
- `Brewfile` includes runtime dependencies (`gh`, `tmux`) so bootstrap fully prepares a machine
- Swift lint configurations are staged with every rule enabled so the app skeleton slice inherits them