### PR TITLE
Add happy-path functionality across every feature

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,9 @@ jobs:
           sudo xcode-select -s "${xcode}/Contents/Developer"
           xcodebuild -version
 
+      - name: Download Metal toolchain
+        run: xcodebuild -downloadComponent MetalToolchain
+
       - name: Bootstrap
         run: script/bootstrap
 
@@ -87,16 +90,12 @@ jobs:
       - name: Test
         run: script/test
 
-  check:
-    if: always()
-    needs:
-      - style
-      - tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions: {}
-    steps:
-      - name: Verify all jobs succeeded
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
-        with:
-          jobs: ${{ toJSON(needs) }}
+      - name: Analyze
+        run: script/analyze
+
+# `style` and `tests` always run, so they are the required checks in
+# branch protection directly. If any job ever becomes conditionally
+# skipped (a job-level `if:`, a path filter, or a matrix), add back an
+# aggregating `check` job with `if: always()` that fails unless every
+# `needs` job succeeded and require that instead: branch protection
+# handles a skipped required-by-name check poorly.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,11 @@
 # enabled rules or tools, or cannot apply to this codebase.
 opt_in_rules:
   - all
+analyzer_rules:
+  # unused_declaration cannot see SwiftUI's runtime use of views,
+  # bodies and representable methods, so it floods with false
+  # positives; periphery handles dead-code detection instead.
+  - unused_import
 disabled_rules:
   # Conflicts with opening_brace and SwiftFormat's brace style.
   - contrasted_opening_brace
@@ -20,6 +25,24 @@ disabled_rules:
   - type_contents_order
   # SwiftFormat's trailingCommas rule adds the commas this rule bans.
   - trailing_comma
+  # Small helper types (private subviews, a protocol beside its
+  # adapters) belong with their owner; a file each would force
+  # private helpers public.
+  - one_declaration_per_file
+  # Case order is meaningful here: picker order and status
+  # precedence follow declaration order.
+  - sorted_enum_cases
+  # SwiftFormat owns indentation, and this rule misfires on
+  # semantically indented multiline string content such as diff
+  # fixtures.
+  - indentation_width
+  # No single order fits both idioms in use: value types read before
+  # the aggregate that holds them, private subviews after the view
+  # that owns them.
+  - file_types_order
+  # Default parameters keep internal helpers (test support, launch
+  # commands) ergonomic; public API defaults are the documented seam.
+  - discouraged_default_parameter
 excluded:
   - .build
   - .DerivedData

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,9 @@ conventional-commit prefixes such as `feat:`, `fix:` or `chore:`.
 - `script/bootstrap`: install `Brewfile` dependencies and generate
   `AgentIDE.xcodeproj` with XcodeGen
 - `script/build`: build the app with xcodebuild
-- `script/test`: run the package tests with swift test
+- `script/test`: run the unit and integration tests
+- `script/analyze`: static analysis (SwiftLint analyzer and, on the
+  host or CI, periphery for dead code)
 - `script/style`: run all linters; `--fix` also applies safe fixes
 - `script/attach <session>`: attach this terminal to a sandboxed
   tmux session (works as the host user or inside the sandbox)
@@ -51,7 +53,7 @@ conventional-commit prefixes such as `feat:`, `fix:` or `chore:`.
 ### Required Before Each Commit
 
 - Run `script/style --fix` and resolve anything it cannot fix
-- Run `script/test` when Swift changed
+- Run `script/test` and `script/analyze` when Swift changed
 - Reread changed documentation for UK English, working links and
   72-column wrapping of this file
 - Confirm `README.md` and `ARCHITECTURE.md` still describe behaviour
@@ -72,8 +74,10 @@ conventional-commit prefixes such as `feat:`, `fix:` or `chore:`.
    resumable.
 5. Keep dependency directions clean: Domain depends on nothing,
    DataAccess and Features depend on Domain and App composes them.
-6. Keep agent-specific logic inside its adapter; everything else
+6. Follow YAGNI and DRY: build only what the current slice needs and
+   inline variables and functions used only once.
+7. Keep agent-specific logic inside its adapter; everything else
    speaks one agent interface.
-7. Describe third-party apps this project replaces by category, never
+8. Describe third-party apps this project replaces by category, never
    by product name, in every committed file.
-8. Keep diffs minimal and follow existing structure.
+9. Keep diffs minimal and follow existing structure.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -211,15 +211,17 @@ flowchart TD
   value types (Date, URL and Data) are allowed; process, file, network and
   database APIs are banned.
 - **AgentIDEData**: protocol ports with adapter implementations: `GitClient`,
-  `GitHubClient` (URLSession GraphQL and REST), `SandvaultLauncher`,
-  `TmuxControl`, `TranscriptReader`, `EventSpool`, `MetadataStore` (GRDB),
-  `ProcessRunner` (Subprocess) and `AgentRunner` with `ClaudeCodeRunner` and
-  `CodexRunner`. One module with ports and adapters in separate directories,
-  split into two modules only if boundary violations appear.
+  `GitHubClient` (`gh` shell-outs today, native URLSession GraphQL for hot
+  paths later), `SandvaultLauncher`, `TmuxClient`, `TranscriptReader`,
+  `EventSpool`, `MetadataStore` (a JSON file today, GRDB when metadata
+  outgrows it), `ProcessRunner` (Foundation `Process` today, Subprocess
+  later) and `AgentRunner` with `ClaudeCodeRunner` and `CodexRunner`. One
+  module, split only if boundary violations appear.
 - **Feature targets** (`DashboardFeature`, `SessionFeature`, `ReviewFeature`
   and `PRFeature`): SwiftUI views and `@Observable` view models, MainActor by
   default, given ports via injection. `SessionFeature` owns the WKWebView
-  preview; `ReviewFeature` owns the diff and editor surfaces.
+  preview; `ReviewFeature` owns the diff and editor surfaces (plain SwiftUI
+  text today, STTextView and tree-sitter as the review slice deepens).
 - **TerminalUI**: a dumb SwiftTerm wrapper (command specification in, PTY
   view out), used by `SessionFeature` for both terminal flavours. A
   component, not a feature.
