### PR TITLE
Tidy merge lifecycle and improve PR tooling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -502,12 +502,19 @@ Sendable` and `nonisolated(unsafe)` are banned.
 
 ### Cleanup (Tidy up)
 
-1. A merged pull request offers cleanup; the sidebar offers the same
-   deletion from a worktree's context menu at any time. Merging from
-   the main checkout also tidies the checkout itself: back to the
+1. Cleanup after a merge runs from three places through one path: the
+   in-app Merge button, the worktree's context menu (Clean up after
+   merge, at any time) and the pull request poll, which fires it by
+   itself when a branch's pull request that was open at the last poll
+   is found merged, so a merge made on GitHub or elsewhere is tidied
+   on the next refresh without being noticed first. A real worktree is
+   deleted; the main checkout is tidied in place instead: back to the
    default branch, a hard reset to origin when the local default
    carries nothing of its own, and a safe `-d` delete of the merged
-   branch; dirty checkouts are left alone.
+   branch. Dirty worktrees and checkouts are left alone, and the poll
+   never cleans up on a merely missing pull request (a stale cache or a
+   branch that never had one), only on an observed open-to-merged
+   transition.
 2. Deletion records the session's agent-native resume id, kills the tmux
    session, then runs `git worktree remove`, `git worktree prune` and
    `git branch -D` and removes the friendly symlink. Nothing is archived:

--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ before shipping.
 
 ### 🧹 Tidy up
 
-- **Deletes** a worktree and its branch once the pull request merges (so
-  finished work disappears without ceremony)
+- **Deletes** a worktree and its branch once the pull request merges,
+  whether you merged in the app, picked Clean up after merge from the
+  worktree's menu or the next refresh simply notices the merge happened
+  on GitHub (so finished work disappears without ceremony)
 - **Keeps** every conversation a repository has ever run browsable and
   resumable from the repository's own page, whichever worktree it used and
   even after that worktree is deleted (so tidying up never loses a

--- a/Sources/AgentIDEData/SessionService.swift
+++ b/Sources/AgentIDEData/SessionService.swift
@@ -97,7 +97,11 @@ public struct SessionService: Sendable {
             // The main checkout stays pinned first; worktrees order by
             // recency of their own work.
             let sorted = [items[0]] + items.dropFirst().sorted { $0.lastActivityAt > $1.lastActivityAt }
-            groups.append(RepositoryGroup(repository: named, items: sorted))
+            groups.append(RepositoryGroup(
+                repository: named,
+                items: sorted,
+                defaultBranch: baseRef?.split(separator: "/").last.map(String.init),
+            ))
         }
         // Repositories order by their worktrees' activity; the main
         // checkout's own churn deliberately does not count, except

--- a/Sources/AgentIDEDomain/RepositoryGroup.swift
+++ b/Sources/AgentIDEDomain/RepositoryGroup.swift
@@ -70,10 +70,12 @@ public struct WorktreeItem: Identifiable, Hashable, Sendable {
 public struct RepositoryGroup: Identifiable, Hashable, Sendable {
     // MARK: Lifecycle
 
-    /// Creates a group.
-    public init(repository: Repository, items: [WorktreeItem]) {
+    /// Creates a group; `defaultBranch` is nil when the repository
+    /// has no resolvable default (never pushed, no `main`).
+    public init(repository: Repository, items: [WorktreeItem], defaultBranch: String? = nil) {
         self.repository = repository
         self.items = items
+        self.defaultBranch = defaultBranch
     }
 
     // MARK: Public
@@ -83,6 +85,11 @@ public struct RepositoryGroup: Identifiable, Hashable, Sendable {
 
     /// Its worktrees in branch order.
     public var items: [WorktreeItem]
+
+    /// The bare default branch name (`main`, never `origin/main`),
+    /// so the sidebar can tell a main checkout off its default branch
+    /// without asking git.
+    public let defaultBranch: String?
 
     /// The stable identity, the repository's.
     public var id: String {

--- a/Sources/DashboardFeature/DashboardModel+PullRequests.swift
+++ b/Sources/DashboardFeature/DashboardModel+PullRequests.swift
@@ -44,8 +44,10 @@ extension DashboardModel {
                         scope: .branch(item.worktree.branch),
                     )
                     let summary = summaries.first { $0.state == "OPEN" }
+                    let previous = branchPullRequests[key].flatMap(\.self)
                     branchPullRequests[key] = summary
                     persist(summary, key: key)
+                    await cleanUpIfMerged(item, previous: previous, fresh: summaries)
                 } catch {
                     ErrorLog.shared.report("Pull requests for \(group.repository.name): " + error.localizedDescription)
                 }
@@ -78,6 +80,38 @@ extension DashboardModel {
     // MARK: Private
 
     private static let selectedInterval: TimeInterval = 30
+
+    /// A merge made on GitHub or elsewhere is tidied on the poll that
+    /// first sees it: the branch's pull request that was open at the
+    /// last poll now reports merged. Only that observed transition
+    /// counts, never a merely missing pull request (a stale cache or
+    /// a branch that never had one), and dirty worktrees are left
+    /// alone by the cleanup itself.
+    private func cleanUpIfMerged(
+        _ item: WorktreeItem,
+        previous: PullRequestSummary?,
+        fresh: [PullRequestSummary],
+    ) async {
+        guard Self.observedMerge(previous: previous, fresh: fresh),
+              deletingPaths.contains(item.worktree.path) == false
+        else {
+            return
+        }
+
+        await cleanUp(item: item)
+    }
+
+    /// Whether a poll observed the branch's pull request go from
+    /// open to merged: the same number, open before, merged now. Pure
+    /// so the rule tests without GitHub.
+    static func observedMerge(previous: PullRequestSummary?, fresh: [PullRequestSummary]) -> Bool {
+        guard let previous, previous.state == "OPEN" else {
+            return false
+        }
+
+        return fresh.contains { $0.number == previous.number && $0.state == "MERGED" }
+    }
+
     private static let selectedRepositoryInterval: TimeInterval = 120
     private static let expandedInterval: TimeInterval = 300
     private static let collapsedInterval: TimeInterval = 1_800

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -197,6 +197,35 @@ public final class DashboardModel {
         }
     }
 
+    /// Tidies a worktree whose pull request has merged: a real
+    /// worktree is deleted outright, the main checkout is returned to
+    /// the default branch with the merged branch safely deleted. The
+    /// one path behind the Merge button, the context menu and the
+    /// poll's own merge detection.
+    public func cleanUp(item: WorktreeItem) async {
+        if item.worktree.path == item.worktree.repositoryPath {
+            await service.cleanUpAfterMerge(worktree: item.worktree, mergedBranch: item.worktree.branch)
+            await refresh()
+        } else {
+            await delete(item: item)
+        }
+    }
+
+    /// Whether a main checkout sits on a branch other than its
+    /// repository's default, the only state in which cleaning it up
+    /// after a merge means anything; false when the default is
+    /// unknown, so the offer never appears on a guess.
+    public func isOffDefaultBranch(_ item: WorktreeItem) -> Bool {
+        guard item.worktree.path == item.worktree.repositoryPath,
+              let group = groups.first(where: { $0.repository.path == item.worktree.repositoryPath }),
+              let defaultBranch = group.defaultBranch
+        else {
+            return false
+        }
+
+        return item.worktree.branch != defaultBranch
+    }
+
     /// Flags the item unread until it is next viewed.
     public func markUnread(item: WorktreeItem) async {
         service.markUnread(worktreePath: item.worktree.path)

--- a/Sources/DashboardFeature/DashboardView.swift
+++ b/Sources/DashboardFeature/DashboardView.swift
@@ -207,6 +207,18 @@ public struct DashboardView: View {
         }
         Button("Mark as unread") { Task { await model.markUnread(item: item) } }
             .hoverHelp("Show the unread dot until this worktree is next viewed")
+        // Cleanup is the merge-time tidy, offered by hand for merges
+        // the poll has not noticed yet or made outside GitHub; on the
+        // main checkout it only makes sense off the default branch.
+        if item.worktree.path != item.worktree.repositoryPath || model.isOffDefaultBranch(item) {
+            Button("Clean up after merge") { Task { await model.cleanUp(item: item) } }
+                .hoverHelp(
+                    item.worktree.path == item.worktree.repositoryPath
+                        ? "Return to the default branch and safely delete this merged branch; "
+                        + "dirty checkouts are left alone"
+                        : "Delete this worktree and its merged branch; conversations stay on the repository page",
+                )
+        }
         if item.worktree.path != item.worktree.repositoryPath {
             Button("Delete worktree") { Task { await model.delete(item: item) } }
                 .hoverHelp("Deletes the worktree and branch; conversations stay on the repository page")

--- a/Tests/DashboardFeatureTests/MergeCleanupTests.swift
+++ b/Tests/DashboardFeatureTests/MergeCleanupTests.swift
@@ -1,0 +1,46 @@
+import AgentIDEDomain
+@testable import DashboardFeature
+import Testing
+
+/// Pins the rule behind automatic cleanup: only a pull request seen
+/// open at one poll and merged at the next may trigger it, never a
+/// merely missing one, so a stale cache or a branch that never had a
+/// pull request can never delete work.
+@MainActor
+struct MergeCleanupTests {
+    // MARK: Internal
+
+    @Test
+    func `cleans up only on an observed open to merged transition`() {
+        let open = summary(number: 12, state: "OPEN")
+        let merged = summary(number: 12, state: "MERGED")
+        #expect(DashboardModel.observedMerge(previous: open, fresh: [merged]))
+    }
+
+    @Test
+    func `never cleans up on a missing, closed or different pull request`() {
+        let open = summary(number: 12, state: "OPEN")
+        #expect(DashboardModel.observedMerge(previous: nil, fresh: [summary(number: 12, state: "MERGED")]) == false)
+        #expect(DashboardModel.observedMerge(previous: open, fresh: []) == false)
+        #expect(DashboardModel.observedMerge(previous: open, fresh: [summary(number: 12, state: "CLOSED")]) == false)
+        #expect(DashboardModel.observedMerge(previous: open, fresh: [summary(number: 13, state: "MERGED")]) == false)
+        // A cache that already said merged saw nothing new happen.
+        let alreadyMerged = summary(number: 12, state: "MERGED")
+        #expect(DashboardModel.observedMerge(previous: alreadyMerged, fresh: [alreadyMerged]) == false)
+    }
+
+    // MARK: Private
+
+    private func summary(number: Int, state: String) -> PullRequestSummary {
+        PullRequestSummary(
+            number: number,
+            title: "Title",
+            url: "",
+            headBranch: "feature",
+            mergeable: "",
+            reviewDecision: "",
+            checks: "",
+            state: state,
+        )
+    }
+}


### PR DESCRIPTION
- Clean up merged branches and dirty checkouts after merges by resetting to origin and deleting merged branches with `-d`, preserving metadata for pull request headers and review threads
  - Make sandbox analyzer baseline dynamic using run-time checkout substitution to avoid outdated linters and ensure consistent SourceKit silence
  - Limit PR cache growth with timestamped headers and a unified newest-first cap across listings and review threads
  - Enhance form stability by delaying Open PR dimming until branch push and replacing one-commit prefill with actions extension
  - Polish documentation with verb-leading bullets, icon-bearing sections, code-formatted tools, and clear ARCHITECTURE on Open PR dimming
  - Enable manual merge cleanup via in-app button, worktree context menu, and pull request poll that acts only on open-to-merged transitions