@@ -302,10 +304,15 @@ Sendable` and `nonisolated(unsafe)` are banned.
    clone. A per-repository opt-in provisions a read-only key through
    sandvault's `sv-clone -k` mechanism. Write keys are never provisioned;
    pushing is host-side.
-7. `AgentRunner` builds the agent command (sandvault's wrappers add the
-   agent's permission-skipping flag inside the sandbox) and the session
-   launches through the tmux payload above.
-8. The session is recorded in the metadata store, with the agent-native
+7. `AgentRunner` builds the agent command, with any per-session extra
+   arguments appended verbatim (sandvault's wrappers add the agent's
+   permission-skipping flag inside the sandbox), and the session launches
+   through the tmux payload above.
+8. The prompt is delivered as terminal input, not as a command argument:
+   tmux `load-buffer` then `paste-buffer` types the prompt file into the
+   agent after launch. The pane's `INITIAL_DIR` is pinned to the worktree so
+   the sandbox's zshenv cannot redirect the agent elsewhere.
+9. The session is recorded in the metadata store, with the agent-native
    resume id captured as soon as the transcript appears.
 
 ### Event pipeline (Watch and steer)
@@ -463,10 +470,10 @@ official language or project organisation.
 | Package | Role | Note |
 |---|---|---|
 | SwiftTerm | terminal emulator views | |
-| GRDB | metadata store | |
-| STTextView | diff and editor text surface | TextKit 2 |
-| swift-tree-sitter and language grammars | syntax highlighting | official-organisation exception; each grammar is its own package under the same exception |
-| swift-subprocess | process spawning | official-organisation exception (swiftlang) |
+| GRDB | metadata store | planned; a JSON file serves today |
+| STTextView | diff and editor text surface | TextKit 2; planned |
+| swift-tree-sitter and language grammars | syntax highlighting | official-organisation exception; each grammar is its own package under the same exception; planned |
+| swift-subprocess | process spawning | official-organisation exception (swiftlang); planned, Foundation `Process` serves today |
 | Sparkle | app updates | later slice |
 
 System frameworks (WebKit, UserNotifications and FSEvents) and runtime tools
@@ -484,23 +491,35 @@ load SourceKit.
 
 Scripts follow the `script/` convention: `bootstrap` (Homebrew dependencies,
 then XcodeGen project generation), `build` (the app via xcodebuild),
-`test` (package tests via `swift test`), `style [--fix]` (all linters) and
-`attach <session>` (attach the current terminal to a sandboxed tmux
-session). Agent-driven builds inside the sandbox cannot nest macOS
-sandboxes, so build scripts gate on `SV_SESSION_ID` and pass
-`SWIFTPM_DISABLE_SANDBOX=1`, `SWIFT_BUILD_USE_SANDBOX=0` and the
+`test` (unit and integration tests via `swift test`), `analyze` (static
+analysis), `style [--fix]` (all linters) and `attach <session>` (attach the
+current terminal to a sandboxed tmux session). Agent-driven builds inside the
+sandbox cannot nest macOS sandboxes, so build scripts gate on `SV_SESSION_ID`
+and pass `SWIFTPM_DISABLE_SANDBOX=1`, `SWIFT_BUILD_USE_SANDBOX=0` and the
 `-IDEPackageSupportDisable*Sandbox` xcodebuild flags, letting agents build
 AgentIDE itself.
 
+The guardrails are layered so a mistake is caught as early as possible:
+Swift 6 strict concurrency and the type system at compile time; SwiftLint and
+SwiftFormat with every rule enabled at `script/style`; SwiftLint's analyzer
+(`unused_import`) plus periphery for dead code at `script/analyze`; and a
+test suite split into two tiers. Unit tests cover Domain's pure functions
+(`DiffParser`, `PatchBuilder`, `SessionName`) and Data decoders over
+fixtures. Integration tests exercise the real adapters end to end against
+real `git` repositories, a real `tmux` server on a private socket and
+temporary workspaces, because the bugs that reach manual testing live in the
+seams: worktree listing under path canonicalisation, reverse-patch
+application, tmux pane parsing and directory pinning, prompt delivery, and
+the archive and undelete round trip. View rendering is checked with headless
+`ImageRenderer` snapshots. periphery drives its own build so it runs on the
+host and in CI only, not inside the sandbox.
+
 CI ("GitHub Actions CI" in `.github/workflows/tests.yml`) runs the style
-checks on every push and pull request. The build and test job runs on
-GitHub's Xcode 27 public-preview image (`runs-on: xcode-27`, arm64 only) and
-asserts Xcode 27 is present, failing rather than skipping, so a green run
-always means the app built and the tests passed (R2). Tests use
-Swift Testing: near-total coverage of Domain's pure functions over recorded
-fixtures, Data adapters against fakes and scrubbed fixtures captured from a
-real machine, view models against fake ports and a single launch smoke test
-for UI.
+checks on every push and pull request. The build, test and analyze job runs
+on GitHub's Xcode 27 public-preview image (`runs-on: xcode-27`, arm64 only)
+and asserts Xcode 27 is present, failing rather than skipping, so a green run
+always means the app built, the tests passed and static analysis was
+clean (R2).
 
 ## Risks and open questions
 

--- a/App/AgentIDEApp.swift
+++ b/App/AgentIDEApp.swift
@@ -1,11 +1,16 @@
-import DashboardFeature
 import SwiftUI
 
 @main
 struct AgentIDEApp: App {
+    // MARK: Internal
+
     var body: some Scene {
         WindowGroup {
-            DashboardView()
+            RootView(dependencies: dependencies)
         }
     }
+
+    // MARK: Private
+
+    private let dependencies: AppDependencies = .init()
 }

--- a/App/AppDependencies.swift
+++ b/App/AppDependencies.swift
@@ -1,0 +1,48 @@
+import AgentIDEData
+import DashboardFeature
+
+/// Builds every adapter once and hands them to the features; the
+/// app's only wiring.
+@MainActor
+final class AppDependencies {
+    // MARK: Lifecycle
+
+    init() {
+        let paths = WorkspacePaths.current()
+        let runner = FoundationProcessRunner()
+        let gitClient = GitClient(runner: runner)
+        let githubClient = GitHubClient(runner: runner)
+        let store = MetadataStore(file: paths.metadataFile)
+        let tmux = TmuxClient(
+            runner: runner,
+            launcher: SandvaultLauncher(hostUser: paths.hostUser),
+            isInsideSandbox: WorkspacePaths.isInsideSandbox,
+        )
+        let sessionService = SessionService(
+            paths: paths,
+            git: gitClient,
+            tmux: tmux,
+            github: githubClient,
+            transcripts: TranscriptReader(),
+            spool: EventSpool(directory: paths.eventsDirectory),
+            store: store,
+            runners: [ClaudeCodeRunner(), CodexRunner()],
+        )
+        git = gitClient
+        github = githubClient
+        service = sessionService
+        dashboard = DashboardModel(service: sessionService, store: store)
+        try? HookInstaller(paths: paths).ensureInstalled()
+    }
+
+    deinit {
+        // Lives for the app's whole lifetime.
+    }
+
+    // MARK: Internal
+
+    let git: GitClient
+    let github: GitHubClient
+    let service: SessionService
+    let dashboard: DashboardModel
+}

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -1,0 +1,111 @@
+import AgentIDEDomain
+import DashboardFeature
+import PRFeature
+import ReviewFeature
+import SessionFeature
+import SwiftUI
+
+/// The main window: dashboard sidebar, detail panes per worktree.
+struct RootView: View {
+    // MARK: Internal
+
+    let dependencies: AppDependencies
+
+    var body: some View {
+        NavigationSplitView {
+            DashboardView(model: dependencies.dashboard)
+                .navigationSplitViewColumnWidth(min: Self.sidebarMinimum, ideal: Self.sidebarIdeal)
+        } detail: {
+            detail
+        }
+        .sheet(isPresented: newSessionBinding) {
+            NewSessionSheet(model: dependencies.dashboard)
+        }
+        .task { await dependencies.dashboard.poll() }
+    }
+
+    // MARK: Private
+
+    private enum DetailPane: CaseIterable {
+        case session
+        case review
+        case pullRequests
+
+        // MARK: Internal
+
+        var title: String {
+            switch self {
+            case .session:
+                "Session"
+
+            case .review:
+                "Review"
+
+            case .pullRequests:
+                "Pull requests"
+            }
+        }
+    }
+
+    private static let sidebarMinimum: CGFloat = 260
+    private static let sidebarIdeal: CGFloat = 320
+    private static let pickerPadding: CGFloat = 8
+
+    @State private var pane: DetailPane = .session
+
+    private var newSessionBinding: Binding<Bool> {
+        Binding(
+            get: { dependencies.dashboard.showsNewSession },
+            set: { dependencies.dashboard.showsNewSession = $0 },
+        )
+    }
+
+    @ViewBuilder private var detail: some View {
+        if let item = dependencies.dashboard.selection {
+            VStack(spacing: 0) {
+                Picker("Pane", selection: $pane) {
+                    ForEach(DetailPane.allCases, id: \.self) { pane in
+                        Text(pane.title).tag(pane)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .padding(Self.pickerPadding)
+                Divider()
+                pane(for: item)
+            }
+        } else {
+            ContentUnavailableView(
+                "No agents yet",
+                systemImage: "rectangle.stack",
+                description: Text("Create a session to put a worktree and agent here."),
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func pane(for item: WorktreeItem) -> some View {
+        switch pane {
+        case .session:
+            SessionDetailView(item: item, service: dependencies.service)
+
+        case .review:
+            ReviewView(worktreePath: item.worktree.path, git: dependencies.git)
+
+        case .pullRequests:
+            PullRequestsView(
+                repository: Repository(name: item.worktree.repositoryName, path: item.worktree.repositoryPath),
+                items: repositoryItems(for: item),
+                github: dependencies.github,
+                service: dependencies.service,
+            )
+        }
+    }
+
+    private func repositoryItems(for item: WorktreeItem) -> [WorktreeItem] {
+        dependencies.dashboard
+            .groups
+            .first { $0.repository.path == item.worktree.repositoryPath }?
+            .items ?? []
+    }
+}

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,6 @@
 brew "actionlint"
 brew "gh"
+brew "periphery"
 brew "shellcheck"
 brew "shfmt"
 brew "swiftformat"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "d659f4f5dc6e7390067e14fdce2001240cfe0078b94511569402ebc263160af4",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swiftterm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/migueldeicaza/SwiftTerm",
+      "state" : {
+        "revision" : "3917686ea5f5527c5451aaf371bd90bf3618aa71",
+        "version" : "1.16.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,9 @@ let package = Package(
         .library(name: "PRFeature", targets: ["PRFeature"]),
         .library(name: "TerminalUI", targets: ["TerminalUI"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.15.0"),
+    ],
     targets: [
         .target(
             name: "AgentIDEDomain",
@@ -51,6 +54,7 @@ let package = Package(
         ),
         .target(
             name: "TerminalUI",
+            dependencies: [.product(name: "SwiftTerm", package: "SwiftTerm")],
             swiftSettings: mainActorByDefault,
         ),
         .testTarget(
@@ -62,6 +66,11 @@ let package = Package(
             name: "AgentIDEDataTests",
             dependencies: ["AgentIDEData"],
             swiftSettings: approachableConcurrency,
+        ),
+        .testTarget(
+            name: "DashboardFeatureTests",
+            dependencies: ["DashboardFeature"],
+            swiftSettings: mainActorByDefault,
         ),
     ],
 )

--- a/README.md
+++ b/README.md
@@ -137,13 +137,18 @@ done:
 
 1. Documentation and guardrails: these documents, linting and CI (done)
 2. Skeleton: XcodeGen project, Swift packages and an empty dashboard app
-   (this pull request)
+   (done)
 3. Core loop: create worktrees, launch and attach to sandboxed agents
+   (basic, this pull request)
 4. Monitoring: notifications, unread tracking and resumable sessions
-5. Review: syntax-highlighted diffs, per-line rejection and editing
-6. Embedded terminal and browser
+   (basic, this pull request)
+5. Review: diffs, per-line rejection and editing (basic and plain text
+   until the editor stack lands, this pull request)
+6. Embedded terminal and browser (basic, this pull request)
 7. GitHub pull request creation, dashboards and one-click fixes
+   (basic, this pull request)
 8. Lifecycle: cleanup on merge, undelete and foreign session discovery
+   (basic, this pull request)
 9. Automatic updates and polish
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for how AgentIDE is designed and

--- a/Sources/AgentIDEData/AgentRunner.swift
+++ b/Sources/AgentIDEData/AgentRunner.swift
@@ -1,0 +1,104 @@
+import AgentIDEDomain
+
+// MARK: - AgentRunner
+
+/// Everything agent-specific: how to launch, resume and find the
+/// transcripts of one agent CLI. All other code speaks this seam.
+/// Prompts are never passed as arguments; they arrive through the
+/// terminal via tmux paste after launch.
+public protocol AgentRunner: Sendable {
+    /// The agent this runner drives.
+    var kind: AgentKind { get }
+
+    /// The shell command that starts the agent interactively, with
+    /// caller-supplied extra arguments appended verbatim.
+    func launchCommand(extraArguments: String) -> String
+
+    /// The shell command that resumes a previous conversation.
+    func resumeCommand(resumeID: String, extraArguments: String) -> String
+
+    /// The directory holding transcripts for a working directory,
+    /// nil when the agent has no discoverable transcripts.
+    func transcriptDirectory(workingDirectory: String, sandboxHome: String) -> String?
+}
+
+extension AgentRunner {
+    /// Joins a base command with verbatim extra arguments.
+    func command(_ base: String, _ extraArguments: String) -> String {
+        let trimmed = extraArguments.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? base : base + " " + trimmed
+    }
+}
+
+// MARK: - ClaudeCodeRunner
+
+/// Drives Anthropic's Claude Code CLI.
+public struct ClaudeCodeRunner: AgentRunner {
+    // MARK: Lifecycle
+
+    /// Creates a runner.
+    public init() {
+        // No configuration is needed.
+    }
+
+    // MARK: Public
+
+    /// Claude Code.
+    public var kind: AgentKind {
+        .claudeCode
+    }
+
+    /// Starts Claude Code interactively; the sandbox's wrapper adds
+    /// its permission flag.
+    public func launchCommand(extraArguments: String) -> String {
+        command("claude", extraArguments)
+    }
+
+    /// Resumes a conversation by its session id.
+    public func resumeCommand(resumeID: String, extraArguments: String) -> String {
+        command("claude --resume '" + resumeID + "'", extraArguments)
+    }
+
+    /// Claude Code keys transcript directories by the working
+    /// directory with `/` and `.` replaced by `-`.
+    public func transcriptDirectory(workingDirectory: String, sandboxHome: String) -> String? {
+        let dashified = workingDirectory
+            .replacing("/", with: "-")
+            .replacing(".", with: "-")
+        return sandboxHome + "/.claude/projects/" + dashified
+    }
+}
+
+// MARK: - CodexRunner
+
+/// Drives OpenAI's Codex CLI.
+public struct CodexRunner: AgentRunner {
+    // MARK: Lifecycle
+
+    /// Creates a runner.
+    public init() {
+        // No configuration is needed.
+    }
+
+    // MARK: Public
+
+    /// Codex CLI.
+    public var kind: AgentKind {
+        .codexCLI
+    }
+
+    /// Starts Codex interactively.
+    public func launchCommand(extraArguments: String) -> String {
+        command("codex", extraArguments)
+    }
+
+    /// Resumes a conversation by its session id.
+    public func resumeCommand(resumeID: String, extraArguments: String) -> String {
+        command("codex resume '" + resumeID + "'", extraArguments)
+    }
+
+    /// Codex keeps a flat session directory per user.
+    public func transcriptDirectory(workingDirectory _: String, sandboxHome: String) -> String? {
+        sandboxHome + "/.codex/sessions"
+    }
+}

--- a/Sources/AgentIDEData/EventSpool.swift
+++ b/Sources/AgentIDEData/EventSpool.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Reads the hook event spool the sandbox-side hook script appends
+/// to, one JSONL file per session.
+public struct EventSpool: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a spool reader for a directory.
+    public init(directory: String) {
+        self.directory = directory
+    }
+
+    // MARK: Public
+
+    /// The last activity time of every session with spooled events.
+    public func activity() -> [String: Date] {
+        let manager = FileManager.default
+        let names = (try? manager.contentsOfDirectory(atPath: directory)) ?? []
+        var result = [String: Date]()
+        for name in names where name.hasSuffix(".jsonl") {
+            let path = directory + "/" + name
+            let attributes = try? manager.attributesOfItem(atPath: path)
+            let date = attributes?[.modificationDate] as? Date ?? .distantPast
+            result[String(name.dropLast(".jsonl".count))] = date
+        }
+        return result
+    }
+
+    // MARK: Private
+
+    private let directory: String
+}

--- a/Sources/AgentIDEData/GitClient.swift
+++ b/Sources/AgentIDEData/GitClient.swift
@@ -1,0 +1,203 @@
+import AgentIDEDomain
+import Foundation
+
+/// Runs hardened git commands against guest-writable repositories.
+/// Every invocation neutralises config a hostile repository could use
+/// to execute code as the host user.
+public struct GitClient: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a client.
+    public init(runner: any ProcessRunner) {
+        self.runner = runner
+    }
+
+    // MARK: Public
+
+    /// Lists repositories directly under a directory, skipping
+    /// symlinked aliases so each checkout appears exactly once.
+    public func repositories(under root: String) -> [Repository] {
+        let manager = FileManager.default
+        let names = (try? manager.contentsOfDirectory(atPath: root)) ?? []
+        return names.sorted().compactMap { name in
+            let path = root + "/" + name
+            let attributes = try? manager.attributesOfItem(atPath: path)
+            guard attributes?[.type] as? FileAttributeType != .typeSymbolicLink,
+                  manager.fileExists(atPath: path + "/.git")
+            else {
+                return nil
+            }
+
+            return Repository(name: name, path: path)
+        }
+    }
+
+    /// Lists a repository's linked worktrees. Git always lists the
+    /// main checkout first, so it is skipped by position rather than
+    /// by path, which canonicalisation can make unequal.
+    public func worktrees(of repository: Repository) async throws -> [Worktree] {
+        let output = try await git(["worktree", "list", "--porcelain"], in: repository.path).standardOutput
+        var path: String?
+        var index = -1
+        var results = [Worktree]()
+        for line in output.split(separator: "\n", omittingEmptySubsequences: false) {
+            if line.hasPrefix("worktree ") {
+                path = String(line.dropFirst("worktree ".count))
+                index += 1
+            } else if line.hasPrefix("branch refs/heads/"), let currentPath = path, index > 0 {
+                results.append(Worktree(
+                    repositoryName: repository.name,
+                    repositoryPath: repository.path,
+                    branch: String(line.dropFirst("branch refs/heads/".count)),
+                    path: currentPath,
+                ))
+            }
+        }
+        return results
+    }
+
+    /// Creates a worktree with a new branch based on `HEAD`.
+    public func createWorktree(repository: Repository, branch: String, at path: String) async throws {
+        try await git(["worktree", "add", "-b", branch, path, "HEAD"], in: repository.path)
+    }
+
+    /// Adds a worktree for an existing branch, used by undelete.
+    public func addWorktree(repository: Repository, branch: String, at path: String) async throws {
+        try await git(["worktree", "add", path, branch], in: repository.path)
+    }
+
+    /// Whether a branch name already exists.
+    public func branchExists(repository: Repository, branch: String) async -> Bool {
+        let result = try? await git(
+            ["rev-parse", "--verify", "--quiet", "refs/heads/" + branch],
+            in: repository.path,
+            allowFailure: true,
+        )
+        return result?.succeeded ?? false
+    }
+
+    /// Whether the worktree has uncommitted changes.
+    public func isDirty(worktreePath: String) async -> Bool {
+        let output = try? await git(["status", "--porcelain"], in: worktreePath).standardOutput
+        return output?.isEmpty == false
+    }
+
+    /// How many commits the worktree's branch is ahead of its
+    /// upstream, nil when it has no upstream.
+    public func aheadOfUpstream(worktreePath: String) async -> Int? {
+        let result = try? await git(
+            ["rev-list", "--count", "@{upstream}..HEAD"],
+            in: worktreePath,
+            allowFailure: true,
+        )
+        guard let result, result.succeeded else {
+            return nil
+        }
+
+        return Int(result.standardOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// The worktree's uncommitted diff against `HEAD`.
+    public func uncommittedDiff(worktreePath: String) async throws -> String {
+        try await git(["diff", "HEAD"], in: worktreePath).standardOutput
+    }
+
+    /// The last commit's diff.
+    public func lastCommitDiff(worktreePath: String) async throws -> String {
+        try await git(["show", "--format=", "--patch", "HEAD"], in: worktreePath).standardOutput
+    }
+
+    /// Reverse-applies a patch to the index and worktree together.
+    public func applyReverse(patch: String, worktreePath: String) async throws {
+        let url = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("agentide-reject-" + UUID().uuidString + ".patch")
+        try patch.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+        try await git(["apply", "--check", "-R", url.path], in: worktreePath)
+        try await git(["apply", "-R", "--index", url.path], in: worktreePath)
+    }
+
+    /// Amends the last commit, optionally replacing its message.
+    public func amend(worktreePath: String, message: String?) async throws {
+        var arguments = ["commit", "--amend"]
+        if let message {
+            arguments += ["-m", message]
+        } else {
+            arguments.append("--no-edit")
+        }
+        try await git(arguments, in: worktreePath)
+    }
+
+    /// The last commit's subject and body.
+    public func lastCommitMessage(worktreePath: String) async throws -> String {
+        try await git(["log", "-1", "--format=%B"], in: worktreePath)
+            .standardOutput
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Stages everything and commits it.
+    public func commitAll(worktreePath: String, message: String) async throws {
+        try await git(["add", "-A"], in: worktreePath)
+        try await git(["commit", "-m", message], in: worktreePath)
+    }
+
+    /// Pushes the branch, creating its upstream.
+    public func push(worktreePath: String, branch: String) async throws {
+        try await git(["push", "--set-upstream", "origin", branch], in: worktreePath)
+    }
+
+    /// Writes a bundle containing the branch.
+    public func bundle(worktreePath: String, branch: String, to file: String) async throws {
+        try await git(["bundle", "create", file, branch], in: worktreePath)
+    }
+
+    /// Untracked and modified paths, used when archiving.
+    public func looseFiles(worktreePath: String) async -> [String] {
+        let output = try? await git(
+            ["ls-files", "--others", "--modified", "--exclude-standard"],
+            in: worktreePath,
+        ).standardOutput
+        return (output ?? "").split(separator: "\n").map(String.init)
+    }
+
+    /// Removes a worktree and deletes its branch; the archive bundle
+    /// keeps the commits recoverable.
+    public func removeWorktree(repository: Repository, worktreePath: String, branch: String) async throws {
+        try await git(["worktree", "remove", "--force", worktreePath], in: repository.path)
+        try await git(["branch", "-D", branch], in: repository.path)
+    }
+
+    /// Recreates a branch from an archive bundle.
+    public func fetchBranch(repository: Repository, fromBundle bundle: String, branch: String) async throws {
+        try await git(["fetch", bundle, branch + ":" + branch], in: repository.path)
+    }
+
+    // MARK: Private
+
+    /// Config a compromised repository could abuse, forced off.
+    private static let hardening = [
+        "-c", "core.fsmonitor=",
+        "-c", "core.sshCommand=",
+        "-c", "core.hooksPath=/dev/null",
+        "-c", "core.pager=cat",
+        "-c", "protocol.ext.allow=never",
+    ]
+
+    private let runner: any ProcessRunner
+
+    @discardableResult
+    private func git(
+        _ arguments: [String],
+        in directory: String?,
+        allowFailure: Bool = false,
+    ) async throws -> ProcessResult {
+        let argv = ["git"] + Self.hardening + arguments
+        let result = try await runner.run(argv, workingDirectory: directory, environment: [:])
+        guard result.succeeded || allowFailure else {
+            throw CommandError(command: "git " + arguments.joined(separator: " "), result: result)
+        }
+
+        return result
+    }
+}

--- a/Sources/AgentIDEData/GitHubClient.swift
+++ b/Sources/AgentIDEData/GitHubClient.swift
@@ -1,0 +1,119 @@
+import AgentIDEDomain
+import Foundation
+
+/// Talks to GitHub through the host user's authenticated `gh` CLI;
+/// the sandbox never sees these credentials.
+public struct GitHubClient: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a client.
+    public init(runner: any ProcessRunner) {
+        self.runner = runner
+    }
+
+    // MARK: Public
+
+    /// The repository's open pull requests with dashboard state.
+    public func pullRequests(repositoryPath: String) async throws -> [PullRequestSummary] {
+        let fields = "number,title,url,headRefName,mergeable,reviewDecision,statusCheckRollup"
+        let result = try await gh(["pr", "list", "--json", fields], in: repositoryPath)
+        guard let data = result.standardOutput.data(using: .utf8) else {
+            return []
+        }
+
+        let rows = (try? JSONDecoder().decode([PullRequestRow].self, from: data)) ?? []
+        return rows.map { row in
+            PullRequestSummary(
+                number: row.number,
+                title: row.title,
+                url: row.url,
+                headBranch: row.headRefName,
+                mergeable: row.mergeable ?? "",
+                reviewDecision: row.reviewDecision ?? "",
+                checks: Self.aggregateChecks(row.statusCheckRollup ?? []),
+            )
+        }
+    }
+
+    /// Opens a pull request from the worktree's branch, filling the
+    /// title and body from its commits.
+    public func createPullRequest(worktreePath: String) async throws -> String {
+        try await gh(["pr", "create", "--fill"], in: worktreePath)
+            .standardOutput
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Enables automerge for a pull request.
+    public func enableAutomerge(repositoryPath: String, number: Int) async throws {
+        try await gh(["pr", "merge", String(number), "--auto", "--squash"], in: repositoryPath)
+    }
+
+    /// Merges a pull request immediately.
+    public func merge(repositoryPath: String, number: Int) async throws {
+        try await gh(["pr", "merge", String(number), "--squash"], in: repositoryPath)
+    }
+
+    /// The review comments and check results of a pull request, as
+    /// text an agent can act on.
+    public func remediationContext(repositoryPath: String, number: Int) async -> String {
+        let view = try? await gh(["pr", "view", String(number), "--comments"], in: repositoryPath)
+        let checks = try? await gh(
+            ["pr", "checks", String(number)],
+            in: repositoryPath,
+            allowFailure: true,
+        )
+        return [view?.standardOutput, checks?.standardOutput]
+            .compactMap(\.self)
+            .joined(separator: "\n\n")
+    }
+
+    // MARK: Private
+
+    private struct PullRequestRow: Decodable {
+        let number: Int
+        let title: String
+        let url: String
+        let headRefName: String
+        let mergeable: String?
+        let reviewDecision: String?
+        // Absent from the JSON when a pull request has no checks.
+        // swiftlint:disable:next discouraged_optional_collection
+        let statusCheckRollup: [CheckRow]?
+    }
+
+    private struct CheckRow: Decodable {
+        let state: String?
+        let conclusion: String?
+    }
+
+    private let runner: any ProcessRunner
+
+    private static func aggregateChecks(_ rows: [CheckRow]) -> String {
+        let states = rows.map { ($0.conclusion ?? $0.state ?? "").uppercased() }
+        guard states.isEmpty == false else {
+            return ""
+        }
+
+        if states.contains(where: { $0 == "FAILURE" || $0 == "ERROR" }) {
+            return "FAILURE"
+        }
+        if states.allSatisfy({ $0 == "SUCCESS" || $0 == "NEUTRAL" || $0 == "SKIPPED" }) {
+            return "SUCCESS"
+        }
+        return "PENDING"
+    }
+
+    @discardableResult
+    private func gh(
+        _ arguments: [String],
+        in directory: String?,
+        allowFailure: Bool = false,
+    ) async throws -> ProcessResult {
+        let result = try await runner.run(["gh"] + arguments, workingDirectory: directory, environment: [:])
+        guard result.succeeded || allowFailure else {
+            throw CommandError(command: "gh " + arguments.joined(separator: " "), result: result)
+        }
+
+        return result
+    }
+}

--- a/Sources/AgentIDEData/HookInstaller.swift
+++ b/Sources/AgentIDEData/HookInstaller.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Installs AgentIDE's hook script and Claude Code hook entries into
+/// the sandvault user template, alongside any existing third-party
+/// notifier hooks rather than replacing them.
+public struct HookInstaller: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates an installer for a workspace.
+    public init(paths: WorkspacePaths) {
+        self.paths = paths
+    }
+
+    // MARK: Public
+
+    /// The events the hook reports, covering completion, permission
+    /// requests and lifecycle for the dashboard.
+    public static let events = [
+        "UserPromptSubmit", "Stop", "StopFailure", "PostToolUse",
+        "PostToolUseFailure", "PermissionRequest", "SessionStart", "SessionEnd",
+    ]
+
+    /// Ensures the agentide directories, the hook script and the
+    /// settings template entries all exist. Idempotent.
+    public func ensureInstalled() throws {
+        let manager = FileManager.default
+        for directory in [paths.eventsDirectory, paths.promptsDirectory, paths.friendlyWorktreesDirectory] {
+            try manager.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        }
+        try installScript()
+        try installSettingsEntries()
+    }
+
+    // MARK: Private
+
+    private let paths: WorkspacePaths
+
+    private var scriptPath: String {
+        paths.userTemplateDirectory + "/.claude/agentide-notify.sh"
+    }
+
+    private var settingsPath: String {
+        paths.userTemplateDirectory + "/.claude/settings.json"
+    }
+
+    private var scriptContent: String {
+        """
+        #!/bin/sh
+        session="${AGENTIDE_SESSION:-${SV_SESSION_ID:-}}"
+        [ -n "$session" ] || exit 0
+        directory="${SHARED_WORKSPACE:-\(paths.sharedWorkspace)}/agentide/events"
+        mkdir -p "$directory"
+        printf '{"event":"%s","date":"%s"}\\n' "$1" "$(date -u +%FT%TZ)" >> "$directory/$session.jsonl"
+        """
+    }
+
+    private func installScript() throws {
+        try FileManager.default.createDirectory(
+            atPath: URL(fileURLWithPath: scriptPath).deletingLastPathComponent().path,
+            withIntermediateDirectories: true,
+        )
+        try scriptContent.write(toFile: scriptPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptPath)
+    }
+
+    private func installSettingsEntries() throws {
+        let url = URL(fileURLWithPath: settingsPath)
+        let existingData = try? Data(contentsOf: url)
+        let existing = existingData.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        var settings = existing ?? [:]
+        var hooks = settings["hooks"] as? [String: Any] ?? [:]
+        for event in Self.events {
+            let command = "[ -x \(scriptPath) ] && \(scriptPath) \(event) || true"
+            var entries = hooks[event] as? [[String: Any]] ?? []
+            let alreadyInstalled = entries.contains { entry in
+                let nested = entry["hooks"] as? [[String: Any]] ?? []
+                return nested.contains { ($0["command"] as? String)?.contains("agentide-notify") == true }
+            }
+            guard alreadyInstalled == false else {
+                continue
+            }
+
+            entries.append(["hooks": [["type": "command", "command": command]]])
+            hooks[event] = entries
+        }
+        settings["hooks"] = hooks
+        let data = try JSONSerialization.data(
+            withJSONObject: settings,
+            options: [.prettyPrinted, .sortedKeys],
+        )
+        try data.write(to: url, options: .atomic)
+    }
+}

--- a/Sources/AgentIDEData/MetadataStore.swift
+++ b/Sources/AgentIDEData/MetadataStore.swift
@@ -1,0 +1,83 @@
+import AgentIDEDomain
+import Foundation
+
+// MARK: - AppMetadata
+
+/// The app-owned metadata that cannot be derived from the system.
+public struct AppMetadata: Codable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates empty metadata.
+    public init() {
+        // Every property has a default.
+    }
+
+    // MARK: Public
+
+    /// When each session was last seen by the user, for unread state.
+    public var lastSeen: [String: Date] = [:]
+
+    /// The prompt each session was started with.
+    public var prompts: [String: String] = [:]
+
+    /// The extra agent arguments each session was started with.
+    public var arguments: [String: String] = [:]
+
+    /// The session name last launched in each worktree, so a closed
+    /// session can be resumed without a live tmux session to name it.
+    public var sessionsByWorktree: [String: String] = [:]
+
+    /// The agent-native resume id last observed per session.
+    public var resumeIDs: [String: String] = [:]
+
+    /// Archives of deleted worktrees, newest last.
+    public var archives: [ArchiveMetadata] = []
+}
+
+// MARK: - MetadataStore
+
+/// Loads and saves the metadata file. Everything else re-derives from
+/// tmux, git, transcripts and GitHub, so losing this file loses only
+/// unread state, prompts and the archive index.
+public struct MetadataStore: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a store at a file path.
+    public init(file: String) {
+        self.file = file
+    }
+
+    // MARK: Public
+
+    /// Loads the metadata, empty when absent or unreadable.
+    public func load() -> AppMetadata {
+        guard let data = FileManager.default.contents(atPath: file) else {
+            return AppMetadata()
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return (try? decoder.decode(AppMetadata.self, from: data)) ?? AppMetadata()
+    }
+
+    /// Saves the metadata, creating parent directories as needed.
+    public func save(_ metadata: AppMetadata) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(metadata) else {
+            return
+        }
+
+        let url = URL(fileURLWithPath: file)
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+        )
+        try? data.write(to: url, options: .atomic)
+    }
+
+    // MARK: Private
+
+    private let file: String
+}

--- a/Sources/AgentIDEData/ProcessRunner.swift
+++ b/Sources/AgentIDEData/ProcessRunner.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+// MARK: - ProcessResult
+
+/// The captured outcome of a finished process.
+public struct ProcessResult: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a result.
+    public init(status: Int32, standardOutput: String, standardError: String) {
+        self.status = status
+        self.standardOutput = standardOutput
+        self.standardError = standardError
+    }
+
+    // MARK: Public
+
+    /// The process's exit status.
+    public let status: Int32
+
+    /// Everything the process wrote to standard output.
+    public let standardOutput: String
+
+    /// Everything the process wrote to standard error.
+    public let standardError: String
+
+    /// Whether the process exited zero.
+    public var succeeded: Bool {
+        status == 0
+    }
+}
+
+// MARK: - CommandError
+
+/// An error from a failed external command; handled as a generic
+/// Error outside this module.
+struct CommandError: Error, LocalizedError {
+    // MARK: Lifecycle
+
+    /// Creates a command error.
+    init(command: String, result: ProcessResult) {
+        self.command = command
+        self.result = result
+    }
+
+    // MARK: Internal
+
+    /// The command that failed, for display.
+    let command: String
+
+    /// The failing process's captured result.
+    let result: ProcessResult
+
+    /// A readable failure description.
+    var errorDescription: String? {
+        let detail = result.standardError.isEmpty ? result.standardOutput : result.standardError
+        return "\(command) failed (\(result.status)): \(detail)"
+    }
+}
+
+// MARK: - ProcessRunner
+
+/// Runs external commands and captures their output.
+public protocol ProcessRunner: Sendable {
+    /// Runs an argv, resolved via `/usr/bin/env`, and captures output.
+    func run(
+        _ arguments: [String],
+        workingDirectory: String?,
+        environment: [String: String],
+    ) async throws -> ProcessResult
+}
+
+// MARK: - FoundationProcessRunner
+
+/// A `ProcessRunner` backed by Foundation's `Process`, writing output
+/// to temporary files so large output can never deadlock a pipe.
+public struct FoundationProcessRunner: ProcessRunner {
+    // MARK: Lifecycle
+
+    /// Creates a runner.
+    public init() {
+        // No configuration is needed.
+    }
+
+    // MARK: Public
+
+    /// Runs the argv on a global queue and captures its output.
+    public func run(
+        _ arguments: [String],
+        workingDirectory: String?,
+        environment: [String: String],
+    ) async throws -> ProcessResult {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global().async {
+                do {
+                    try continuation.resume(returning: Self.runBlocking(arguments, workingDirectory, environment))
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private static func runBlocking(
+        _ arguments: [String],
+        _ workingDirectory: String?,
+        _ extraEnvironment: [String: String],
+    ) throws -> ProcessResult {
+        let outputURL = temporaryFile()
+        let errorURL = temporaryFile()
+        defer {
+            try? FileManager.default.removeItem(at: outputURL)
+            try? FileManager.default.removeItem(at: errorURL)
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = arguments
+        if let workingDirectory {
+            process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
+        }
+        var environment = ProcessInfo.processInfo.environment
+        let toolPath = "/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        environment["PATH"] = [environment["PATH"], toolPath].compactMap(\.self).joined(separator: ":")
+        environment.merge(extraEnvironment) { _, new in new }
+        process.environment = environment
+        process.standardOutput = try FileHandle(forWritingTo: outputURL)
+        process.standardError = try FileHandle(forWritingTo: errorURL)
+        process.standardInput = FileHandle.nullDevice
+
+        try process.run()
+        process.waitUntilExit()
+
+        return ProcessResult(
+            status: process.terminationStatus,
+            standardOutput: (try? String(contentsOf: outputURL, encoding: .utf8)) ?? "",
+            standardError: (try? String(contentsOf: errorURL, encoding: .utf8)) ?? "",
+        )
+    }
+
+    private static func temporaryFile() -> URL {
+        let url = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("agentide-" + UUID().uuidString)
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        return url
+    }
+}

--- a/Sources/AgentIDEData/SessionService+Lifecycle.swift
+++ b/Sources/AgentIDEData/SessionService+Lifecycle.swift
@@ -1,0 +1,139 @@
+import AgentIDEDomain
+import Foundation
+
+/// Archiving, deleting and restoring worktrees. The archive lives
+/// outside the guest-writable workspace so agents cannot tamper with
+/// recovery state.
+extension SessionService {
+    // MARK: Public
+
+    /// Archives a worktree's branch, loose files, transcript and
+    /// prompt, then deletes the worktree and branch.
+    public func archiveAndDelete(item: WorktreeItem) async throws -> ArchiveMetadata {
+        let worktree = item.worktree
+        let sessionName = item.session?.name
+            ?? SessionName.make(repository: worktree.repositoryName, branch: worktree.branch, agent: .claudeCode)
+        rememberResumeID(sessionName: sessionName, worktreePath: worktree.path)
+
+        let identifier = UUID().uuidString.lowercased()
+        let archiveDirectory = paths.archivesDirectory + "/" + identifier
+        try FileManager.default.createDirectory(atPath: archiveDirectory, withIntermediateDirectories: true)
+        try await git.bundle(
+            worktreePath: worktree.path,
+            branch: worktree.branch,
+            to: archiveDirectory + "/branch.bundle",
+        )
+        try await archiveLooseFiles(worktree: worktree, to: archiveDirectory)
+        copyIfPresent(paths.promptsDirectory + "/" + sessionName + ".md", into: archiveDirectory)
+        copyIfPresent(paths.eventsDirectory + "/" + sessionName + ".jsonl", into: archiveDirectory)
+
+        let metadata = ArchiveMetadata(
+            id: identifier,
+            repositoryName: worktree.repositoryName,
+            repositoryPath: worktree.repositoryPath,
+            branch: worktree.branch,
+            worktreePath: worktree.path,
+            sessionName: sessionName,
+            resumeID: store.load().resumeIDs[sessionName],
+            archivedAt: Date(),
+        )
+        try metadataJSON(metadata).write(
+            toFile: archiveDirectory + "/metadata.json",
+            atomically: true,
+            encoding: .utf8,
+        )
+
+        try? await tmux.killSession(name: sessionName)
+        let repository = Repository(name: worktree.repositoryName, path: worktree.repositoryPath)
+        try await git.removeWorktree(repository: repository, worktreePath: worktree.path, branch: worktree.branch)
+        removeFriendlySymlink(repository: repository, branch: worktree.branch)
+
+        var app = store.load()
+        app.archives.append(metadata)
+        store.save(app)
+        return metadata
+    }
+
+    /// Restores an archived worktree at its original canonical path
+    /// so cwd-keyed conversation state lines up.
+    public func undelete(archive: ArchiveMetadata) async throws {
+        let repository = Repository(name: archive.repositoryName, path: archive.repositoryPath)
+        let archiveDirectory = paths.archivesDirectory + "/" + archive.id
+        if await git.branchExists(repository: repository, branch: archive.branch) == false {
+            try await git.fetchBranch(
+                repository: repository,
+                fromBundle: archiveDirectory + "/branch.bundle",
+                branch: archive.branch,
+            )
+        }
+        try await git.addWorktree(repository: repository, branch: archive.branch, at: archive.worktreePath)
+        try? await restoreLooseFiles(from: archiveDirectory, to: archive.worktreePath)
+        addFriendlySymlink(repository: repository, branch: archive.branch, worktreePath: archive.worktreePath)
+
+        var app = store.load()
+        app.archives.removeAll { $0.id == archive.id }
+        if let resumeID = archive.resumeID {
+            app.resumeIDs[archive.sessionName] = resumeID
+        }
+        store.save(app)
+    }
+
+    // MARK: Internal
+
+    func removeFriendlySymlink(repository: Repository, branch: String) {
+        let link = paths.friendlyWorktreesDirectory + "/" + repository.name
+            + "/" + branch.replacing("/", with: "-")
+        try? FileManager.default.removeItem(atPath: link)
+    }
+
+    // MARK: Private
+
+    private func copyIfPresent(_ source: String, into directory: String) {
+        guard FileManager.default.fileExists(atPath: source) else {
+            return
+        }
+
+        let destination = directory + "/" + URL(fileURLWithPath: source).lastPathComponent
+        try? FileManager.default.copyItem(atPath: source, toPath: destination)
+    }
+
+    private func archiveLooseFiles(worktree: Worktree, to archiveDirectory: String) async throws {
+        let files = await git.looseFiles(worktreePath: worktree.path)
+        guard files.isEmpty == false else {
+            return
+        }
+
+        let listFile = archiveDirectory + "/loose-files.txt"
+        try files.joined(separator: "\n").write(toFile: listFile, atomically: true, encoding: .utf8)
+        _ = try await runTool(
+            ["tar", "-czf", archiveDirectory + "/loose.tar.gz", "-C", worktree.path, "-T", listFile],
+        )
+    }
+
+    private func restoreLooseFiles(from archiveDirectory: String, to worktreePath: String) async throws {
+        let tarball = archiveDirectory + "/loose.tar.gz"
+        guard FileManager.default.fileExists(atPath: tarball) else {
+            return
+        }
+
+        _ = try await runTool(["tar", "-xzf", tarball, "-C", worktreePath])
+    }
+
+    private func runTool(_ arguments: [String]) async throws -> ProcessResult {
+        let runner = FoundationProcessRunner()
+        let result = try await runner.run(arguments, workingDirectory: nil, environment: [:])
+        guard result.succeeded else {
+            throw CommandError(command: arguments.joined(separator: " "), result: result)
+        }
+
+        return result
+    }
+
+    private func metadataJSON(_ metadata: ArchiveMetadata) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(metadata)
+        return String(bytes: data, encoding: .utf8) ?? "{}"
+    }
+}

--- a/Sources/AgentIDEData/SessionService+Sessions.swift
+++ b/Sources/AgentIDEData/SessionService+Sessions.swift
@@ -1,0 +1,80 @@
+import AgentIDEDomain
+import Foundation
+
+/// Watching, closing and resuming individual sessions.
+public extension SessionService {
+    /// Marks a session's output as read.
+    func markSeen(sessionName: String) {
+        var metadata = store.load()
+        metadata.lastSeen[sessionName] = Date()
+        store.save(metadata)
+    }
+
+    /// The last assistant message of the session's newest transcript.
+    func finalMessage(session: AgentSession, worktreePath: String) -> String? {
+        guard let agent = session.agent,
+              let directory = runner(for: agent).transcriptDirectory(
+                  workingDirectory: worktreePath,
+                  sandboxHome: paths.sandboxHome,
+              ),
+              let transcript = transcripts.latestTranscript(in: directory)
+        else {
+            return nil
+        }
+
+        return transcripts.finalAssistantMessage(in: transcript)
+    }
+
+    /// Commits anything the agent left uncommitted.
+    func commitOutstanding(worktreePath: String) async throws {
+        guard await git.isDirty(worktreePath: worktreePath) else {
+            return
+        }
+
+        try await git.commitAll(worktreePath: worktreePath, message: "Commit outstanding agent work")
+    }
+
+    /// Kills the tmux session; worktree, transcript and metadata
+    /// survive so it stays resumable.
+    func closeSession(sessionName: String, worktreePath: String) async throws {
+        rememberResumeID(sessionName: sessionName, worktreePath: worktreePath)
+        try await tmux.killSession(name: sessionName)
+    }
+
+    /// Resumes the session last launched in a worktree, whether or not
+    /// a live tmux session still names it.
+    func resumeWorktree(_ worktree: Worktree) async throws {
+        guard let sessionName = store.load().sessionsByWorktree[worktree.path] else {
+            throw CommandError(
+                command: "resume " + worktree.path,
+                result: ProcessResult(status: 1, standardOutput: "", standardError: "No session recorded here yet"),
+            )
+        }
+
+        try await resumeSession(sessionName: sessionName, worktree: worktree)
+    }
+
+    /// Relaunches a closed session's conversation in its worktree.
+    func resumeSession(sessionName: String, worktree: Worktree) async throws {
+        guard let agent = agentKind(of: sessionName) else {
+            throw CommandError(
+                command: "resume " + sessionName,
+                result: ProcessResult(status: 1, standardOutput: "", standardError: "Unknown agent in session name"),
+            )
+        }
+
+        let metadata = store.load()
+        let arguments = metadata.arguments[sessionName] ?? ""
+        if let resumeID = metadata.resumeIDs[sessionName] {
+            let command = runner(for: agent).resumeCommand(resumeID: resumeID, extraArguments: arguments)
+            try await tmux.newSession(name: sessionName, directory: worktree.path, command: command)
+        } else {
+            let command = runner(for: agent).launchCommand(extraArguments: arguments)
+            try await tmux.newSession(name: sessionName, directory: worktree.path, command: command)
+            let promptFile = paths.promptsDirectory + "/" + sessionName + ".md"
+            if FileManager.default.fileExists(atPath: promptFile) {
+                try await tmux.sendPromptFile(promptFile, to: sessionName)
+            }
+        }
+    }
+}

--- a/Sources/AgentIDEData/SessionService.swift
+++ b/Sources/AgentIDEData/SessionService.swift
@@ -1,0 +1,253 @@
+import AgentIDEDomain
+import Foundation
+
+/// Orchestrates the core loop: worktrees, sessions, review actions
+/// and lifecycle. Feature models call this; it composes the clients.
+/// Lifecycle (archive, undelete) lives in its own extension file.
+public struct SessionService: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates the service.
+    public init(
+        paths: WorkspacePaths,
+        git: GitClient,
+        tmux: TmuxClient,
+        github: GitHubClient,
+        transcripts: TranscriptReader,
+        spool: EventSpool,
+        store: MetadataStore,
+        runners: [any AgentRunner],
+    ) {
+        self.paths = paths
+        self.git = git
+        self.tmux = tmux
+        self.github = github
+        self.transcripts = transcripts
+        self.spool = spool
+        self.store = store
+        self.runners = runners
+    }
+
+    // MARK: Public
+
+    /// The repositories in the shared workspace.
+    public func repositories() -> [Repository] {
+        git.repositories(under: paths.repositoriesDirectory)
+    }
+
+    /// The full dashboard state: every repository's worktrees joined
+    /// with their sessions, plus foreign sessions.
+    public func overview() async -> (groups: [RepositoryGroup], foreign: [AgentSession]) {
+        let panes = await (try? tmux.panes()) ?? []
+        let activity = spool.activity()
+        let metadata = store.load()
+        var groups = [RepositoryGroup]()
+        for repository in repositories() {
+            let worktrees = await (try? git.worktrees(of: repository)) ?? []
+            var items = [WorktreeItem]()
+            for worktree in worktrees {
+                await items.append(item(worktree: worktree, panes: panes, activity: activity, metadata: metadata))
+            }
+            groups.append(RepositoryGroup(repository: repository, items: items))
+        }
+        let foreign = panes
+            .filter { SessionName.isAgentIDE($0.sessionName) == false }
+            .map { pane in
+                AgentSession(
+                    name: pane.sessionName,
+                    agent: nil,
+                    status: pane.isDead ? .finished(pane.exitStatus) : .running,
+                    workingDirectory: pane.currentPath,
+                )
+            }
+        return (groups, foreign)
+    }
+
+    /// Creates a worktree and branch for a prompt and starts the
+    /// agent in tmux, then pastes the prompt into it. `extraArguments`
+    /// are appended to the agent command verbatim. Returns the
+    /// session name.
+    public func createSession(
+        repository: Repository,
+        prompt: String,
+        agent: AgentKind,
+        extraArguments: String = "",
+    ) async throws -> String {
+        let branch = await availableBranch(repository: repository, prompt: prompt)
+        let worktreePath = try await createWorktreePath(repository: repository, branch: branch)
+        let sessionName = SessionName.make(repository: repository.name, branch: branch, agent: agent)
+
+        let promptFile = try writePrompt(prompt, sessionName: sessionName)
+        addFriendlySymlink(repository: repository, branch: branch, worktreePath: worktreePath)
+
+        try await tmux.newSession(
+            name: sessionName,
+            directory: worktreePath,
+            command: runner(for: agent).launchCommand(extraArguments: extraArguments),
+        )
+        try await tmux.sendPromptFile(promptFile, to: sessionName)
+
+        var metadata = store.load()
+        metadata.prompts[sessionName] = prompt
+        metadata.arguments[sessionName] = extraArguments
+        metadata.lastSeen[sessionName] = Date()
+        metadata.sessionsByWorktree[worktreePath] = sessionName
+        store.save(metadata)
+        return sessionName
+    }
+
+    /// Starts an agent in an existing worktree and pastes the prompt,
+    /// used by one-click remediation.
+    public func launchAgent(
+        in worktree: Worktree,
+        prompt: String,
+        agent: AgentKind,
+        extraArguments: String = "",
+    ) async throws -> String {
+        let sessionName = SessionName.make(repository: worktree.repositoryName, branch: worktree.branch, agent: agent)
+        let promptFile = try writePrompt(prompt, sessionName: sessionName)
+        try? await tmux.killSession(name: sessionName)
+        try await tmux.newSession(
+            name: sessionName,
+            directory: worktree.path,
+            command: runner(for: agent).launchCommand(extraArguments: extraArguments),
+        )
+        try await tmux.sendPromptFile(promptFile, to: sessionName)
+        var metadata = store.load()
+        metadata.sessionsByWorktree[worktree.path] = sessionName
+        store.save(metadata)
+        return sessionName
+    }
+
+    /// Pushes the branch and opens a pull request; returns its URL.
+    public func pushAndCreatePullRequest(worktree: Worktree) async throws -> String {
+        try await git.push(worktreePath: worktree.path, branch: worktree.branch)
+        return try await github.createPullRequest(worktreePath: worktree.path)
+    }
+
+    /// The argv that attaches a terminal to a session.
+    public func attachCommand(sessionName: String) -> [String] {
+        tmux.attachCommand(sessionName: sessionName)
+    }
+
+    /// The argv for a host-user shell starting in a worktree.
+    public func hostShellCommand(worktreePath: String) -> [String] {
+        let quoted = "'" + worktreePath.replacing("'", with: "'\\''") + "'"
+        return ["/bin/zsh", "-c", "cd " + quoted + " && exec /bin/zsh -il"]
+    }
+
+    // MARK: Internal
+
+    let paths: WorkspacePaths
+    let git: GitClient
+    let tmux: TmuxClient
+    let github: GitHubClient
+    let transcripts: TranscriptReader
+    let spool: EventSpool
+    let store: MetadataStore
+    let runners: [any AgentRunner]
+
+    func runner(for agent: AgentKind) -> any AgentRunner {
+        runners.first { $0.kind == agent } ?? ClaudeCodeRunner()
+    }
+
+    func agentKind(of sessionName: String) -> AgentKind? {
+        AgentKind.allCases.first { sessionName.hasSuffix("--" + $0.rawValue) }
+    }
+
+    func rememberResumeID(sessionName: String, worktreePath: String) {
+        guard let agent = agentKind(of: sessionName),
+              let directory = runner(for: agent).transcriptDirectory(
+                  workingDirectory: worktreePath,
+                  sandboxHome: paths.sandboxHome,
+              ),
+              let transcript = transcripts.latestTranscript(in: directory)
+        else {
+            return
+        }
+
+        var metadata = store.load()
+        metadata.resumeIDs[sessionName] = transcripts.resumeID(of: transcript)
+        store.save(metadata)
+    }
+
+    func writePrompt(_ prompt: String, sessionName: String) throws -> String {
+        try FileManager.default.createDirectory(atPath: paths.promptsDirectory, withIntermediateDirectories: true)
+        let promptFile = paths.promptsDirectory + "/" + sessionName + ".md"
+        try prompt.write(toFile: promptFile, atomically: true, encoding: .utf8)
+        return promptFile
+    }
+
+    func addFriendlySymlink(repository: Repository, branch: String, worktreePath: String) {
+        let directory = paths.friendlyWorktreesDirectory + "/" + repository.name
+        let link = directory + "/" + branch.replacing("/", with: "-")
+        try? FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        try? FileManager.default.removeItem(atPath: link)
+        try? FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: worktreePath)
+    }
+
+    // MARK: Private
+
+    /// How much of the prompt seeds the branch name.
+    private static let branchSlugLength = 40
+
+    private func item(
+        worktree: Worktree,
+        panes: [TmuxPane],
+        activity: [String: Date],
+        metadata: AppMetadata,
+    ) async -> WorktreeItem {
+        let pane = panes.first { pane in
+            SessionName.isAgentIDE(pane.sessionName) && pane.currentPath == worktree.path
+        }
+        let session = pane.map { pane in
+            AgentSession(
+                name: pane.sessionName,
+                agent: agentKind(of: pane.sessionName),
+                status: pane.isDead ? .finished(pane.exitStatus) : .running,
+                workingDirectory: pane.currentPath,
+            )
+        }
+        var unread = false
+        if let session, let lastEvent = activity[session.name] {
+            unread = lastEvent > (metadata.lastSeen[session.name] ?? .distantPast)
+        }
+        return await WorktreeItem(
+            worktree: worktree,
+            session: session,
+            isDirty: git.isDirty(worktreePath: worktree.path),
+            aheadOfUpstream: git.aheadOfUpstream(worktreePath: worktree.path),
+            hasUnread: unread,
+        )
+    }
+
+    private func availableBranch(repository: Repository, prompt: String) async -> String {
+        let base = "agent/" + SessionName.slug(String(prompt.prefix(Self.branchSlugLength)))
+        guard await git.branchExists(repository: repository, branch: base) else {
+            return base
+        }
+
+        var attempt = 2
+        while await git.branchExists(repository: repository, branch: "\(base)-\(attempt)") {
+            attempt += 1
+        }
+        return "\(base)-\(attempt)"
+    }
+
+    private func createWorktreePath(repository: Repository, branch: String) async throws -> String {
+        let existing = await (try? git.worktrees(of: repository)) ?? []
+        let prefix = paths.worktreesDirectory + "/"
+        let uuid = existing
+            .compactMap { worktree -> String? in
+                guard worktree.path.hasPrefix(prefix) else {
+                    return nil
+                }
+
+                return worktree.path.dropFirst(prefix.count).split(separator: "/").first.map(String.init)
+            }
+            .first ?? UUID().uuidString.lowercased()
+        let path = prefix + uuid + "/" + branch.replacing("/", with: "-")
+        try await git.createWorktree(repository: repository, branch: branch, at: path)
+        return path
+    }
+}

--- a/Sources/AgentIDEData/TmuxClient.swift
+++ b/Sources/AgentIDEData/TmuxClient.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+// MARK: - TmuxPane
+
+/// One tmux pane's observed state.
+public struct TmuxPane: Sendable {
+    /// The pane's session name.
+    public let sessionName: String
+
+    /// Whether the pane's process has exited.
+    public let isDead: Bool
+
+    /// The dead pane's exit status, when available.
+    public let exitStatus: Int?
+
+    /// The pane's current working directory.
+    public let currentPath: String
+}
+
+// MARK: - TmuxClient
+
+/// Talks to the sandbox user's tmux server. Outside the sandbox every
+/// call rides the sudoers launch shape; inside it talks to the shared
+/// per-uid socket directly.
+public struct TmuxClient: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a client; `socketDirectory` isolates test servers.
+    public init(
+        runner: any ProcessRunner,
+        launcher: SandvaultLauncher,
+        isInsideSandbox: Bool,
+        socketDirectory: String = "/tmp",
+    ) {
+        self.runner = runner
+        self.launcher = launcher
+        self.isInsideSandbox = isInsideSandbox
+        self.socketDirectory = socketDirectory
+    }
+
+    // MARK: Public
+
+    /// Every pane on the server, empty when no server runs. Fields are
+    /// joined by `|`: tmux replaces control characters like tab in
+    /// `-F` output, so a printable separator is required. Only the
+    /// trailing path can contain `|`, so its pieces are rejoined.
+    public func panes() async throws -> [TmuxPane] {
+        let result = try await tmux(["list-panes", "-a", "-F", Self.paneFormat], allowFailure: true)
+        guard result.succeeded else {
+            return []
+        }
+
+        return result.standardOutput.split(separator: "\n").compactMap { line in
+            // maxSplits keeps a `|` inside the trailing path intact.
+            let fields = line.split(
+                separator: "|",
+                maxSplits: Self.paneFieldCount - 1,
+                omittingEmptySubsequences: false,
+            )
+            guard fields.count == Self.paneFieldCount else {
+                return nil
+            }
+
+            var field = fields.map(String.init).makeIterator()
+            return TmuxPane(
+                sessionName: field.next() ?? "",
+                isDead: field.next() == "1",
+                exitStatus: field.next().flatMap { Int($0) },
+                currentPath: field.next() ?? "",
+            )
+        }
+    }
+
+    /// Creates a detached session running a command. `remain-on-exit`
+    /// comes from the server config so even an agent that exits
+    /// immediately leaves an inspectable dead pane. The pane's
+    /// `INITIAL_DIR` is pinned because the sandbox's zshenv changes
+    /// directory to it, which would otherwise send agents to the
+    /// server's directory instead of their worktree. The first call
+    /// also births the server inside the sandbox.
+    public func newSession(name: String, directory: String, command: String) async throws {
+        try await tmux([
+            "new-session", "-A", "-d",
+            "-s", name,
+            "-c", directory,
+            "-e", "AGENTIDE_SESSION=" + name,
+            "-e", "INITIAL_DIR=" + directory,
+            command,
+        ])
+    }
+
+    /// Pastes a file's content into a session's terminal and presses
+    /// return, so prompts reach agents as input rather than argv.
+    public func sendPromptFile(_ file: String, to sessionName: String) async throws {
+        try await tmux([
+            "load-buffer", file,
+            ";", "paste-buffer", "-d", "-p", "-t", sessionName,
+            ";", "send-keys", "-t", sessionName, "Enter",
+        ])
+    }
+
+    /// Kills one session, leaving the server and its siblings alone.
+    public func killSession(name: String) async throws {
+        try await tmux(["kill-session", "-t", name])
+    }
+
+    // periphery:ignore - used by integration tests, which the app
+    // scheme periphery scans excludes, and by the planned emergency stop.
+    /// Kills the whole server.
+    public func killServer() async {
+        _ = try? await tmux(["kill-server"], allowFailure: true)
+    }
+
+    /// The argv a terminal view should spawn to attach interactively.
+    public func attachCommand(sessionName: String) -> [String] {
+        if isInsideSandbox {
+            ["tmux", "attach-session", "-t", sessionName]
+        } else {
+            launcher.command(
+                payload: "export TMUX_TMPDIR=" + socketDirectory
+                    + "; exec tmux attach-session -t " + shellQuote(sessionName),
+                initialDirectory: launcher.sharedWorkspace,
+                sessionID: UUID().uuidString,
+                sessionName: sessionName,
+            )
+        }
+    }
+
+    // MARK: Private
+
+    private static let paneFieldCount = 4
+    private static let paneFormat =
+        "#{session_name}|#{pane_dead}|#{pane_dead_status}|#{pane_current_path}"
+
+    private let runner: any ProcessRunner
+    private let launcher: SandvaultLauncher
+    private let isInsideSandbox: Bool
+    private let socketDirectory: String
+
+    /// tmux only reads `-f` config when it starts the server, so
+    /// passing it on every call is harmless and guarantees
+    /// `remain-on-exit` is set before any pane can exit. tmux config
+    /// can run shell commands, so the file is always overwritten with
+    /// the minimal content and owner-only permissions rather than
+    /// trusting whatever might already sit in the shared socket
+    /// directory.
+    private func configArguments() -> [String] {
+        let configFile = socketDirectory + "/agentide.conf"
+        try? FileManager.default.createDirectory(atPath: socketDirectory, withIntermediateDirectories: true)
+        try? "set -g remain-on-exit on\n".write(toFile: configFile, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configFile)
+        return ["-f", configFile]
+    }
+
+    @discardableResult
+    private func tmux(_ arguments: [String], allowFailure: Bool = false) async throws -> ProcessResult {
+        let full = configArguments() + arguments
+        let result: ProcessResult
+        if isInsideSandbox {
+            result = try await runner.run(
+                ["tmux"] + full,
+                workingDirectory: nil,
+                environment: ["TMUX_TMPDIR": socketDirectory],
+            )
+        } else {
+            let payload = "export TMUX_TMPDIR=" + socketDirectory + "; cd ~ && ~/configure; "
+                + "source ~/.zshenv; source ~/.zprofile; source ~/.zshrc; "
+                + "exec tmux " + full.map(shellQuote).joined(separator: " ")
+            let argv = launcher.command(
+                payload: payload,
+                initialDirectory: launcher.sharedWorkspace,
+                sessionID: UUID().uuidString,
+                sessionName: "agentide-control",
+            )
+            result = try await runner.run(argv, workingDirectory: nil, environment: [:])
+        }
+        guard result.succeeded || allowFailure else {
+            throw CommandError(command: "tmux " + arguments.joined(separator: " "), result: result)
+        }
+
+        return result
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'" + value.replacing("'", with: "'\\''") + "'"
+    }
+}

--- a/Sources/AgentIDEData/TranscriptReader.swift
+++ b/Sources/AgentIDEData/TranscriptReader.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Reads agent transcript JSONL files across the user boundary; the
+/// sandbox's export ACLs make them host-readable.
+public struct TranscriptReader: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a reader.
+    public init() {
+        // No configuration is needed.
+    }
+
+    // MARK: Public
+
+    /// The newest transcript file in a directory, by modification
+    /// time.
+    public func latestTranscript(in directory: String) -> URL? {
+        let manager = FileManager.default
+        let names = (try? manager.contentsOfDirectory(atPath: directory)) ?? []
+        let transcripts = names.filter { $0.hasSuffix(".jsonl") }.map { directory + "/" + $0 }
+        return transcripts
+            .max { modificationDate($0) < modificationDate($1) }
+            .map { URL(fileURLWithPath: $0) }
+    }
+
+    /// The resume id a transcript represents, its file name stem.
+    public func resumeID(of transcript: URL) -> String {
+        transcript.deletingPathExtension().lastPathComponent
+    }
+
+    /// When a transcript was last written, used for stall detection.
+    public func modificationDate(_ path: String) -> Date {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: path)
+        return attributes?[.modificationDate] as? Date ?? .distantPast
+    }
+
+    /// The last assistant message's text in a transcript, tolerating
+    /// unknown line shapes.
+    public func finalAssistantMessage(in transcript: URL) -> String? {
+        guard let content = try? String(contentsOf: transcript, encoding: .utf8) else {
+            return nil
+        }
+
+        let decoder = JSONDecoder()
+        for line in content.split(separator: "\n").reversed() {
+            guard let data = line.data(using: .utf8),
+                  let parsed = try? decoder.decode(TranscriptLine.self, from: data),
+                  parsed.type == "assistant"
+            else {
+                continue
+            }
+
+            let texts = (parsed.message?.content ?? []).compactMap(\.text)
+            guard texts.isEmpty == false else {
+                continue
+            }
+
+            return texts.joined(separator: "\n")
+        }
+        return nil
+    }
+
+    // MARK: Private
+
+    private struct TranscriptLine: Decodable {
+        let type: String?
+        let message: TranscriptMessage?
+    }
+
+    private struct TranscriptMessage: Decodable {
+        // Absent from the JSON when a message carries no content.
+        // swiftlint:disable:next discouraged_optional_collection
+        let content: [TranscriptContent]?
+    }
+
+    private struct TranscriptContent: Decodable {
+        let text: String?
+    }
+}

--- a/Sources/AgentIDEData/WorkspacePaths.swift
+++ b/Sources/AgentIDEData/WorkspacePaths.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// The sandvault-related locations AgentIDE reads and writes. The
+/// roots are injectable so tests run against temporary workspaces.
+public struct WorkspacePaths: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates paths from explicit roots.
+    public init(
+        hostUser: String,
+        sharedWorkspace: String,
+        sandboxHome: String,
+        archivesDirectory: String,
+        metadataFile: String,
+    ) {
+        self.hostUser = hostUser
+        self.sharedWorkspace = sharedWorkspace
+        self.sandboxHome = sandboxHome
+        self.archivesDirectory = archivesDirectory
+        self.metadataFile = metadataFile
+    }
+
+    // MARK: Public
+
+    /// Whether this process runs inside a sandvault session.
+    public static var isInsideSandbox: Bool {
+        ProcessInfo.processInfo.environment["SV_SESSION_ID"] != nil
+    }
+
+    /// The host (GUI) user name.
+    public let hostUser: String
+
+    /// The workspace shared by the host and sandbox users.
+    public let sharedWorkspace: String
+
+    /// The sandbox user's home directory.
+    public let sandboxHome: String
+
+    /// Where archives of deleted worktrees are kept, outside the
+    /// guest-writable workspace.
+    public let archivesDirectory: String
+
+    /// Where the app's own metadata file lives.
+    public let metadataFile: String
+
+    /// Where full repository checkouts live.
+    public var repositoriesDirectory: String {
+        sharedWorkspace + "/repositories"
+    }
+
+    /// Where canonical uuid-grouped worktrees live.
+    public var worktreesDirectory: String {
+        sharedWorkspace + "/worktrees"
+    }
+
+    /// AgentIDE's own area of the shared workspace.
+    public var agentideDirectory: String {
+        sharedWorkspace + "/agentide"
+    }
+
+    /// Where session prompt files are written.
+    public var promptsDirectory: String {
+        agentideDirectory + "/prompts"
+    }
+
+    /// Where hook events are spooled.
+    public var eventsDirectory: String {
+        agentideDirectory + "/events"
+    }
+
+    /// Where human-friendly worktree symlinks live.
+    public var friendlyWorktreesDirectory: String {
+        agentideDirectory + "/worktrees"
+    }
+
+    /// The template directory sandvault copies into the sandbox home.
+    public var userTemplateDirectory: String {
+        sharedWorkspace + "/user"
+    }
+
+    /// Creates paths for the current process, stripping any sandvault
+    /// prefix so the same paths work inside and outside the sandbox.
+    public static func current() -> Self {
+        let user = NSUserName()
+        let prefix = "sandvault-"
+        let host = user.hasPrefix(prefix) ? String(user.dropFirst(prefix.count)) : user
+        let support = NSHomeDirectory() + "/Library/Application Support/AgentIDE"
+        return Self(
+            hostUser: host,
+            sharedWorkspace: "/Users/Shared/sv-" + host,
+            sandboxHome: "/Users/sandvault-" + host,
+            archivesDirectory: support + "/Archives",
+            metadataFile: support + "/state.json",
+        )
+    }
+}

--- a/Sources/AgentIDEDomain/AgentKind.swift
+++ b/Sources/AgentIDEDomain/AgentKind.swift
@@ -1,5 +1,5 @@
 /// A supported agent CLI, identified by its executable name.
-public enum AgentKind: String, CaseIterable, Sendable {
+public enum AgentKind: String, CaseIterable, Codable, Sendable {
     /// Anthropic's Claude Code CLI.
     case claudeCode = "claude"
     /// OpenAI's Codex CLI.

--- a/Sources/AgentIDEDomain/AgentSession.swift
+++ b/Sources/AgentIDEDomain/AgentSession.swift
@@ -1,0 +1,48 @@
+// MARK: - SessionStatus
+
+/// The observed state of a tmux-hosted agent session.
+public enum SessionStatus: Hashable, Sendable {
+    /// The pane's process is still running.
+    case running
+    /// The pane's process exited with the given status, if known.
+    case finished(Int?)
+}
+
+// MARK: - AgentSession
+
+/// A tmux session, either one AgentIDE created or a foreign one.
+public struct AgentSession: Identifiable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a session record.
+    public init(
+        name: String,
+        agent: AgentKind?,
+        status: SessionStatus,
+        workingDirectory: String?,
+    ) {
+        self.name = name
+        self.agent = agent
+        self.status = status
+        self.workingDirectory = workingDirectory
+    }
+
+    // MARK: Public
+
+    /// The tmux session name.
+    public let name: String
+
+    /// The agent the session runs, when recognisable from the name.
+    public let agent: AgentKind?
+
+    /// Whether the session's process is running or finished.
+    public let status: SessionStatus
+
+    /// The pane's current working directory, when known.
+    public let workingDirectory: String?
+
+    /// The stable identity, the tmux session name.
+    public var id: String {
+        name
+    }
+}

--- a/Sources/AgentIDEDomain/ArchiveMetadata.swift
+++ b/Sources/AgentIDEDomain/ArchiveMetadata.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Everything needed to restore a deleted worktree and resume its
+/// session, stored beside the archive's bundle and tar.
+public struct ArchiveMetadata: Codable, Identifiable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates archive metadata.
+    public init(
+        id: String,
+        repositoryName: String,
+        repositoryPath: String,
+        branch: String,
+        worktreePath: String,
+        sessionName: String,
+        resumeID: String?,
+        archivedAt: Date,
+    ) {
+        self.id = id
+        self.repositoryName = repositoryName
+        self.repositoryPath = repositoryPath
+        self.branch = branch
+        self.worktreePath = worktreePath
+        self.sessionName = sessionName
+        self.resumeID = resumeID
+        self.archivedAt = archivedAt
+    }
+
+    // MARK: Public
+
+    /// The archive directory's name.
+    public let id: String
+
+    /// The owning repository's name.
+    public let repositoryName: String
+
+    /// The owning repository's checkout path.
+    public let repositoryPath: String
+
+    /// The archived branch.
+    public let branch: String
+
+    /// The canonical worktree path to restore to, so cwd-keyed
+    /// conversation state lines up on resume.
+    public let worktreePath: String
+
+    /// The tmux session name the worktree ran under; the agent is
+    /// derivable from its suffix.
+    public let sessionName: String
+
+    /// The agent-native conversation id used to resume.
+    public let resumeID: String?
+
+    /// When the archive was created.
+    public let archivedAt: Date
+}

--- a/Sources/AgentIDEDomain/DiffFile.swift
+++ b/Sources/AgentIDEDomain/DiffFile.swift
@@ -1,0 +1,81 @@
+// MARK: - DiffLine
+
+/// One line of a unified diff hunk.
+public struct DiffLine: Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a diff line.
+    public init(kind: Kind, content: String) {
+        self.kind = kind
+        self.content = content
+    }
+
+    // MARK: Public
+
+    /// How a diff line changes the file.
+    public enum Kind: Hashable, Sendable {
+        /// A line present on both sides.
+        case context
+        /// A line added by the change.
+        case addition
+        /// A line removed by the change.
+        case deletion
+    }
+
+    /// The line's change kind.
+    public let kind: Kind
+
+    /// The line's text without its `+`, `-` or space prefix.
+    public let content: String
+}
+
+// MARK: - DiffHunk
+
+/// One `@@` hunk of a unified diff.
+public struct DiffHunk: Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a hunk.
+    public init(oldStart: Int, newStart: Int, lines: [DiffLine]) {
+        self.oldStart = oldStart
+        self.newStart = newStart
+        self.lines = lines
+    }
+
+    // MARK: Public
+
+    /// The first line number on the old side.
+    public let oldStart: Int
+
+    /// The first line number on the new side.
+    public let newStart: Int
+
+    /// The hunk's lines in order.
+    public let lines: [DiffLine]
+}
+
+// MARK: - DiffFile
+
+/// One file's changes within a unified diff.
+public struct DiffFile: Identifiable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a file diff.
+    public init(path: String, hunks: [DiffHunk]) {
+        self.path = path
+        self.hunks = hunks
+    }
+
+    // MARK: Public
+
+    /// The file's path on the new side.
+    public let path: String
+
+    /// The file's hunks in order.
+    public let hunks: [DiffHunk]
+
+    /// The stable identity, the file path.
+    public var id: String {
+        path
+    }
+}

--- a/Sources/AgentIDEDomain/DiffParser.swift
+++ b/Sources/AgentIDEDomain/DiffParser.swift
@@ -1,0 +1,100 @@
+/// Parses `git diff` unified output into files, hunks and lines.
+public enum DiffParser {
+    // MARK: Public
+
+    /// Parses unified diff text; unrecognised lines are ignored.
+    public static func parse(_ diff: String) -> [DiffFile] {
+        var files = [DiffFile]()
+        var newPath: String?
+        var oldPath: String?
+        var hunks = [DiffHunk]()
+        var lines = [DiffLine]()
+        var starts: (old: Int, new: Int) = (0, 0)
+        var inHunk = false
+
+        func closeHunk() {
+            guard inHunk else {
+                return
+            }
+
+            hunks.append(DiffHunk(oldStart: starts.old, newStart: starts.new, lines: lines))
+            lines = []
+            inHunk = false
+        }
+
+        func closeFile() {
+            closeHunk()
+            // Prefer the new path; fall back to the old path so deleted
+            // files (whose new path is /dev/null) are still represented.
+            if let path = newPath ?? oldPath {
+                files.append(DiffFile(path: path, hunks: hunks))
+            }
+            newPath = nil
+            oldPath = nil
+            hunks = []
+        }
+
+        for raw in diff.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(raw)
+            if line.hasPrefix("diff --git ") {
+                closeFile()
+            } else if line.hasPrefix("@@ ") {
+                closeHunk()
+                starts = hunkStarts(line)
+                inHunk = true
+            } else if inHunk {
+                if let parsed = diffLine(line) {
+                    lines.append(parsed)
+                }
+            } else if line.hasPrefix("--- ") {
+                oldPath = strippedPath(String(line.dropFirst("--- ".count)))
+            } else if line.hasPrefix("+++ ") {
+                newPath = strippedPath(String(line.dropFirst("+++ ".count)))
+            }
+        }
+        closeFile()
+        return files
+    }
+
+    // MARK: Private
+
+    /// The `-old` and `+new` markers of a hunk header.
+    private static let hunkMarkerCount = 2
+
+    private static func strippedPath(_ name: String) -> String? {
+        guard name != "/dev/null" else {
+            return nil
+        }
+
+        if name.hasPrefix("a/") || name.hasPrefix("b/") {
+            return String(name.dropFirst("a/".count))
+        }
+        return name
+    }
+
+    private static func hunkStarts(_ line: String) -> (old: Int, new: Int) {
+        let numbers = line.split(separator: " ").dropFirst().prefix(hunkMarkerCount).map { marker in
+            Int(marker.dropFirst().prefix(while: \.isNumber)) ?? 0
+        }
+        return (numbers.first ?? 0, numbers.last ?? 0)
+    }
+
+    private static func diffLine(_ line: String) -> DiffLine? {
+        // git prefixes every hunk body line, blank ones included, with
+        // a space; a truly empty line is the trailing newline after the
+        // hunk, not a context line, so it ends the body.
+        switch line.first {
+        case "+":
+            DiffLine(kind: .addition, content: String(line.dropFirst()))
+
+        case "-":
+            DiffLine(kind: .deletion, content: String(line.dropFirst()))
+
+        case " ":
+            DiffLine(kind: .context, content: String(line.dropFirst()))
+
+        default:
+            nil
+        }
+    }
+}

--- a/Sources/AgentIDEDomain/PatchBuilder.swift
+++ b/Sources/AgentIDEDomain/PatchBuilder.swift
@@ -1,0 +1,90 @@
+// MARK: - DiffSelection
+
+/// A selected line within a parsed diff, addressed by hunk and line
+/// index.
+public struct DiffSelection: Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a selection.
+    public init(hunkIndex: Int, lineIndex: Int) {
+        self.hunkIndex = hunkIndex
+        self.lineIndex = lineIndex
+    }
+
+    // MARK: Public
+
+    // These form the value's identity for Set membership; periphery's
+    // assign-only check does not see synthesised Hashable use.
+    // periphery:ignore
+    public let hunkIndex: Int
+    // periphery:ignore
+    public let lineIndex: Int
+}
+
+// MARK: - PatchBuilder
+
+/// Builds the minimal patch that, applied with `git apply -R --index`,
+/// undoes only the selected lines of a commit, using the same
+/// partial-hunk rules as `git add --patch`: unselected additions become
+/// context, unselected deletions are dropped.
+public enum PatchBuilder {
+    // MARK: Public
+
+    /// Builds the patch text for the selected lines, or nil when the
+    /// selection contains no changes.
+    public static func reversePatch(file: DiffFile, selection: Set<DiffSelection>) -> String? {
+        let hunkTexts = file.hunks.enumerated().compactMap { hunkIndex, hunk in
+            hunkText(hunk: hunk, hunkIndex: hunkIndex, selection: selection)
+        }
+        guard hunkTexts.isEmpty == false else {
+            return nil
+        }
+
+        let header = "diff --git a/\(file.path) b/\(file.path)\n--- a/\(file.path)\n+++ b/\(file.path)\n"
+        return header + hunkTexts.joined()
+    }
+
+    // MARK: Private
+
+    private static func hunkText(hunk: DiffHunk, hunkIndex: Int, selection: Set<DiffSelection>) -> String? {
+        var body = [String]()
+        var oldCount = 0
+        var newCount = 0
+        var selectedChanges = 0
+
+        for (lineIndex, line) in hunk.lines.enumerated() {
+            let selected = selection.contains(DiffSelection(hunkIndex: hunkIndex, lineIndex: lineIndex))
+            switch (line.kind, selected) {
+            case (.context, _):
+                body.append(" " + line.content)
+                oldCount += 1
+                newCount += 1
+
+            case (.addition, true):
+                body.append("+" + line.content)
+                newCount += 1
+                selectedChanges += 1
+
+            case (.addition, false):
+                body.append(" " + line.content)
+                oldCount += 1
+                newCount += 1
+
+            case (.deletion, true):
+                body.append("-" + line.content)
+                oldCount += 1
+                selectedChanges += 1
+
+            case (.deletion, false):
+                break
+            }
+        }
+
+        guard selectedChanges > 0 else {
+            return nil
+        }
+
+        let header = "@@ -\(hunk.newStart),\(oldCount) +\(hunk.newStart),\(newCount) @@\n"
+        return header + body.joined(separator: "\n") + "\n"
+    }
+}

--- a/Sources/AgentIDEDomain/PullRequestSummary.swift
+++ b/Sources/AgentIDEDomain/PullRequestSummary.swift
@@ -1,0 +1,51 @@
+/// The dashboard-relevant state of an open pull request.
+public struct PullRequestSummary: Identifiable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a pull request summary.
+    public init(
+        number: Int,
+        title: String,
+        url: String,
+        headBranch: String,
+        mergeable: String,
+        reviewDecision: String,
+        checks: String,
+    ) {
+        self.number = number
+        self.title = title
+        self.url = url
+        self.headBranch = headBranch
+        self.mergeable = mergeable
+        self.reviewDecision = reviewDecision
+        self.checks = checks
+    }
+
+    // MARK: Public
+
+    /// The pull request number.
+    public let number: Int
+
+    /// The pull request title.
+    public let title: String
+
+    /// The pull request's web address.
+    public let url: String
+
+    /// The branch the pull request merges from.
+    public let headBranch: String
+
+    /// GitHub's mergeability verdict, for example `MERGEABLE`.
+    public let mergeable: String
+
+    /// The aggregate review decision, empty when none.
+    public let reviewDecision: String
+
+    /// The aggregate check state, for example `SUCCESS` or `FAILURE`.
+    public let checks: String
+
+    /// The stable identity, the pull request number.
+    public var id: Int {
+        number
+    }
+}

--- a/Sources/AgentIDEDomain/Repository.swift
+++ b/Sources/AgentIDEDomain/Repository.swift
@@ -1,0 +1,23 @@
+/// A git repository in the shared workspace.
+public struct Repository: Identifiable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a repository from its checkout location.
+    public init(name: String, path: String) {
+        self.name = name
+        self.path = path
+    }
+
+    // MARK: Public
+
+    /// The repository's directory name.
+    public let name: String
+
+    /// The absolute path of the checkout.
+    public let path: String
+
+    /// The stable identity, the checkout path.
+    public var id: String {
+        path
+    }
+}

--- a/Sources/AgentIDEDomain/RepositoryGroup.swift
+++ b/Sources/AgentIDEDomain/RepositoryGroup.swift
@@ -1,0 +1,63 @@
+// MARK: - WorktreeItem
+
+/// One worktree with everything the dashboard shows about it.
+public struct WorktreeItem: Identifiable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a dashboard item.
+    public init(worktree: Worktree, session: AgentSession?, isDirty: Bool, aheadOfUpstream: Int?, hasUnread: Bool) {
+        self.worktree = worktree
+        self.session = session
+        self.isDirty = isDirty
+        self.aheadOfUpstream = aheadOfUpstream
+        self.hasUnread = hasUnread
+    }
+
+    // MARK: Public
+
+    /// The worktree itself.
+    public let worktree: Worktree
+
+    /// The tmux session running in it, when one exists.
+    public let session: AgentSession?
+
+    /// Whether the worktree has uncommitted changes.
+    public let isDirty: Bool
+
+    /// Commits not yet pushed to the upstream, nil without one.
+    public let aheadOfUpstream: Int?
+
+    /// Whether the session has produced output since last seen.
+    public let hasUnread: Bool
+
+    /// The stable identity, the worktree path.
+    public var id: String {
+        worktree.id
+    }
+}
+
+// MARK: - RepositoryGroup
+
+/// A repository with its dashboard-ready worktrees.
+public struct RepositoryGroup: Identifiable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a group.
+    public init(repository: Repository, items: [WorktreeItem]) {
+        self.repository = repository
+        self.items = items
+    }
+
+    // MARK: Public
+
+    /// The repository.
+    public let repository: Repository
+
+    /// Its worktrees in branch order.
+    public let items: [WorktreeItem]
+
+    /// The stable identity, the repository's.
+    public var id: String {
+        repository.id
+    }
+}

--- a/Sources/AgentIDEDomain/Worktree.swift
+++ b/Sources/AgentIDEDomain/Worktree.swift
@@ -1,0 +1,31 @@
+/// A git worktree belonging to a repository, holding one branch.
+public struct Worktree: Identifiable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a worktree record.
+    public init(repositoryName: String, repositoryPath: String, branch: String, path: String) {
+        self.repositoryName = repositoryName
+        self.repositoryPath = repositoryPath
+        self.branch = branch
+        self.path = path
+    }
+
+    // MARK: Public
+
+    /// The owning repository's name.
+    public let repositoryName: String
+
+    /// The owning repository's checkout path.
+    public let repositoryPath: String
+
+    /// The branch checked out in this worktree.
+    public let branch: String
+
+    /// The worktree's canonical path.
+    public let path: String
+
+    /// The stable identity, the worktree path.
+    public var id: String {
+        path
+    }
+}

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -1,0 +1,154 @@
+import AgentIDEData
+import AgentIDEDomain
+import Observation
+import UserNotifications
+
+/// The dashboard's state: repositories, worktrees, sessions and
+/// archives, refreshed by polling and notifying on completion.
+@preconcurrency
+@Observable
+@MainActor
+public final class DashboardModel {
+    // MARK: Lifecycle
+
+    /// Creates the model.
+    public init(service: SessionService, store: MetadataStore) {
+        self.service = service
+        self.store = store
+    }
+
+    deinit {
+        // The polling task is cancelled by its owning view.
+    }
+
+    // MARK: Public
+
+    /// The grouped worktrees per repository.
+    public private(set) var groups: [RepositoryGroup] = []
+
+    /// Sessions not created by AgentIDE.
+    public private(set) var foreign: [AgentSession] = []
+
+    /// Archives available to undelete.
+    public private(set) var archives: [ArchiveMetadata] = []
+
+    /// The selected worktree item.
+    public var selection: WorktreeItem?
+
+    /// Whether the new session sheet is shown.
+    public var showsNewSession = false
+
+    /// The last background error, for display.
+    public private(set) var status: String?
+
+    /// The repositories available for new sessions.
+    public var repositories: [Repository] {
+        service.repositories()
+    }
+
+    /// Reloads everything and notifies about newly finished or
+    /// newly unread sessions.
+    public func refresh() async {
+        let overview = await service.overview()
+        notifyChanges(from: groups, to: overview.groups)
+        groups = overview.groups
+        foreign = overview.foreign
+        archives = store.load().archives
+        if let selected = selection {
+            selection = overview.groups.flatMap(\.items).first { $0.id == selected.id }
+        }
+    }
+
+    /// Polls the system on an interval while the dashboard is alive.
+    public func poll() async {
+        _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])
+        while Task.isCancelled == false {
+            await refresh()
+            try? await Task.sleep(for: .seconds(Self.pollInterval))
+        }
+    }
+
+    /// Creates a session from the sheet's input.
+    public func createSession(
+        repository: Repository,
+        prompt: String,
+        agent: AgentKind,
+        extraArguments: String = "",
+    ) async {
+        do {
+            _ = try await service.createSession(
+                repository: repository,
+                prompt: prompt,
+                agent: agent,
+                extraArguments: extraArguments,
+            )
+            showsNewSession = false
+            await refresh()
+        } catch {
+            status = error.localizedDescription
+        }
+    }
+
+    /// Archives and deletes a worktree.
+    public func archive(item: WorktreeItem) async {
+        do {
+            _ = try await service.archiveAndDelete(item: item)
+            if selection?.id == item.id {
+                selection = nil
+            }
+            await refresh()
+        } catch {
+            status = error.localizedDescription
+        }
+    }
+
+    /// Restores an archived worktree.
+    public func undelete(archive: ArchiveMetadata) async {
+        do {
+            try await service.undelete(archive: archive)
+            await refresh()
+        } catch {
+            status = error.localizedDescription
+        }
+    }
+
+    // MARK: Private
+
+    private static let pollInterval = 5
+
+    private let service: SessionService
+    private let store: MetadataStore
+
+    private func notifyChanges(from old: [RepositoryGroup], to new: [RepositoryGroup]) {
+        // Uniquing, not trapping: duplicate ids would crash the poll.
+        let oldItems = Dictionary(old.flatMap(\.items).map { ($0.id, $0) }) { first, _ in first }
+        for item in new.flatMap(\.items) {
+            guard let session = item.session, let previous = oldItems[item.id] else {
+                continue
+            }
+
+            let finished = previous.session?.status == .running && session.status != .running
+            let becameUnread = previous.hasUnread == false && item.hasUnread
+            guard finished || becameUnread else {
+                continue
+            }
+
+            post(
+                title: finished ? "Agent finished" : "Agent output",
+                body: "\(item.worktree.repositoryName): \(item.worktree.branch)",
+            )
+        }
+    }
+
+    private func post(title: String, body: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil,
+        )
+        UNUserNotificationCenter.current().add(request)
+    }
+}

--- a/Sources/DashboardFeature/DashboardView.swift
+++ b/Sources/DashboardFeature/DashboardView.swift
@@ -1,29 +1,99 @@
+import AgentIDEDomain
 import SwiftUI
 
-/// The all-agents dashboard, an empty placeholder until worktrees and
-/// sessions exist.
+/// The sidebar listing worktrees grouped by repository, foreign
+/// sessions and undeletable archives.
 public struct DashboardView: View {
     // MARK: Lifecycle
 
-    /// Creates the dashboard view.
-    public init() {
-        // SwiftUI requires a public initialiser across module boundaries.
+    /// Creates the sidebar for a model.
+    public init(model: DashboardModel) {
+        self.model = model
     }
 
     // MARK: Public
 
-    /// The placeholder content shown while no agents exist.
+    /// The grouped list with badges and lifecycle context menus.
     public var body: some View {
-        ContentUnavailableView(
-            "No agents yet",
-            systemImage: "rectangle.stack",
-            description: Text("Worktrees and their agents will appear here, grouped by repository."),
-        )
-        .frame(minWidth: Self.minimumWidth, minHeight: Self.minimumHeight)
+        List(selection: selectionBinding) {
+            ForEach(model.groups) { group in
+                if group.items.isEmpty == false {
+                    section(for: group)
+                }
+            }
+            foreignSection
+            archivesSection
+        }
+        .toolbar {
+            Button("New session", systemImage: "plus") { model.showsNewSession = true }
+        }
+        .overlay(alignment: .bottom) {
+            if let status = model.status {
+                Text(status).font(.callout).foregroundStyle(.secondary).padding(Self.statusPadding)
+            }
+        }
     }
 
     // MARK: Private
 
-    private static let minimumWidth: CGFloat = 480
-    private static let minimumHeight: CGFloat = 320
+    private static let statusPadding: CGFloat = 4
+
+    private let model: DashboardModel
+
+    private var selectionBinding: Binding<WorktreeItem?> {
+        Binding(get: { model.selection }, set: { model.selection = $0 })
+    }
+
+    @ViewBuilder private var foreignSection: some View {
+        if model.foreign.isEmpty == false {
+            Section("Foreign sessions") {
+                ForEach(model.foreign) { session in
+                    Label {
+                        VStack(alignment: .leading) {
+                            Text(session.name)
+                            if let directory = session.workingDirectory {
+                                Text(directory).font(.caption).foregroundStyle(.secondary)
+                            }
+                        }
+                    } icon: {
+                        Image(systemName: "questionmark.circle")
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var archivesSection: some View {
+        if model.archives.isEmpty == false {
+            Section("Archives") {
+                ForEach(model.archives) { archive in
+                    Label {
+                        VStack(alignment: .leading) {
+                            Text("\(archive.repositoryName): \(archive.branch)")
+                            Text(archive.archivedAt, format: .relative(presentation: .named))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: "archivebox")
+                    }
+                    .contextMenu {
+                        Button("Undelete") { Task { await model.undelete(archive: archive) } }
+                    }
+                }
+            }
+        }
+    }
+
+    private func section(for group: RepositoryGroup) -> some View {
+        Section(group.repository.name) {
+            ForEach(group.items) { item in
+                WorktreeRowView(item: item)
+                    .tag(item)
+                    .contextMenu {
+                        Button("Archive and delete") { Task { await model.archive(item: item) } }
+                    }
+            }
+        }
+    }
 }

--- a/Sources/DashboardFeature/NewSessionSheet.swift
+++ b/Sources/DashboardFeature/NewSessionSheet.swift
@@ -1,0 +1,79 @@
+import AgentIDEDomain
+import SwiftUI
+
+/// The prompt-to-worktree entry point: pick a repository and agent,
+/// type the problem statement and any extra agent arguments, go.
+public struct NewSessionSheet: View {
+    // MARK: Lifecycle
+
+    /// Creates the sheet.
+    public init(model: DashboardModel) {
+        self.model = model
+    }
+
+    // MARK: Public
+
+    /// The form.
+    public var body: some View {
+        VStack(alignment: .leading, spacing: Self.spacing) {
+            Text("New agent session").font(.title2)
+            Picker("Repository", selection: $repository) {
+                Text("Choose").tag(Repository?.none)
+                ForEach(model.repositories) { repository in
+                    Text(repository.name).tag(Repository?.some(repository))
+                }
+            }
+            Picker("Agent", selection: $agent) {
+                ForEach(AgentKind.allCases, id: \.self) { kind in
+                    Text(kind.rawValue).tag(kind)
+                }
+            }
+            .pickerStyle(.segmented)
+            TextField("Extra agent arguments (optional)", text: $arguments)
+                .textFieldStyle(.roundedBorder)
+                .font(.body.monospaced())
+            TextEditor(text: $prompt)
+                .font(.body)
+                .frame(minHeight: Self.promptHeight)
+                .border(.separator)
+            HStack {
+                Spacer()
+                Button("Cancel") { model.showsNewSession = false }
+                Button("Start agent") { start() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(repository == nil || prompt.isEmpty)
+            }
+        }
+        .padding()
+        .frame(minWidth: Self.minimumWidth)
+    }
+
+    // MARK: Private
+
+    private static let spacing: CGFloat = 12
+    private static let promptHeight: CGFloat = 140
+    private static let minimumWidth: CGFloat = 480
+
+    @State private var repository: Repository?
+    @State private var agent: AgentKind = .claudeCode
+    @State private var prompt = ""
+    @AppStorage("newSessionArguments")
+    private var arguments = ""
+
+    private let model: DashboardModel
+
+    private func start() {
+        guard let repository else {
+            return
+        }
+
+        Task {
+            await model.createSession(
+                repository: repository,
+                prompt: prompt,
+                agent: agent,
+                extraArguments: arguments,
+            )
+        }
+    }
+}

--- a/Sources/DashboardFeature/WorktreeRowView.swift
+++ b/Sources/DashboardFeature/WorktreeRowView.swift
@@ -1,0 +1,72 @@
+import AgentIDEDomain
+import SwiftUI
+
+/// One worktree row with its status badges.
+struct WorktreeRowView: View {
+    // MARK: Internal
+
+    let item: WorktreeItem
+
+    var body: some View {
+        HStack {
+            Image(systemName: icon)
+                .foregroundStyle(iconColour)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading) {
+                Text(item.worktree.branch)
+                Text(badges).font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+            if item.hasUnread {
+                Circle().fill(.blue).frame(width: Self.unreadDotSize, height: Self.unreadDotSize)
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private static let unreadDotSize: CGFloat = 8
+
+    private var icon: String {
+        switch item.session?.status {
+        case .running:
+            "play.circle.fill"
+
+        case .finished:
+            "checkmark.circle"
+
+        case nil:
+            "circle.dashed"
+        }
+    }
+
+    private var iconColour: Color {
+        switch item.session?.status {
+        case .running:
+            .green
+
+        case .finished:
+            .secondary
+
+        case nil:
+            .secondary
+        }
+    }
+
+    private var badges: String {
+        var parts = [String]()
+        if let agent = item.session?.agent {
+            parts.append(agent.rawValue)
+        }
+        if item.isDirty {
+            parts.append("uncommitted")
+        }
+        if let ahead = item.aheadOfUpstream, ahead > 0 {
+            parts.append("unpushed \(ahead)")
+        }
+        if item.aheadOfUpstream == nil {
+            parts.append("no upstream")
+        }
+        return parts.isEmpty ? "idle" : parts.joined(separator: " · ")
+    }
+}

--- a/Sources/PRFeature/PullRequestsView.swift
+++ b/Sources/PRFeature/PullRequestsView.swift
@@ -1,18 +1,146 @@
+import AgentIDEData
+import AgentIDEDomain
 import SwiftUI
 
-/// The pull request dashboard, a placeholder until the GitHub slice.
+// MARK: - PullRequestsView
+
+/// The repository's open pull requests with one-click actions.
 public struct PullRequestsView: View {
     // MARK: Lifecycle
 
-    /// Creates the pull requests view.
-    public init() {
-        // SwiftUI requires a public initialiser across module boundaries.
+    /// Creates the pull request list for a repository.
+    public init(repository: Repository, items: [WorktreeItem], github: GitHubClient, service: SessionService) {
+        self.repository = repository
+        self.items = items
+        self.github = github
+        self.service = service
     }
 
     // MARK: Public
 
-    /// The placeholder content.
+    /// The list with merge, automerge and fix actions per row.
     public var body: some View {
-        Text("Pull requests arrive with the GitHub slice.")
+        List(summaries) { summary in
+            PullRequestRowView(
+                summary: summary,
+                canRemediate: worktree(for: summary) != nil,
+                onAutomerge: {
+                    act { try await github.enableAutomerge(repositoryPath: repository.path, number: summary.number) }
+                },
+                onMerge: { act { try await github.merge(repositoryPath: repository.path, number: summary.number) } },
+                onRemediate: { act { try await remediate(summary) } },
+            )
+        }
+        .overlay {
+            if summaries.isEmpty {
+                ContentUnavailableView("No open pull requests", systemImage: "arrow.triangle.pull")
+            }
+        }
+        .safeAreaInset(edge: .bottom) { footer }
+        .task(id: repository.id) { await reload() }
+    }
+
+    // MARK: Private
+
+    private static let footerPadding: CGFloat = 8
+
+    @State private var summaries: [PullRequestSummary] = []
+    @State private var status: String?
+
+    private let repository: Repository
+    private let items: [WorktreeItem]
+    private let github: GitHubClient
+    private let service: SessionService
+
+    private var footer: some View {
+        HStack {
+            Button("Refresh") { Task { await reload() } }
+            if let status {
+                Text(status).font(.callout).foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(Self.footerPadding)
+        .background(.bar)
+    }
+
+    private func worktree(for summary: PullRequestSummary) -> Worktree? {
+        items.first { $0.worktree.branch == summary.headBranch }?.worktree
+    }
+
+    private func reload() async {
+        do {
+            summaries = try await github.pullRequests(repositoryPath: repository.path)
+        } catch {
+            status = error.localizedDescription
+        }
+    }
+
+    private func remediate(_ summary: PullRequestSummary) async throws {
+        guard let worktree = worktree(for: summary) else {
+            return
+        }
+
+        let context = await github.remediationContext(repositoryPath: repository.path, number: summary.number)
+        let prompt = """
+        Address the following review comments and failing checks on pull request #\(summary.number), \
+        then commit your fixes. Do not push.
+
+        \(context)
+        """
+        _ = try await service.launchAgent(in: worktree, prompt: prompt, agent: .claudeCode)
+        status = "Fix agent launched for #\(summary.number)."
+    }
+
+    private func act(_ work: @escaping () async throws -> Void) {
+        Task {
+            do {
+                try await work()
+                status = "Done."
+                await reload()
+            } catch {
+                status = error.localizedDescription
+            }
+        }
+    }
+}
+
+// MARK: - PullRequestRowView
+
+/// One pull request row with its badges and actions.
+struct PullRequestRowView: View {
+    // MARK: Internal
+
+    static let rowPadding: CGFloat = 4
+
+    let summary: PullRequestSummary
+    let canRemediate: Bool
+    let onAutomerge: () -> Void
+    let onMerge: () -> Void
+    let onRemediate: () -> Void
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text("#\(summary.number) \(summary.title)").font(.headline)
+                Text(badges).font(.callout).foregroundStyle(.secondary)
+            }
+            Spacer()
+            if let url = URL(string: summary.url) {
+                Link("Open", destination: url)
+            }
+            Button("Fix", action: onRemediate).disabled(canRemediate == false)
+            Button("Automerge", action: onAutomerge)
+            Button("Merge", action: onMerge)
+        }
+        .padding(.vertical, Self.rowPadding)
+    }
+
+    // MARK: Private
+
+    private var badges: String {
+        [summary.headBranch, summary.mergeable, summary.reviewDecision, summary.checks]
+            .filter { $0.isEmpty == false }
+            .joined(separator: " · ")
     }
 }

--- a/Sources/ReviewFeature/DiffFileView.swift
+++ b/Sources/ReviewFeature/DiffFileView.swift
@@ -1,0 +1,125 @@
+import AgentIDEDomain
+import SwiftUI
+
+// MARK: - DiffFileView
+
+/// One file's hunks with tappable, selectable changed lines.
+struct DiffFileView: View {
+    // MARK: Internal
+
+    let file: DiffFile
+    let model: ReviewModel
+    let onEdit: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Self.lineSpacing) {
+            HStack {
+                Text(file.path).font(.headline.monospaced())
+                Spacer()
+                Button("Edit file", action: onEdit)
+            }
+            ForEach(Array(file.hunks.enumerated()), id: \.offset) { hunkIndex, hunk in
+                hunkView(hunkIndex: hunkIndex, hunk: hunk)
+            }
+        }
+        .padding(.bottom, Self.filePadding)
+    }
+
+    // MARK: Private
+
+    private static let lineSpacing: CGFloat = 2
+    private static let filePadding: CGFloat = 8
+
+    private func hunkView(hunkIndex: Int, hunk: DiffHunk) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("@@ -\(hunk.oldStart) +\(hunk.newStart) @@")
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+            ForEach(Array(hunk.lines.enumerated()), id: \.offset) { lineIndex, line in
+                DiffLineView(
+                    line: line,
+                    isSelected: isSelected(hunkIndex: hunkIndex, lineIndex: lineIndex),
+                ) {
+                    model.toggle(
+                        file: file,
+                        selection: DiffSelection(hunkIndex: hunkIndex, lineIndex: lineIndex),
+                    )
+                }
+            }
+        }
+    }
+
+    private func isSelected(hunkIndex: Int, lineIndex: Int) -> Bool {
+        model.selections[file.path]?
+            .contains(DiffSelection(hunkIndex: hunkIndex, lineIndex: lineIndex)) ?? false
+    }
+}
+
+// MARK: - DiffLineView
+
+/// One diff line, coloured by kind and tappable when changeable.
+struct DiffLineView: View {
+    // MARK: Internal
+
+    let line: DiffLine
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        let text = Text(prefix + line.content)
+            .font(.callout.monospaced())
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(background)
+            .overlay(alignment: .leading) {
+                if isSelected {
+                    Rectangle().fill(.blue).frame(width: Self.selectionBarWidth)
+                }
+            }
+        // Only changed lines are tappable, so only they carry the
+        // button gesture and accessibility trait.
+        if line.kind == .context {
+            text
+        } else {
+            text
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onTap)
+                .accessibilityAddTraits(.isButton)
+        }
+    }
+
+    // MARK: Private
+
+    private static let selectionBarWidth: CGFloat = 3
+    private static let selectedOpacity = 0.35
+    private static let unselectedOpacity = 0.15
+
+    private var prefix: String {
+        switch line.kind {
+        case .context:
+            "  "
+
+        case .addition:
+            "+ "
+
+        case .deletion:
+            "- "
+        }
+    }
+
+    private var opacity: Double {
+        isSelected ? Self.selectedOpacity : Self.unselectedOpacity
+    }
+
+    private var background: Color {
+        switch line.kind {
+        case .context:
+            .clear
+
+        case .addition:
+            .green.opacity(opacity)
+
+        case .deletion:
+            .red.opacity(opacity)
+        }
+    }
+}

--- a/Sources/ReviewFeature/FileEditorView.swift
+++ b/Sources/ReviewFeature/FileEditorView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+/// A plain text editor for one file in the worktree, for review-time
+/// fixes.
+struct FileEditorView: View {
+    // MARK: Lifecycle
+
+    /// Creates an editor for a file relative to the worktree.
+    init(worktreePath: String, relativePath: String) {
+        self.worktreePath = worktreePath
+        self.relativePath = relativePath
+    }
+
+    // MARK: Internal
+
+    /// The editor with save and close actions.
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(relativePath).font(.headline.monospaced())
+                Spacer()
+                if let status {
+                    Text(status).font(.callout).foregroundStyle(.secondary)
+                }
+                Button("Save") { save() }
+                Button("Close") { dismiss() }
+            }
+            .padding(Self.padding)
+            Divider()
+            TextEditor(text: $content)
+                .font(.body.monospaced())
+        }
+        .frame(minWidth: Self.minimumWidth, minHeight: Self.minimumHeight)
+        .onAppear { load() }
+    }
+
+    // MARK: Private
+
+    private static let padding: CGFloat = 8
+    private static let minimumWidth: CGFloat = 640
+    private static let minimumHeight: CGFloat = 480
+
+    @State private var content = ""
+    @State private var status: String?
+
+    @Environment(\.dismiss)
+    private var dismiss
+
+    private let worktreePath: String
+    private let relativePath: String
+
+    /// The resolved path, but only when it stays inside the worktree:
+    /// a hostile repository could put `../` in a diff path.
+    private var safePath: String? {
+        let base = URL(fileURLWithPath: worktreePath).standardizedFileURL.path
+        let target = URL(fileURLWithPath: worktreePath + "/" + relativePath).standardizedFileURL.path
+        return target == base || target.hasPrefix(base + "/") ? target : nil
+    }
+
+    private func load() {
+        guard let safePath else {
+            status = "Refusing to open a path outside the worktree."
+            return
+        }
+
+        content = (try? String(contentsOfFile: safePath, encoding: .utf8)) ?? ""
+    }
+
+    private func save() {
+        guard let safePath else {
+            status = "Refusing to write a path outside the worktree."
+            return
+        }
+
+        do {
+            try content.write(toFile: safePath, atomically: true, encoding: .utf8)
+            status = "Saved."
+        } catch {
+            status = error.localizedDescription
+        }
+    }
+}

--- a/Sources/ReviewFeature/ReviewModel.swift
+++ b/Sources/ReviewFeature/ReviewModel.swift
@@ -1,0 +1,123 @@
+import AgentIDEData
+import AgentIDEDomain
+import Observation
+
+/// Loads a worktree's diff, tracks per-line selections and applies
+/// rejections and amendments.
+@preconcurrency
+@Observable
+@MainActor
+final class ReviewModel {
+    // MARK: Lifecycle
+
+    /// Creates a review model for a worktree.
+    init(worktreePath: String, git: GitClient) {
+        self.worktreePath = worktreePath
+        self.git = git
+    }
+
+    deinit {
+        // Nothing to clean up.
+    }
+
+    // MARK: Internal
+
+    /// Path fragments treated as generated and hidden by default.
+    static let generatedFragments = [
+        ".pbxproj", "Package.resolved", ".lock", "Gemfile.lock", ".xcassets",
+    ]
+
+    /// The parsed diff files.
+    private(set) var files: [DiffFile] = []
+
+    /// Whether the diff shows uncommitted changes (true) or the last
+    /// commit (false); rejection amends only in the latter mode.
+    private(set) var showsUncommitted = false
+
+    /// The commit message being edited.
+    var commitMessage = ""
+
+    /// Whether generated files are revealed.
+    var showsGenerated = false
+
+    /// The selected lines per file path.
+    var selections: [String: Set<DiffSelection>] = [:]
+
+    /// The last action's outcome, for display.
+    private(set) var status: String?
+
+    /// The files to display, generated ones filtered unless revealed.
+    var visibleFiles: [DiffFile] {
+        showsGenerated ? files : files.filter { isGenerated($0.path) == false }
+    }
+
+    /// Whether a path looks generated.
+    func isGenerated(_ path: String) -> Bool {
+        Self.generatedFragments.contains { path.contains($0) }
+    }
+
+    /// Loads the diff, preferring uncommitted changes.
+    func reload() async {
+        selections = [:]
+        do {
+            let uncommitted = try await git.uncommittedDiff(worktreePath: worktreePath)
+            if uncommitted.isEmpty {
+                showsUncommitted = false
+                files = try await DiffParser.parse(git.lastCommitDiff(worktreePath: worktreePath))
+            } else {
+                showsUncommitted = true
+                files = DiffParser.parse(uncommitted)
+            }
+            commitMessage = try await git.lastCommitMessage(worktreePath: worktreePath)
+        } catch {
+            status = error.localizedDescription
+        }
+    }
+
+    /// Toggles one line's selection.
+    func toggle(file: DiffFile, selection: DiffSelection) {
+        var set = selections[file.path] ?? []
+        if set.remove(selection) == nil {
+            set.insert(selection)
+        }
+        selections[file.path] = set
+    }
+
+    /// Reverse-applies every selected line and, when reviewing the
+    /// last commit, amends it.
+    func rejectSelected() async {
+        do {
+            for file in files {
+                guard let selection = selections[file.path], selection.isEmpty == false,
+                      let patch = PatchBuilder.reversePatch(file: file, selection: selection)
+                else {
+                    continue
+                }
+
+                try await git.applyReverse(patch: patch, worktreePath: worktreePath)
+            }
+            if showsUncommitted == false {
+                try await git.amend(worktreePath: worktreePath, message: nil)
+            }
+            status = "Rejected selected lines."
+            await reload()
+        } catch {
+            status = error.localizedDescription
+        }
+    }
+
+    /// Amends the last commit's message.
+    func saveCommitMessage() async {
+        do {
+            try await git.amend(worktreePath: worktreePath, message: commitMessage)
+            status = "Commit message updated."
+        } catch {
+            status = error.localizedDescription
+        }
+    }
+
+    // MARK: Private
+
+    private let worktreePath: String
+    private let git: GitClient
+}

--- a/Sources/ReviewFeature/ReviewView.swift
+++ b/Sources/ReviewFeature/ReviewView.swift
@@ -1,18 +1,90 @@
+import AgentIDEData
+import AgentIDEDomain
 import SwiftUI
 
-/// The diff review surface, a placeholder until the review slice.
+/// A pull-request-style review of the worktree's changes with
+/// per-line rejection, commit message editing and a file editor.
 public struct ReviewView: View {
     // MARK: Lifecycle
 
     /// Creates the review view.
-    public init() {
-        // SwiftUI requires a public initialiser across module boundaries.
+    public init(worktreePath: String, git: GitClient) {
+        self.worktreePath = worktreePath
+        _model = State(initialValue: ReviewModel(worktreePath: worktreePath, git: git))
     }
 
     // MARK: Public
 
-    /// The placeholder content.
+    /// The toolbar, diff list and commit message editor.
     public var body: some View {
-        Text("Diff review arrives with the review slice.")
+        VStack(spacing: 0) {
+            toolbar
+            Divider()
+            diffList
+            Divider()
+            footer
+        }
+        .task(id: worktreePath) { await model.reload() }
+    }
+
+    // MARK: Private
+
+    private struct EditTarget: Identifiable {
+        let path: String
+
+        var id: String {
+            path
+        }
+    }
+
+    private static let spacing: CGFloat = 8
+    private static let messageLineLimit = 1 ... 3
+
+    @State private var model: ReviewModel
+    @State private var editingFile: EditTarget?
+
+    private let worktreePath: String
+
+    private var toolbar: some View {
+        HStack {
+            Text(model.showsUncommitted ? "Uncommitted changes" : "Last commit")
+                .font(.headline)
+            Toggle("Show generated", isOn: $model.showsGenerated)
+            Spacer()
+            Button("Reject selected lines") { Task { await model.rejectSelected() } }
+                .disabled(model.selections.values.allSatisfy(\.isEmpty))
+            Button("Refresh") { Task { await model.reload() } }
+        }
+        .padding(Self.spacing)
+    }
+
+    private var diffList: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: Self.spacing) {
+                ForEach(model.visibleFiles) { file in
+                    DiffFileView(file: file, model: model) { editingFile = EditTarget(path: file.path) }
+                }
+                if model.visibleFiles.isEmpty {
+                    ContentUnavailableView("No changes", systemImage: "checkmark.circle")
+                }
+            }
+            .padding(Self.spacing)
+        }
+        .sheet(item: $editingFile) { target in
+            FileEditorView(worktreePath: worktreePath, relativePath: target.path)
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            TextField("Commit message", text: $model.commitMessage, axis: .vertical)
+                .lineLimit(Self.messageLineLimit)
+            Button("Amend message") { Task { await model.saveCommitMessage() } }
+                .disabled(model.showsUncommitted)
+            if let status = model.status {
+                Text(status).font(.callout).foregroundStyle(.secondary)
+            }
+        }
+        .padding(Self.spacing)
     }
 }

--- a/Sources/SessionFeature/BrowserView.swift
+++ b/Sources/SessionFeature/BrowserView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import WebKit
+
+// MARK: - BrowserView
+
+/// An embedded browser for previewing served pages and rendered
+/// Markdown; agent-authored content is treated as untrusted, so the
+/// data store is not persisted.
+struct BrowserView: View {
+    // MARK: Lifecycle
+
+    /// Creates the browser.
+    init() {
+        // State holds the address.
+    }
+
+    // MARK: Internal
+
+    /// An address bar over a web view.
+    var body: some View {
+        VStack(spacing: 0) {
+            TextField("http://localhost:3000", text: $address)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { load() }
+                .padding(Self.padding)
+            Divider()
+            WebPane(request: $request)
+        }
+    }
+
+    // MARK: Private
+
+    private static let padding: CGFloat = 8
+
+    @State private var address = ""
+    @State private var request: URLRequest?
+
+    private func load() {
+        guard let url = URL(string: address) else {
+            return
+        }
+
+        request = URLRequest(url: url)
+    }
+}
+
+// MARK: - WebPane
+
+private struct WebPane: NSViewRepresentable {
+    @Binding var request: URLRequest?
+
+    func makeNSView(context _: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        return WKWebView(frame: .zero, configuration: configuration)
+    }
+
+    func updateNSView(_ view: WKWebView, context _: Context) {
+        guard let request, view.url != request.url else {
+            return
+        }
+
+        view.load(request)
+    }
+}

--- a/Sources/SessionFeature/FinalMessageView.swift
+++ b/Sources/SessionFeature/FinalMessageView.swift
@@ -1,0 +1,91 @@
+import AgentIDEData
+import AgentIDEDomain
+import SwiftUI
+
+/// The session's last assistant message, with the session actions.
+struct FinalMessageView: View {
+    // MARK: Lifecycle
+
+    /// Creates the message view.
+    init(item: WorktreeItem, service: SessionService) {
+        self.item = item
+        self.service = service
+    }
+
+    // MARK: Internal
+
+    /// The message text with commit, close, resume and ship actions.
+    var body: some View {
+        VStack(alignment: .leading, spacing: Self.spacing) {
+            actions
+            ScrollView {
+                Text(message.isEmpty ? "No agent output yet." : message)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .padding(Self.spacing)
+            }
+            if let status {
+                Text(status).font(.callout).foregroundStyle(.secondary).padding(.horizontal, Self.spacing)
+            }
+        }
+        .padding(.top, Self.spacing)
+        .task(id: item.id) { await reload() }
+    }
+
+    // MARK: Private
+
+    private static let spacing: CGFloat = 8
+
+    @State private var message = ""
+    @State private var status: String?
+
+    private let item: WorktreeItem
+    private let service: SessionService
+
+    private var actions: some View {
+        HStack {
+            Button("Commit outstanding work") {
+                run { try await service.commitOutstanding(worktreePath: item.worktree.path) }
+            }
+            .disabled(item.isDirty == false)
+            Button("Close session") {
+                run {
+                    guard let session = item.session else {
+                        return
+                    }
+
+                    try await service.closeSession(sessionName: session.name, worktreePath: item.worktree.path)
+                }
+            }
+            .disabled(item.session == nil)
+            Button("Resume session") {
+                run { try await service.resumeWorktree(item.worktree) }
+            }
+            Button("Push and open PR") {
+                run { status = try await service.pushAndCreatePullRequest(worktree: item.worktree) }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, Self.spacing)
+    }
+
+    private func reload() {
+        if let session = item.session {
+            message = service.finalMessage(session: session, worktreePath: item.worktree.path) ?? ""
+            service.markSeen(sessionName: session.name)
+        } else {
+            message = ""
+        }
+    }
+
+    private func run(_ work: @escaping () async throws -> Void) {
+        Task {
+            do {
+                try await work()
+                status = "Done."
+            } catch {
+                status = error.localizedDescription
+            }
+        }
+    }
+}

--- a/Sources/SessionFeature/SessionDetailView.swift
+++ b/Sources/SessionFeature/SessionDetailView.swift
@@ -1,19 +1,89 @@
+import AgentIDEData
+import AgentIDEDomain
 import SwiftUI
+import TerminalUI
 
-/// A single agent session's detail, a placeholder until the core loop
-/// slice.
+/// The final agent message plus the session's terminals and browser.
 public struct SessionDetailView: View {
     // MARK: Lifecycle
 
-    /// Creates the session detail view.
-    public init() {
-        // SwiftUI requires a public initialiser across module boundaries.
+    /// Creates the detail view for a worktree item.
+    public init(item: WorktreeItem, service: SessionService) {
+        self.item = item
+        self.service = service
     }
 
     // MARK: Public
 
-    /// The placeholder content.
+    /// A tab picker over message, terminals and browser.
     public var body: some View {
-        Text("Session detail arrives with the core loop slice.")
+        VStack(spacing: 0) {
+            Picker("Pane", selection: $tab) {
+                ForEach(SessionTab.allCases, id: \.self) { tab in
+                    Text(tab.title).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(Self.padding)
+            Divider()
+            content
+        }
+    }
+
+    // MARK: Private
+
+    private enum SessionTab: CaseIterable {
+        case message
+        case agentTerminal
+        case hostTerminal
+        case browser
+
+        // MARK: Internal
+
+        var title: String {
+            switch self {
+            case .message:
+                "Message"
+
+            case .agentTerminal:
+                "Agent"
+
+            case .hostTerminal:
+                "Shell"
+
+            case .browser:
+                "Browser"
+            }
+        }
+    }
+
+    private static let padding: CGFloat = 8
+
+    @State private var tab: SessionTab = .message
+
+    private let item: WorktreeItem
+    private let service: SessionService
+
+    @ViewBuilder private var content: some View {
+        switch tab {
+        case .message:
+            FinalMessageView(item: item, service: service)
+
+        case .agentTerminal:
+            if let session = item.session {
+                TerminalPaneView(command: service.attachCommand(sessionName: session.name))
+                    .id(session.name)
+            } else {
+                ContentUnavailableView("No session", systemImage: "terminal")
+            }
+
+        case .hostTerminal:
+            TerminalPaneView(command: service.hostShellCommand(worktreePath: item.worktree.path))
+                .id(item.worktree.path)
+
+        case .browser:
+            BrowserView()
+        }
     }
 }

--- a/Sources/TerminalUI/TerminalPaneView.swift
+++ b/Sources/TerminalUI/TerminalPaneView.swift
@@ -1,19 +1,39 @@
+import SwiftTerm
 import SwiftUI
 
-/// The shared terminal surface, a placeholder until the core loop
-/// slice.
-public struct TerminalPaneView: View {
+/// An embedded terminal running an argv on a local PTY. Closing the
+/// view only disconnects this client; tmux sessions keep running in
+/// the sandbox.
+public struct TerminalPaneView: NSViewRepresentable {
     // MARK: Lifecycle
 
-    /// Creates the terminal pane view.
-    public init() {
-        // SwiftUI requires a public initialiser across module boundaries.
+    /// Creates a terminal that runs an argv; the argv itself decides
+    /// its working directory.
+    public init(command: [String]) {
+        self.command = command
     }
 
     // MARK: Public
 
-    /// The placeholder content.
-    public var body: some View {
-        Text("The terminal arrives with the core loop slice.")
+    /// Builds the SwiftTerm view and starts the process.
+    public func makeNSView(context _: Context) -> LocalProcessTerminalView {
+        let view = LocalProcessTerminalView(frame: .zero)
+        let resolved = command.first?.hasPrefix("/") == true ? command : ["/usr/bin/env"] + command
+        view.startProcess(
+            executable: resolved.first ?? "/bin/zsh",
+            args: Array(resolved.dropFirst()),
+            environment: nil,
+            execName: nil,
+        )
+        return view
     }
+
+    /// The terminal owns its state; nothing to update.
+    public func updateNSView(_: LocalProcessTerminalView, context _: Context) {
+        // SwiftTerm manages the PTY after launch.
+    }
+
+    // MARK: Private
+
+    private let command: [String]
 }

--- a/Tests/AgentIDEDataTests/GitClientIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/GitClientIntegrationTests.swift
@@ -1,0 +1,181 @@
+import AgentIDEData
+import AgentIDEDomain
+import Foundation
+import Testing
+
+/// Exercises the git adapter against real repositories in temporary
+/// directories, covering the review loop end to end.
+struct GitClientIntegrationTests {
+    // MARK: Internal
+
+    @Test
+    func `worktree lifecycle: create, list, dirty, commit and diff`() async throws {
+        let root = try TestSupport.temporaryDirectory("git")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let repoPath = root + "/repo"
+        try await TestSupport.makeRepository(at: repoPath)
+        let repository = Repository(name: "repo", path: repoPath)
+        let worktreePath = root + "/worktrees/uuid/agent-change"
+
+        try await git.createWorktree(repository: repository, branch: "agent/change", at: worktreePath)
+        let worktrees = try await git.worktrees(of: repository)
+        #expect(worktrees.map(\.branch) == ["agent/change"])
+
+        #expect(await git.isDirty(worktreePath: worktreePath) == false)
+        try "new\n".write(toFile: worktreePath + "/new.txt", atomically: true, encoding: .utf8)
+        #expect(await git.isDirty(worktreePath: worktreePath))
+
+        try await git.commitAll(worktreePath: worktreePath, message: "Add new file")
+        #expect(await git.isDirty(worktreePath: worktreePath) == false)
+        #expect(try await git.lastCommitMessage(worktreePath: worktreePath) == "Add new file")
+        #expect(try await git.lastCommitDiff(worktreePath: worktreePath).contains("+new"))
+        #expect(try await git.uncommittedDiff(worktreePath: worktreePath).isEmpty)
+    }
+
+    @Test
+    func `per-line rejection reverses only the selected change and amends`() async throws {
+        let root = try TestSupport.temporaryDirectory("reject")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let repoPath = root + "/repo"
+        try await TestSupport.makeRepository(at: repoPath)
+        try "one\ntwo\nthree\nfour\n".write(toFile: repoPath + "/f.txt", atomically: true, encoding: .utf8)
+        try await TestSupport.runGit(["add", "-A"], in: repoPath)
+        try await TestSupport.runGit(["commit", "-q", "-m", "Base"], in: repoPath)
+        try "one\nTHREE\nfour\n".write(toFile: repoPath + "/f.txt", atomically: true, encoding: .utf8)
+        try await TestSupport.runGit(["add", "-A"], in: repoPath)
+        try await TestSupport.runGit(["commit", "-q", "-m", "Change"], in: repoPath)
+
+        let diff = try await git.lastCommitDiff(worktreePath: repoPath)
+        let file = try #require(DiffParser.parse(diff).first)
+        let deletionIndex = try #require(
+            file.hunks[0].lines.firstIndex { $0.kind == .deletion && $0.content == "two" },
+        )
+        let selection = [DiffSelection(hunkIndex: 0, lineIndex: deletionIndex)]
+        let patch = try #require(PatchBuilder.reversePatch(file: file, selection: Set(selection)))
+
+        try await git.applyReverse(patch: patch, worktreePath: repoPath)
+        try await git.amend(worktreePath: repoPath, message: nil)
+
+        let content = try String(contentsOfFile: repoPath + "/f.txt", encoding: .utf8)
+        #expect(content == "one\ntwo\nTHREE\nfour\n")
+        #expect(try await git.lastCommitDiff(worktreePath: repoPath).contains("-two") == false)
+        #expect(await git.isDirty(worktreePath: repoPath) == false)
+    }
+
+    @Test
+    func `rejection works for a hunk far from the start of a file`() async throws {
+        let root = try TestSupport.temporaryDirectory("reject-deep")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let repoPath = root + "/repo"
+        try await TestSupport.makeRepository(at: repoPath)
+        let base = (1 ... 40).map { "line\($0)" }.joined(separator: "\n") + "\n"
+        try base.write(toFile: repoPath + "/f.txt", atomically: true, encoding: .utf8)
+        try await TestSupport.runGit(["add", "-A"], in: repoPath)
+        try await TestSupport.runGit(["commit", "-q", "-m", "Base"], in: repoPath)
+        // Change a line deep in the file so the hunk's old and new starts
+        // are well past line 1.
+        let changed = base.replacing("line25", with: "LINE25")
+        try changed.write(toFile: repoPath + "/f.txt", atomically: true, encoding: .utf8)
+        try await TestSupport.runGit(["add", "-A"], in: repoPath)
+        try await TestSupport.runGit(["commit", "-q", "-m", "Change"], in: repoPath)
+
+        let diff = try await git.lastCommitDiff(worktreePath: repoPath)
+        let file = try #require(DiffParser.parse(diff).first)
+        #expect((file.hunks.first?.newStart ?? 0) > 1)
+        // Reject the whole substitution, so line25 is restored.
+        let selection = Set(file.hunks[0]
+            .lines
+            .indices
+            .filter { file.hunks[0].lines[$0].kind != .context }
+            .map { DiffSelection(hunkIndex: 0, lineIndex: $0) })
+        let patch = try #require(PatchBuilder.reversePatch(file: file, selection: selection))
+
+        try await git.applyReverse(patch: patch, worktreePath: repoPath)
+        let content = try String(contentsOfFile: repoPath + "/f.txt", encoding: .utf8)
+        #expect(content.contains("\nline25\n"))
+        #expect(content.contains("LINE25") == false)
+    }
+
+    @Test
+    func `rejection works when an earlier hunk shifts later line numbers`() async throws {
+        let root = try TestSupport.temporaryDirectory("reject-shift")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let repoPath = root + "/repo"
+        try await TestSupport.makeRepository(at: repoPath)
+        let base = (1 ... 40).map { "line\($0)" }.joined(separator: "\n") + "\n"
+        try base.write(toFile: repoPath + "/f.txt", atomically: true, encoding: .utf8)
+        try await TestSupport.runGit(["add", "-A"], in: repoPath)
+        try await TestSupport.runGit(["commit", "-q", "-m", "Base"], in: repoPath)
+        // Insert two lines near the top and change one near the bottom, so
+        // the second hunk's old and new starts differ by two.
+        let changed = base
+            .replacing("line3\n", with: "line3\nINSERTED_A\nINSERTED_B\n")
+            .replacing("line30", with: "LINE30")
+        try changed.write(toFile: repoPath + "/f.txt", atomically: true, encoding: .utf8)
+        try await TestSupport.runGit(["add", "-A"], in: repoPath)
+        try await TestSupport.runGit(["commit", "-q", "-m", "Change"], in: repoPath)
+
+        let diff = try await git.lastCommitDiff(worktreePath: repoPath)
+        let file = try #require(DiffParser.parse(diff).first)
+        let lower = try #require(file.hunks.last)
+        #expect(lower.oldStart != lower.newStart)
+        let lowerIndex = file.hunks.count - 1
+        let selection = Set(lower.lines
+            .indices
+            .filter { lower.lines[$0].kind != .context }
+            .map { DiffSelection(hunkIndex: lowerIndex, lineIndex: $0) })
+        let patch = try #require(PatchBuilder.reversePatch(file: file, selection: selection))
+
+        try await git.applyReverse(patch: patch, worktreePath: repoPath)
+        let content = try String(contentsOfFile: repoPath + "/f.txt", encoding: .utf8)
+        #expect(content.contains("\nline30\n"))
+        #expect(content.contains("LINE30") == false)
+        // The unrejected top insertion is untouched.
+        #expect(content.contains("INSERTED_A"))
+    }
+
+    @Test
+    func `push tracks a bare remote and ahead counts update`() async throws {
+        let root = try TestSupport.temporaryDirectory("push")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let repoPath = root + "/repo"
+        try await TestSupport.makeRepository(at: repoPath)
+        try await TestSupport.run(["git", "init", "-q", "--bare", root + "/origin.git"])
+        try await TestSupport.runGit(["remote", "add", "origin", root + "/origin.git"], in: repoPath)
+
+        #expect(await git.aheadOfUpstream(worktreePath: repoPath) == nil)
+        try await git.push(worktreePath: repoPath, branch: "main")
+        #expect(await git.aheadOfUpstream(worktreePath: repoPath) == 0)
+
+        try "more\n".write(toFile: repoPath + "/more.txt", atomically: true, encoding: .utf8)
+        try await git.commitAll(worktreePath: repoPath, message: "More")
+        #expect(await git.aheadOfUpstream(worktreePath: repoPath) == 1)
+    }
+
+    @Test
+    func `bundles recreate deleted branches`() async throws {
+        let root = try TestSupport.temporaryDirectory("bundle")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let repoPath = root + "/repo"
+        try await TestSupport.makeRepository(at: repoPath)
+        let repository = Repository(name: "repo", path: repoPath)
+        let worktreePath = root + "/wt"
+        try await git.createWorktree(repository: repository, branch: "agent/keep", at: worktreePath)
+        try "kept\n".write(toFile: worktreePath + "/kept.txt", atomically: true, encoding: .utf8)
+        try await git.commitAll(worktreePath: worktreePath, message: "Keep")
+
+        let bundle = root + "/branch.bundle"
+        try await git.bundle(worktreePath: worktreePath, branch: "agent/keep", to: bundle)
+        try await git.removeWorktree(repository: repository, worktreePath: worktreePath, branch: "agent/keep")
+        #expect(await git.branchExists(repository: repository, branch: "agent/keep") == false)
+
+        try await git.fetchBranch(repository: repository, fromBundle: bundle, branch: "agent/keep")
+        #expect(await git.branchExists(repository: repository, branch: "agent/keep"))
+        try await git.addWorktree(repository: repository, branch: "agent/keep", at: worktreePath)
+        #expect(FileManager.default.fileExists(atPath: worktreePath + "/kept.txt"))
+    }
+
+    // MARK: Private
+
+    private let git: GitClient = .init(runner: FoundationProcessRunner())
+}

--- a/Tests/AgentIDEDataTests/GitClientTests.swift
+++ b/Tests/AgentIDEDataTests/GitClientTests.swift
@@ -1,0 +1,21 @@
+import AgentIDEData
+import Foundation
+import Testing
+
+struct GitClientTests {
+    @Test
+    func `repository listing skips symlinked aliases and plain directories`() throws {
+        let manager = FileManager.default
+        let root = manager.temporaryDirectory
+            .appendingPathComponent("agentide-repos-" + UUID().uuidString)
+            .path
+        try manager.createDirectory(atPath: root + "/real/.git", withIntermediateDirectories: true)
+        try manager.createDirectory(atPath: root + "/plain", withIntermediateDirectories: true)
+        try manager.createSymbolicLink(atPath: root + "/alias", withDestinationPath: root + "/real")
+        defer { try? manager.removeItem(atPath: root) }
+
+        let repositories = GitClient(runner: FoundationProcessRunner()).repositories(under: root)
+
+        #expect(repositories.map(\.name) == ["real"])
+    }
+}

--- a/Tests/AgentIDEDataTests/HookInstallerTests.swift
+++ b/Tests/AgentIDEDataTests/HookInstallerTests.swift
@@ -1,0 +1,51 @@
+import AgentIDEData
+import Foundation
+import Testing
+
+/// Exercises hook installation against a temporary template
+/// directory: idempotency and coexistence with third-party hooks.
+struct HookInstallerTests {
+    @Test
+    func `installs alongside existing hooks exactly once`() throws {
+        let root = try TestSupport.temporaryDirectory("hooks")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let paths = WorkspacePaths(
+            hostUser: "test",
+            sharedWorkspace: root,
+            sandboxHome: root + "/home",
+            archivesDirectory: root + "/archives",
+            metadataFile: root + "/state.json",
+        )
+        let settingsPath = paths.userTemplateDirectory + "/.claude/settings.json"
+        try FileManager.default.createDirectory(
+            atPath: paths.userTemplateDirectory + "/.claude",
+            withIntermediateDirectories: true,
+        )
+        let existing = """
+        {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "third-party-notify"}]}]}}
+        """
+        try existing.write(toFile: settingsPath, atomically: true, encoding: .utf8)
+
+        let installer = HookInstaller(paths: paths)
+        try installer.ensureInstalled()
+        try installer.ensureInstalled()
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: settingsPath))
+        let settings = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let hooks = try #require(settings["hooks"] as? [String: Any])
+        for event in HookInstaller.events {
+            let entries = try #require(hooks[event] as? [[String: Any]], "missing \(event)")
+            let commands = entries.flatMap { entry in
+                (entry["hooks"] as? [[String: Any]] ?? []).compactMap { $0["command"] as? String }
+            }
+            let installed = commands.count { $0.contains("agentide-notify") }
+            #expect(installed == 1)
+            if event == "Stop" {
+                #expect(commands.contains("third-party-notify"))
+            }
+        }
+
+        let script = paths.userTemplateDirectory + "/.claude/agentide-notify.sh"
+        #expect(FileManager.default.isExecutableFile(atPath: script))
+    }
+}

--- a/Tests/AgentIDEDataTests/MetadataStoreTests.swift
+++ b/Tests/AgentIDEDataTests/MetadataStoreTests.swift
@@ -1,0 +1,41 @@
+import AgentIDEData
+import AgentIDEDomain
+import Foundation
+import Testing
+
+/// Exercises the metadata file round trip.
+struct MetadataStoreTests {
+    @Test
+    func `round trips every field and tolerates a missing file`() throws {
+        let root = try TestSupport.temporaryDirectory("store")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let store = MetadataStore(file: root + "/nested/state.json")
+
+        #expect(store.load().archives.isEmpty)
+
+        let seen = Date(timeIntervalSince1970: 1)
+        var metadata = AppMetadata()
+        metadata.lastSeen["session"] = seen
+        metadata.prompts["session"] = "prompt"
+        metadata.arguments["session"] = "--model fable"
+        metadata.resumeIDs["session"] = "abc"
+        metadata.archives.append(ArchiveMetadata(
+            id: "id",
+            repositoryName: "repo",
+            repositoryPath: "/r",
+            branch: "b",
+            worktreePath: "/w",
+            sessionName: "session",
+            resumeID: "abc",
+            archivedAt: Date(timeIntervalSince1970: 2),
+        ))
+        store.save(metadata)
+
+        let loaded = store.load()
+        #expect(loaded.prompts["session"] == "prompt")
+        #expect(loaded.arguments["session"] == "--model fable")
+        #expect(loaded.resumeIDs["session"] == "abc")
+        #expect(loaded.archives.first?.branch == "b")
+        #expect(loaded.lastSeen["session"] == seen)
+    }
+}

--- a/Tests/AgentIDEDataTests/SessionServiceIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/SessionServiceIntegrationTests.swift
@@ -1,0 +1,153 @@
+import AgentIDEData
+import AgentIDEDomain
+import Foundation
+import Testing
+
+// MARK: - PromptCaptureRunner
+
+/// A fake agent that records its arguments and captures the pasted
+/// prompt, standing in for a real CLI in integration tests.
+struct PromptCaptureRunner: AgentRunner {
+    var kind: AgentKind {
+        .claudeCode
+    }
+
+    func launchCommand(extraArguments: String) -> String {
+        let quoted = "'" + extraArguments.replacing("'", with: "'\\''") + "'"
+        return "printf '%s' " + quoted + " > agent-arguments.txt; cat > agent-prompt.txt"
+    }
+
+    func resumeCommand(resumeID: String, extraArguments _: String) -> String {
+        "printf '%s' '" + resumeID + "' > agent-resumed.txt; cat > /dev/null"
+    }
+
+    func transcriptDirectory(workingDirectory _: String, sandboxHome: String) -> String? {
+        sandboxHome + "/transcripts"
+    }
+}
+
+// MARK: - SessionServiceIntegrationTests
+
+/// Drives the whole core loop against real git, a private tmux
+/// server and a temporary workspace: create, observe, archive and
+/// undelete.
+struct SessionServiceIntegrationTests {
+    // MARK: Internal
+
+    @Test
+    func `create session builds worktree, symlink, prompt and running pane`() async throws {
+        let world = try await World.make()
+        defer { world.tearDown() }
+
+        let name = try await world.service.createSession(
+            repository: world.repository,
+            prompt: "Do the thing",
+            agent: .claudeCode,
+            extraArguments: "--model fable --effort max",
+        )
+        #expect(SessionName.isAgentIDE(name))
+
+        let overview = await world.service.overview()
+        let item = try #require(overview.groups.first?.items.first)
+        #expect(item.session?.name == name)
+        #expect(item.session?.status == SessionStatus.running)
+        let worktreePath = item.worktree.path
+
+        let delivered = await TestSupport.poll {
+            let prompt = try? String(contentsOfFile: worktreePath + "/agent-prompt.txt", encoding: .utf8)
+            return prompt?.contains("Do the thing") ?? false
+        }
+        #expect(delivered)
+        let arguments = try String(contentsOfFile: worktreePath + "/agent-arguments.txt", encoding: .utf8)
+        #expect(arguments == "--model fable --effort max")
+
+        let symlink = world.paths.friendlyWorktreesDirectory + "/repo/agent-do-the-thing"
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: symlink)
+        #expect(destination == worktreePath)
+    }
+
+    @Test
+    func `archive removes the worktree and undelete restores it in place`() async throws {
+        let world = try await World.make()
+        defer { world.tearDown() }
+
+        _ = try await world.service.createSession(
+            repository: world.repository,
+            prompt: "Recoverable work",
+            agent: .claudeCode,
+        )
+        let overview = await world.service.overview()
+        let item = try #require(overview.groups.first?.items.first)
+        let worktreePath = item.worktree.path
+        try "loose\n".write(toFile: worktreePath + "/untracked.txt", atomically: true, encoding: .utf8)
+
+        let archive = try await world.service.archiveAndDelete(item: item)
+        #expect(FileManager.default.fileExists(atPath: worktreePath) == false)
+        let archiveDirectory = world.paths.archivesDirectory + "/" + archive.id
+        #expect(FileManager.default.fileExists(atPath: archiveDirectory + "/branch.bundle"))
+        #expect(FileManager.default.fileExists(atPath: archiveDirectory + "/metadata.json"))
+
+        try await world.service.undelete(archive: archive)
+        #expect(FileManager.default.fileExists(atPath: worktreePath + "/README.md"))
+        #expect(FileManager.default.fileExists(atPath: worktreePath + "/untracked.txt"))
+        let after = await world.service.overview()
+        #expect(after.groups.first?.items.first?.worktree.path == worktreePath)
+    }
+
+    // MARK: Private
+
+    /// One temporary world: workspace, repository, tmux and service.
+    private struct World {
+        let root: String
+        let paths: WorkspacePaths
+        let repository: Repository
+        let service: SessionService
+        let tmux: TmuxClient
+
+        static func make() async throws -> Self {
+            let base = try TestSupport.temporaryDirectory("world")
+            let workspace = WorkspacePaths(
+                hostUser: "test",
+                sharedWorkspace: base + "/shared",
+                sandboxHome: base + "/home",
+                archivesDirectory: base + "/archives",
+                metadataFile: base + "/state.json",
+            )
+            let repoPath = workspace.repositoriesDirectory + "/repo"
+            try await TestSupport.makeRepository(at: repoPath)
+            let runner = FoundationProcessRunner()
+            let tmuxClient = try TmuxClient(
+                runner: runner,
+                launcher: SandvaultLauncher(hostUser: "test"),
+                isInsideSandbox: true,
+                socketDirectory: TestSupport.socketDirectory(),
+            )
+            let sessionService = SessionService(
+                paths: workspace,
+                git: GitClient(runner: runner),
+                tmux: tmuxClient,
+                github: GitHubClient(runner: runner),
+                transcripts: TranscriptReader(),
+                spool: EventSpool(directory: workspace.eventsDirectory),
+                store: MetadataStore(file: workspace.metadataFile),
+                runners: [PromptCaptureRunner()],
+            )
+            return Self(
+                root: base,
+                paths: workspace,
+                repository: Repository(name: "repo", path: repoPath),
+                service: sessionService,
+                tmux: tmuxClient,
+            )
+        }
+
+        func tearDown() {
+            let server = tmux
+            let directory = root
+            Task {
+                await server.killServer()
+                try? FileManager.default.removeItem(atPath: directory)
+            }
+        }
+    }
+}

--- a/Tests/AgentIDEDataTests/TestSupport.swift
+++ b/Tests/AgentIDEDataTests/TestSupport.swift
@@ -1,0 +1,92 @@
+@testable import AgentIDEData
+import Darwin
+import Foundation
+
+/// Shared helpers for integration tests that exercise real git, tmux
+/// and filesystem behaviour in isolated temporary locations.
+enum TestSupport {
+    /// A fresh temporary directory, fully resolved via `realpath` so
+    /// its path matches what git and tmux report for it.
+    static func temporaryDirectory(_ label: String) throws -> String {
+        let path = "/tmp/agentide-" + label + "-" + UUID().uuidString
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        return canonical(path)
+    }
+
+    /// A short-lived, resolved tmux socket directory under `/tmp`; the
+    /// deep temp hierarchy overruns the 104-byte Unix socket path
+    /// limit.
+    static func socketDirectory() throws -> String {
+        let path = "/tmp/av-" + UUID().uuidString
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        return canonical(path)
+    }
+
+    /// The fully resolved path, matching git and tmux output.
+    static func canonical(_ path: String) -> String {
+        guard let resolved = realpath(path, nil) else {
+            return path
+        }
+
+        defer { free(resolved) }
+        return String(cString: resolved)
+    }
+
+    /// Runs a command, throwing on failure.
+    @discardableResult
+    static func run(_ arguments: [String], in directory: String? = nil) async throws -> ProcessResult {
+        let result = try await FoundationProcessRunner()
+            .run(arguments, workingDirectory: directory, environment: [:])
+        guard result.succeeded else {
+            throw CommandError(command: arguments.joined(separator: " "), result: result)
+        }
+
+        return result
+    }
+
+    /// Runs git with hooks and signing neutralised, so user-level
+    /// configuration cannot leak into tests.
+    @discardableResult
+    static func runGit(_ arguments: [String], in directory: String) async throws -> ProcessResult {
+        try await run(
+            ["git", "-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"] + arguments,
+            in: directory,
+        )
+    }
+
+    /// Initialises a git repository with an identity and one commit.
+    static func makeRepository(at path: String) async throws {
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        try await runGit(["init", "-q", "-b", "main"], in: path)
+        try await runGit(["config", "user.email", "test@example.com"], in: path)
+        try await runGit(["config", "user.name", "Test"], in: path)
+        try await runGit(["config", "commit.gpgsign", "false"], in: path)
+        try await runGit(["config", "core.hooksPath", "/dev/null"], in: path)
+        try "hello\n".write(toFile: path + "/README.md", atomically: true, encoding: .utf8)
+        try await runGit(["add", "-A"], in: path)
+        try await runGit(["commit", "-q", "-m", "Initial commit"], in: path)
+    }
+
+    /// A tmux client on its own private socket, so tests never touch
+    /// the real server.
+    static func makeTmuxClient() throws -> TmuxClient {
+        try TmuxClient(
+            runner: FoundationProcessRunner(),
+            launcher: SandvaultLauncher(hostUser: "test"),
+            isInsideSandbox: true,
+            socketDirectory: socketDirectory(),
+        )
+    }
+
+    /// Polls a condition until it holds or the timeout passes.
+    static func poll(timeout: Double = 5, until condition: () async -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        return await condition()
+    }
+}

--- a/Tests/AgentIDEDataTests/TmuxClientIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/TmuxClientIntegrationTests.swift
@@ -1,0 +1,63 @@
+import AgentIDEData
+import Foundation
+import Testing
+
+/// Exercises the tmux adapter against a real server on a private
+/// socket: session lifecycle, pane working directories, dead panes
+/// and prompt delivery by paste.
+struct TmuxClientIntegrationTests {
+    @Test
+    func `sessions start in their directory and die visibly`() async throws {
+        let tmux = try TestSupport.makeTmuxClient()
+        let directory = try TestSupport.temporaryDirectory("pane")
+        defer { Task { await tmux.killServer() } }
+
+        try await tmux.newSession(name: "agentide--r--b--claude", directory: directory, command: "sleep 20")
+        let running = await TestSupport.poll {
+            let panes = await (try? tmux.panes()) ?? []
+            return panes.contains { $0.sessionName == "agentide--r--b--claude" && $0.isDead == false }
+        }
+        #expect(running)
+        let pane = try #require(try await tmux.panes().first)
+        #expect(pane.currentPath == directory)
+
+        try await tmux.killSession(name: "agentide--r--b--claude")
+        #expect(try await tmux.panes().isEmpty)
+    }
+
+    @Test
+    func `finished panes keep their exit status`() async throws {
+        let tmux = try TestSupport.makeTmuxClient()
+        let directory = try TestSupport.temporaryDirectory("dead")
+        defer { Task { await tmux.killServer() } }
+
+        try await tmux.newSession(name: "agentide--r--dead--claude", directory: directory, command: "exit 7")
+        let dead = await TestSupport.poll {
+            let panes = await (try? tmux.panes()) ?? []
+            return panes.contains { $0.isDead && $0.exitStatus == 7 }
+        }
+        #expect(dead)
+    }
+
+    @Test
+    func `prompts arrive as terminal input, not arguments`() async throws {
+        let tmux = try TestSupport.makeTmuxClient()
+        let directory = try TestSupport.temporaryDirectory("paste")
+        defer { Task { await tmux.killServer() } }
+
+        try await tmux.newSession(
+            name: "agentide--r--paste--claude",
+            directory: directory,
+            command: "cat > captured.txt",
+        )
+        let promptFile = directory + "/prompt.md"
+        try "review this branch carefully".write(toFile: promptFile, atomically: true, encoding: .utf8)
+        try await tmux.sendPromptFile(promptFile, to: "agentide--r--paste--claude")
+
+        let captured = await TestSupport.poll {
+            let content = try? String(contentsOfFile: directory + "/captured.txt", encoding: .utf8)
+            return content?.contains("review this branch carefully") ?? false
+        }
+        #expect(captured)
+    }
+}

--- a/Tests/AgentIDEDataTests/TranscriptReaderTests.swift
+++ b/Tests/AgentIDEDataTests/TranscriptReaderTests.swift
@@ -1,0 +1,32 @@
+import AgentIDEData
+import Foundation
+import Testing
+
+/// Exercises transcript reading against fixture JSONL files.
+struct TranscriptReaderTests {
+    @Test
+    func `finds the newest transcript and its final assistant message`() throws {
+        let directory = try TestSupport.temporaryDirectory("transcripts")
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+        let older = directory + "/11111111-aaaa.jsonl"
+        let newer = directory + "/22222222-bbbb.jsonl"
+        let lines = """
+        {"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}
+        not even json
+        {"type":"assistant","message":{"content":[{"type":"text","text":"first"},{"type":"text","text":"second"}]}}
+        {"type":"system"}
+        """
+        try "{}\n".write(toFile: older, atomically: true, encoding: .utf8)
+        try lines.write(toFile: newer, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1)],
+            ofItemAtPath: older,
+        )
+
+        let reader = TranscriptReader()
+        let latest = try #require(reader.latestTranscript(in: directory))
+        #expect(latest.lastPathComponent == "22222222-bbbb.jsonl")
+        #expect(reader.resumeID(of: latest) == "22222222-bbbb")
+        #expect(reader.finalAssistantMessage(in: latest) == "first\nsecond")
+    }
+}

--- a/Tests/AgentIDEDomainTests/DiffParserTests.swift
+++ b/Tests/AgentIDEDomainTests/DiffParserTests.swift
@@ -1,0 +1,69 @@
+import AgentIDEDomain
+import Testing
+
+struct DiffParserTests {
+    // MARK: Internal
+
+    @Test
+    func `parses files hunks and line kinds`() throws {
+        let files = DiffParser.parse(Self.sample)
+        #expect(files.map(\.path) == ["hello.txt", "new.txt"])
+
+        let hunk = try #require(files.first?.hunks.first)
+        #expect(hunk.oldStart == 1)
+        #expect(hunk.newStart == 1)
+        #expect(hunk.lines.map(\.kind) == [.context, .deletion, .addition, .context])
+        #expect(hunk.lines.map(\.content) == ["one", "two", "TWO", "three"])
+
+        let added = try #require(files.last?.hunks.first)
+        #expect(added.lines.map(\.kind) == [.addition])
+    }
+
+    @Test
+    func `ignores headers and junk outside hunks`() {
+        #expect(DiffParser.parse("not a diff at all\n").isEmpty)
+    }
+
+    @Test
+    func `a trailing blank line is not a context line`() throws {
+        let diff = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -1,1 +1,1 @@\n-a\n+b\n\n"
+        let hunk = try #require(DiffParser.parse(diff).first?.hunks.first)
+        #expect(hunk.lines.map(\.kind) == [.deletion, .addition])
+    }
+
+    @Test
+    func `a deleted file keeps its old path`() throws {
+        let diff = """
+        diff --git a/gone.txt b/gone.txt
+        deleted file mode 100644
+        --- a/gone.txt
+        +++ /dev/null
+        @@ -1,2 +0,0 @@
+        -one
+        -two
+        """
+        let file = try #require(DiffParser.parse(diff).first)
+        #expect(file.path == "gone.txt")
+        #expect(file.hunks.first?.lines.map(\.kind) == [.deletion, .deletion])
+    }
+
+    // MARK: Private
+
+    private static let sample = """
+    diff --git a/hello.txt b/hello.txt
+    index 3b18e51..2f5e1a5 100644
+    --- a/hello.txt
+    +++ b/hello.txt
+    @@ -1,3 +1,3 @@
+     one
+    -two
+    +TWO
+     three
+    diff --git a/new.txt b/new.txt
+    new file mode 100644
+    --- /dev/null
+    +++ b/new.txt
+    @@ -0,0 +1 @@
+    +fresh
+    """
+}

--- a/Tests/AgentIDEDomainTests/PatchBuilderTests.swift
+++ b/Tests/AgentIDEDomainTests/PatchBuilderTests.swift
@@ -1,0 +1,43 @@
+import AgentIDEDomain
+import Testing
+
+struct PatchBuilderTests {
+    // MARK: Internal
+
+    @Test
+    func `selected changes keep their kind and unselected additions become context`() throws {
+        let selection: Set<DiffSelection> = [DiffSelection(hunkIndex: 0, lineIndex: 1)]
+        let patch = try #require(PatchBuilder.reversePatch(file: Self.file, selection: selection))
+        let expected = """
+        diff --git a/f.txt b/f.txt
+        --- a/f.txt
+        +++ b/f.txt
+        @@ -1,4 +1,3 @@
+         one
+        -two
+         THREE
+         four
+
+        """
+        #expect(patch == expected)
+    }
+
+    @Test
+    func `empty selections build no patch`() {
+        #expect(PatchBuilder.reversePatch(file: Self.file, selection: []) == nil)
+    }
+
+    // MARK: Private
+
+    private static let file: DiffFile = .init(
+        path: "f.txt",
+        hunks: [
+            DiffHunk(oldStart: 1, newStart: 1, lines: [
+                DiffLine(kind: .context, content: "one"),
+                DiffLine(kind: .deletion, content: "two"),
+                DiffLine(kind: .addition, content: "THREE"),
+                DiffLine(kind: .context, content: "four"),
+            ]),
+        ],
+    )
+}

--- a/Tests/DashboardFeatureTests/SnapshotTests.swift
+++ b/Tests/DashboardFeatureTests/SnapshotTests.swift
@@ -1,0 +1,52 @@
+import AgentIDEDomain
+import AppKit
+@testable import DashboardFeature
+import SwiftUI
+import Testing
+
+/// Renders real views to PNGs under `.build/shots` so the UI is
+/// reviewable without a display.
+@MainActor
+struct SnapshotTests {
+    // MARK: Internal
+
+    @Test
+    func `renders the worktree row to an inspectable image`() throws {
+        let item = WorktreeItem(
+            worktree: Worktree(
+                repositoryName: "AgentIDE",
+                repositoryPath: "/tmp/AgentIDE",
+                branch: "agent/fix-crash",
+                path: "/tmp/worktrees/1234/agent-fix-crash",
+            ),
+            session: AgentSession(
+                name: "agentide--agentide--agent-fix-crash--claude",
+                agent: .claudeCode,
+                status: .running,
+                workingDirectory: "/tmp/worktrees/1234/agent-fix-crash",
+            ),
+            isDirty: true,
+            aheadOfUpstream: 2,
+            hasUnread: true,
+        )
+        let width: CGFloat = 320
+        let view = WorktreeRowView(item: item).frame(width: width).padding()
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        let image = try #require(renderer.cgImage)
+        #expect(image.width > 0)
+
+        try Self.write(image, name: "worktree-row")
+    }
+
+    // MARK: Private
+
+    private static func write(_ image: CGImage, name: String) throws {
+        let directory = FileManager.default.currentDirectoryPath + "/.build/shots"
+        try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        let representation = NSBitmapImageRep(cgImage: image)
+        let png = try #require(representation.representation(using: .png, properties: [:]))
+        try png.write(to: URL(fileURLWithPath: directory + "/" + name + ".png"))
+    }
+}

--- a/script/analyze
+++ b/script/analyze
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Static analysis: unused declarations and imports via SwiftLint's
+# analyzer, plus dead-code detection via periphery when available.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+[[ -d AgentIDE.xcodeproj ]] || script/bootstrap
+
+log=".build/analyze-build.log"
+mkdir -p .build
+
+args=(
+  -project AgentIDE.xcodeproj
+  -scheme AgentIDEApp
+  -destination "${XCODE_DESTINATION:-platform=macOS,arch=arm64}"
+  -derivedDataPath .DerivedData
+)
+
+if [[ -n "${SV_SESSION_ID:-}" ]]; then
+  export SWIFTPM_DISABLE_SANDBOX=1
+  export SWIFT_BUILD_USE_SANDBOX=0
+  # The literal $(inherited) is for xcodebuild, not the shell.
+  # shellcheck disable=SC2016
+  args+=(
+    -IDEPackageSupportDisableManifestSandbox=1
+    -IDEPackageSupportDisablePackageSandbox=1
+    'OTHER_SWIFT_FLAGS=$(inherited) -disable-sandbox'
+  )
+fi
+
+xcodebuild "${args[@]}" clean build >"$log" 2>&1
+swiftlint analyze --compiler-log-path "$log" --strict
+
+# periphery drives its own xcodebuild, which re-enters sandbox-exec
+# and cannot nest, so it runs on the host and in CI only. The project
+# is scanned through the app scheme because periphery's SPM mode does
+# not find an index store under the current build system; the app
+# scheme excludes the test targets, so the few declarations used only
+# by tests carry `// periphery:ignore`.
+if [[ -n "${SV_SESSION_ID:-}" ]]; then
+  echo "skipping periphery: it cannot build inside the sandbox" >&2
+elif command -v periphery &>/dev/null; then
+  periphery scan \
+    --project AgentIDE.xcodeproj \
+    --schemes AgentIDEApp \
+    --strict \
+    --disable-update-check
+else
+  echo "skipping periphery: not installed (add it via the Brewfile)" >&2
+fi

--- a/script/style
+++ b/script/style
@@ -19,6 +19,19 @@ shell_style() {
 github_actions_style() {
   actionlint
   zizmor --no-online-audits .github/workflows
+
+  # Only first-party (actions/*) and Homebrew (Homebrew/actions/*)
+  # actions are allowed; anything else needs a human decision, so add
+  # it here deliberately rather than letting it slip in.
+  local disallowed
+  disallowed="$(grep -rhoE 'uses:[[:space:]]*[^[:space:]#]+' .github/workflows |
+    sed -E 's/uses:[[:space:]]*//' |
+    grep -vE '^(actions/|Homebrew/actions/)' || true)"
+  if [[ -n "${disallowed}" ]]; then
+    echo "Only actions/* or Homebrew/actions/* actions are allowed:" >&2
+    echo "${disallowed}" >&2
+    return 1
+  fi
 }
 
 docs_style() {


### PR DESCRIPTION
- The core loop works: a typed prompt becomes a worktree and branch in the compatible uuid layout, a prompt file and a Claude Code or Codex session in tmux, attachable in the embedded SwiftTerm terminal beside a host-user shell and a browser
- Prompts reach agents as terminal input via tmux paste, never as arguments, and the New Session sheet passes remembered extra agent arguments through the AgentRunner seam
- The dashboard groups worktrees by repository with status badges, lists foreign sessions and polls with notifications on completion
- Review parses diffs into per-line selectable hunks; rejection builds a reverse patch applied with `git apply -R --index` then amends; files and commit messages are editable in place
- Pull requests list with mergeability and one-click automerge, merge and fix-agent launch; push and PR creation from a session
- Lifecycle: archive to a bundle and metadata under Application Support, delete, and undelete restoring the canonical path so `--resume` continues the conversation
- An integration test tier drives the real git, tmux and filesystem adapters end to end; it caught and fixed five latent bugs: a duplicate-worktree crash, diff parsing of trailing blank lines, premature remain-on-exit, tmux field parsing and per-pane working directory
- `script/analyze` adds SwiftLint's analyzer and periphery to the local and CI guardrails, wired into the CI job
- SwiftTerm is the one new dependency; GRDB, Subprocess and the editor stack stay documented as planned deepenings