### PR TITLE
Ensure merge safety and clean workflows across sessions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -203,6 +203,8 @@ Two visually unmistakable flavours ride that one client:
 
 Remote access is SSH to the Mac as the host user from an iOS client, then
 `script/attach <session>` (which also works from inside sandbox sessions).
+A session picker for that shell is a later slice: today the session name
+must be known or listed by hand.
 Remote Login must be enabled in macOS settings first. An SSH session is
 isolated by user permissions rather than sandbox-exec whichever account it
 targets, but attaching connects it to the sandboxed tmux server, so agent

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -341,8 +341,11 @@ Sendable` and `nonisolated(unsafe)` are banned.
 ### Create a worktree and launch an agent (Start work)
 
 1. Input: a typed prompt, or an issue or pull request number with optional
-   extra context, plus a target repository, agent, model and effort. An
-   issue's title and body become the prompt. A pull request instead gets a
+   extra context, plus a target repository, agent, model and effort. The
+   form is a middle-pane action on its repository, so opening it (from a
+   repository's plus button, a worktree's new session action or Cmd-N and
+   the picker) selects that repository's main checkout in the sidebar
+   without closing the form. An issue's title and body become the prompt. A pull request instead gets a
    detached worktree that `gh pr checkout` (host-side) turns into the pull
    request's own branch, so pushes and pulls track it directly.
 2. The branch name summarises the prompt: the on-device Apple foundation

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -347,7 +347,15 @@ Sendable` and `nonisolated(unsafe)` are banned.
    form is a middle-pane action on its repository, so opening it (from a
    repository's plus button, a worktree's new session action or Cmd-N and
    the picker) selects that repository's main checkout in the sidebar
-   without closing the form. An issue's title and body become the prompt. A pull request instead gets a
+   without closing the form. The agent, model and effort come back as
+   they were last time; the pickers re-validate the pair on appearance
+   as well as on change, since a persisted model of one agent must never
+   launch another (a Codex id once reached Claude that way). Submitting
+   inserts a greyed placeholder row under a provisional name into the
+   repository the instant the click lands and selects it, with the
+   primary pane showing creation progress; the real worktree replaces
+   the row on the refresh that follows, and a failure removes it and
+   returns to the form. An issue's title and body become the prompt. A pull request instead gets a
    detached worktree that `gh pr checkout` (host-side) turns into the pull
    request's own branch, so pushes and pulls track it directly.
 2. The branch name summarises the prompt: the on-device Apple foundation
@@ -512,14 +520,19 @@ Sendable` and `nonisolated(unsafe)` are banned.
    merge, at any time) and the pull request poll, which fires it by
    itself when a branch's pull request that was open at the last poll
    is found merged, so a merge made on GitHub or elsewhere is tidied
-   on the next refresh without being noticed first. A real worktree is
-   deleted; the main checkout is tidied in place instead: back to the
-   default branch, a hard reset to origin when the local default
-   carries nothing of its own, and a safe `-d` delete of the merged
-   branch. Dirty worktrees and checkouts are left alone, and the poll
-   never cleans up on a merely missing pull request (a stale cache or a
-   branch that never had one), only on an observed open-to-merged
-   transition.
+   on the next refresh without being noticed first. Cleanup is
+   merge-safe by construction: a real worktree's branch is deleted
+   with `git branch -d`, which git refuses for an unmerged branch, and
+   a dirty worktree is refused before anything runs; the main checkout
+   is tidied in place instead: back to the default branch, a hard reset
+   to origin when the local default carries nothing of its own, and the
+   same safe `-d` delete. A refusal reports why rather than forcing.
+   Only the explicit Delete worktree action force-deletes (`--force`,
+   `git branch -D`), and it confirms first with a dialog naming exactly
+   what would be lost (uncommitted changes, unmerged commits); the poll
+   never prompts and never forces, and never cleans up on a merely
+   missing pull request (a stale cache or a branch that never had one),
+   only on an observed open-to-merged transition.
 2. Deletion records the session's agent-native resume id, kills the tmux
    session, then runs `git worktree remove`, `git worktree prune` and
    `git branch -D` and removes the friendly symlink. Nothing is archived:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -192,12 +192,14 @@ Two visually unmistakable flavours ride that one client:
   black in dark); what separates them visually is position, the agent
   pane on the left and the shell in the utility pane. External attaches
   to agent sessions (SSH, `script/attach`) still get tmux-native mouse
-  scrolling and
-  OSC 52 copying from the server config. An agent pane attaching
-  detaches any
-  other client of its session (`-d`): clients leaked by an earlier app
-  run would otherwise linger forever, so an SSH viewer is dropped when
-  the app's pane (re)attaches and simply reattaches when wanted.
+  scrolling and OSC 52 copying from the server config. An agent pane
+  attaching detaches any other client of its session (`-d`): clients
+  leaked by an earlier app run would otherwise linger forever, so an
+  SSH viewer is dropped when the app's pane (re)attaches and simply
+  reattaches when wanted. Cmd-K clears the shell pane the way a
+  terminal app's clear does, screen and local scrollback wiped and the
+  prompt redrawn; agent panes ignore it, so an agent's conversation
+  can never be cleared from view by a stray shortcut.
 
 Remote access is SSH to the Mac as the host user from an iOS client, then
 `script/attach <session>` (which also works from inside sandbox sessions).

--- a/App/AppCommands.swift
+++ b/App/AppCommands.swift
@@ -23,6 +23,8 @@ struct AppCommands: Commands {
             Button("Manage Sessions…") { dashboard.showsSessionManager = true }
         }
         CommandMenu("Worktree") {
+            Button("Clear Shell") { clearShellRequest += 1 }
+                .keyboardShortcut("k", modifiers: .command)
             Button("Push") { bump("pushRequest") }
                 .keyboardShortcut("p", modifiers: [.command, .shift])
             Button("Rebase on Origin") { bump("rebaseRequest") }
@@ -63,6 +65,11 @@ struct AppCommands: Commands {
     private var finderSearchesContents = false
     @AppStorage("finderFocusRequest")
     private var finderFocusRequest = 0
+
+    /// Cmd-K's counter: the active shell pane clears once per raise;
+    /// agent panes ignore it.
+    @AppStorage("clearShellRequest")
+    private var clearShellRequest = 0
 
     /// Increments a storage-bus counter; the pane owning the
     /// action observes it and runs.

--- a/App/AppCommands.swift
+++ b/App/AppCommands.swift
@@ -14,8 +14,7 @@ struct AppCommands: Commands {
             Button("New Agent Session") {
                 // No preset: the menu is repository-agnostic, and a
                 // stale preset would lock the picker.
-                dashboard.newSessionRepository = nil
-                dashboard.showsNewSession = true
+                dashboard.openNewSession(for: nil)
             }
             .keyboardShortcut("n", modifiers: .command)
             Button("Open Repository…") { dashboard.showsRepositoryFinder = true }

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -86,8 +86,7 @@ extension RootView {
 
     /// Opens the new session form preset to the item's repository.
     func newSession(for item: WorktreeItem) {
-        dependencies.dashboard.newSessionRepository = repository(of: item)
-        dependencies.dashboard.showsNewSession = true
+        dependencies.dashboard.openNewSession(for: repository(of: item))
     }
 
     /// Continues the worktree's most recent conversation: the newest

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -84,11 +84,6 @@ extension RootView {
         )
     }
 
-    /// Opens the new session form preset to the item's repository.
-    func newSession(for item: WorktreeItem) {
-        dependencies.dashboard.openNewSession(for: repository(of: item))
-    }
-
     /// Continues the worktree's most recent conversation: the newest
     /// transcript when one lists here, otherwise the recorded closed
     /// session. The state refreshes first, so a stale cached item

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -292,7 +292,6 @@ struct RootView: View {
             RepositorySessionsView(
                 repository: repository(of: item),
                 service: dependencies.service,
-                onNewSession: { newSession(for: item) },
                 // The review surfaces follow the selected
                 // conversation's worktree, so clicking around the
                 // repository page retargets Review and PRs.
@@ -304,9 +303,7 @@ struct RootView: View {
                 repository: repository(of: item),
                 service: dependencies.service,
                 worktreePath: item.worktree.path,
-                onNewSession: { newSession(for: item) },
-                onResumed: { await sessionStarted() },
-            )
+            ) { await sessionStarted() }
         } else {
             CreateSessionPane(
                 worktree: item.worktree,

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -272,7 +272,11 @@ struct RootView: View {
     /// a worktree with nothing to list offers the new session form.
     @ViewBuilder
     private func primary(for item: WorktreeItem) -> some View {
-        if isAutoResuming, item.session == nil {
+        if item.isPlaceholder {
+            // The row exists before the worktree does.
+            ProgressView("Creating worktree and starting the agent…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if isAutoResuming, item.session == nil {
             ProgressView("Resuming conversation…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let session = item.session {

--- a/App/UtilityTabStrip.swift
+++ b/App/UtilityTabStrip.swift
@@ -41,7 +41,7 @@ struct UtilityTabStrip: View {
                     .font(.callout)
                 if tab == .errors, errorLog.errorCount > 0 {
                     Text(String(errorLog.errorCount))
-                        .font(.caption2.bold())
+                        .font(.caption.bold())
                         .foregroundStyle(.white)
                         .padding(.horizontal, Self.badgeSpacing)
                         .background(Capsule().fill(.red))

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ done:
 9. Polish, including checking the Brewfile's tools are installed at
    startup and offering to install any that are missing from a copy
    vendored in the app bundle
+10. A terminal session picker for SSH: one command on the sandbox
+    user's `PATH` that lists the running agent sessions and attaches
+    to the chosen one, so steering from an iOS SSH client needs no
+    remembered session names
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for how AgentIDE is designed and
 [AGENTS.md](AGENTS.md) if you are working on this repository, human or agent.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ before shipping.
   your Mac while the sessions keep running in `tmux` (so native terminal
   feel costs no session survival)
 - **Reflows** multi-line copies from agent terminals: indentation, gutter
-  marks and hard line breaks go while paragraphs and lists survive, and
+  marks and hard line breaks go while paragraphs and lists survive, but a
+  block that reads as commands or code keeps every line exactly, and
   Option-drag copies a rectangle (so answers paste cleanly into chat,
-  notes and pull request bodies)
+  notes and pull request bodies, and a copied script still runs)
 - **Commits** work the agent forgot to commit, clearly authored as such (so
   nothing is stranded in a worktree and review still sees everything)
 - **Lets** you SSH into any session from an iOS SSH client (so you can steer or

--- a/Sources/AgentIDEData/FoundationModelClient.swift
+++ b/Sources/AgentIDEData/FoundationModelClient.swift
@@ -44,6 +44,25 @@ public struct FoundationModelClient: Sendable {
         return Self.branchName(fromModelAnswer: raw)
     }
 
+    /// A commit message drafted from a diff: a subject line, a
+    /// blank line and a short body. Nil when the model cannot help,
+    /// so the field stays exactly as the user left it.
+    public func commitMessage(fromDiff diff: String) async -> String? {
+        let instructions = """
+        Summarise this git diff as a commit message: a sentence-case imperative \
+        subject under fifty characters, then a blank line, then one short \
+        paragraph on why. No conventional-commit prefix, no quotes, no code \
+        fences. Answer with the message alone.
+        """
+        guard let raw = await respond(instructions: instructions, to: String(diff.prefix(Self.diffLimit)))
+        else {
+            return nil
+        }
+
+        let cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
     /// A pull request title and body drafted from the branch's
     /// commit messages, nil when the model cannot help.
     public func pullRequestDescription(fromCommits commits: [String]) async -> (title: String, body: String)? {
@@ -192,6 +211,10 @@ public struct FoundationModelClient: Sendable {
     }
 
     // MARK: Private
+
+    /// Enough of a diff to summarise without paying for a whole
+    /// refactor's worth of context.
+    private static let diffLimit = 8_000
 
     /// Enough prompt for a name without paying for a whole spec.
     private static let promptLimit = 500

--- a/Sources/AgentIDEData/GitClient+Branches.swift
+++ b/Sources/AgentIDEData/GitClient+Branches.swift
@@ -81,6 +81,18 @@ public extension GitClient {
         _ = try? await git(["branch", "-d", branch], in: worktreePath, allowFailure: true)
     }
 
+    /// Whether every commit of a branch is reachable from a base ref,
+    /// which is what makes deleting it lossless. False when either
+    /// ref is unreadable, keeping the safe path shut when in doubt.
+    func isMerged(worktreePath: String, branch: String, into baseRef: String) async -> Bool {
+        let result = try? await git(
+            ["merge-base", "--is-ancestor", branch, baseRef],
+            in: worktreePath,
+            allowFailure: true,
+        )
+        return result?.succeeded ?? false
+    }
+
     /// The branch's full commit messages beyond the base ref,
     /// oldest first, for drafting pull request descriptions.
     func commitMessages(worktreePath: String, baseRef: String) async -> [String] {

--- a/Sources/AgentIDEData/GitClient.swift
+++ b/Sources/AgentIDEData/GitClient.swift
@@ -292,6 +292,16 @@ public struct GitClient: Sendable {
         try await forgetWorktree(repository: repository, branch: branch)
     }
 
+    /// Removes a worktree and deletes its branch the way git itself
+    /// judges safe: no `--force`, and `-d` rather than `-D`, so git
+    /// refuses a dirty worktree or an unmerged branch even if the
+    /// caller's own checks were wrong or raced.
+    public func removeMergedWorktree(repository: Repository, worktreePath: String, branch: String) async throws {
+        try await git(["worktree", "remove", worktreePath], in: repository.path)
+        try await git(["worktree", "prune"], in: repository.path)
+        try await git(["branch", "-d", branch], in: repository.path)
+    }
+
     /// Prunes gone worktrees and deletes the branch, the git-side
     /// half of removal for callers that deleted the files another
     /// way.

--- a/Sources/AgentIDEData/GitHubClient+Threads.swift
+++ b/Sources/AgentIDEData/GitHubClient+Threads.swift
@@ -20,6 +20,25 @@ public extension GitHubClient {
         20_000
     }
 
+    /// `gh run view --log-failed` prefixes every line with its job
+    /// and step names, tab separated.
+    private static var stepPrefixFields: Int {
+        // swiftlint:disable:next no_magic_numbers
+        2
+    }
+
+    /// How many lines of a failed step to keep, and how many before
+    /// its first error line for context.
+    private static var stepTailLines: Int {
+        // swiftlint:disable:next no_magic_numbers
+        60
+    }
+
+    private static var errorContextLines: Int {
+        // swiftlint:disable:next no_magic_numbers
+        5
+    }
+
     // MARK: Public
 
     /// The pull request's review conversation threads with a REST
@@ -117,12 +136,55 @@ public extension GitHubClient {
                 continue
             }
 
-            sections += "\n\nFailed steps of run " + runID + ":\n" + String(output.prefix(Self.runLogLimit))
+            sections += "\n\nFailed steps of run " + runID + ":\n" + Self.failureExcerpt(fromRunLog: output)
         }
         return sections
     }
 
     // MARK: Internal
+
+    /// The useful part of a `gh run view --log-failed` dump: its
+    /// lines carry a repeated `job\tstep\t` prefix, and the failure
+    /// is at the end, so the head of a long log was setup noise
+    /// rather than the error. Each failed step keeps its own tail,
+    /// from its first error line where one exists.
+    internal static func failureExcerpt(fromRunLog log: String) -> String {
+        var steps = [String]()
+        var lines = [String: [String]]()
+        for raw in log.split(separator: "\n", omittingEmptySubsequences: false) {
+            let fields = raw.split(separator: "\t", maxSplits: stepPrefixFields, omittingEmptySubsequences: false)
+            let step = fields.count > stepPrefixFields
+                ? fields[0 ..< stepPrefixFields].joined(separator: " / ")
+                : ""
+            let text = fields.count > stepPrefixFields ? String(fields[stepPrefixFields]) : String(raw)
+            if lines[step] == nil {
+                steps.append(step)
+                lines[step] = []
+            }
+            lines[step]?.append(text)
+        }
+        return steps
+            .map { step in
+                let body = Self.tail(of: lines[step] ?? [])
+                return step.isEmpty ? body : step + "\n" + body
+            }
+            .joined(separator: "\n\n")
+            .prefixWithinLimit(runLogLimit)
+    }
+
+    /// One step's last lines, starting at its first error line when
+    /// it has one: the message that explains the failure sits there,
+    /// with the lines after it as context.
+    internal static func tail(of lines: [String]) -> String {
+        let markers = ["error:", "##[error]", "error ", "failed", "fatal:", "assertion"]
+        let firstError = lines.firstIndex { line in
+            let lowered = line.lowercased()
+            return markers.contains { lowered.contains($0) }
+        }
+        let start = firstError.map { max($0 - errorContextLines, 0) }
+            ?? max(lines.count - stepTailLines, 0)
+        return lines[start...].suffix(stepTailLines).joined(separator: "\n")
+    }
 
     /// Groups the REST inline comments into anchored threads; the
     /// REST rows carry no resolvable thread id, so these render

--- a/Sources/AgentIDEData/MetadataStore.swift
+++ b/Sources/AgentIDEData/MetadataStore.swift
@@ -93,6 +93,8 @@ public struct AppMetadata: Codable, Sendable {
             .decodeIfPresent([String: CachedThreads].self, forKey: .threadsCache) ?? [:]
         intentionallyClosed = try container
             .decodeIfPresent([String].self, forKey: .intentionallyClosed) ?? []
+        pullRequestDrafts = try container
+            .decodeIfPresent([String: PullRequestFormDraft].self, forKey: .pullRequestDrafts) ?? [:]
     }
 
     // MARK: Public
@@ -161,6 +163,10 @@ public struct AppMetadata: Codable, Sendable {
     /// reopened conversation paints them instantly.
     public var threadsCache: [String: CachedThreads] = [:]
 
+    /// Unfinished pull request text by `repositoryPath#branch`, so
+    /// the creation form survives leaving the tab.
+    public var pullRequestDrafts: [String: PullRequestFormDraft] = [:]
+
     /// Worktrees whose last session the user closed deliberately;
     /// automatic resumes leave them alone until a session starts
     /// there again.
@@ -201,6 +207,32 @@ public struct AppMetadata: Codable, Sendable {
     /// without the file growing forever.
     private static let conversationCap = 80
     private static let listingCap = 40
+}
+
+// MARK: - PullRequestFormDraft
+
+/// A branch's unfinished pull request text, kept so leaving the tab
+/// and coming back does not lose the writing.
+public struct PullRequestFormDraft: Codable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a draft.
+    public init(title: String, body: String, template: String) {
+        self.title = title
+        self.body = body
+        self.template = template
+    }
+
+    // MARK: Public
+
+    /// The drafted title.
+    public let title: String
+
+    /// The drafted body.
+    public let body: String
+
+    /// The template as edited.
+    public let template: String
 }
 
 // MARK: - CachedSummary

--- a/Sources/AgentIDEData/ProcessRunner.swift
+++ b/Sources/AgentIDEData/ProcessRunner.swift
@@ -70,6 +70,15 @@ extension String {
     }
 }
 
+public extension String {
+    /// The string capped to a length, keeping its end: log excerpts
+    /// explain themselves at the bottom, so trimming the head is
+    /// what keeps the useful part.
+    func prefixWithinLimit(_ limit: Int) -> String {
+        count <= limit ? self : "…\n" + String(suffix(limit))
+    }
+}
+
 // MARK: - ProcessEnvironment
 
 /// The one environment every spawned process starts from.

--- a/Sources/AgentIDEData/SessionService+Lifecycle.swift
+++ b/Sources/AgentIDEData/SessionService+Lifecycle.swift
@@ -42,6 +42,12 @@ public extension SessionService {
             try await removeAsSandboxUser(path: worktree.path)
             try await git.forgetWorktree(repository: repository, branch: worktree.branch)
         }
+        removeFriendlySymlink(worktree: worktree)
+    }
+
+    /// Removes a worktree's human-friendly symlink; the canonical
+    /// path is what git knows, so this is cosmetic cleanup.
+    internal func removeFriendlySymlink(worktree: Worktree) {
         let link = paths.friendlyWorktreesDirectory + "/" + worktree.repositoryName
             + "/" + worktree.branch.replacing("/", with: "-")
         try? FileManager.default.removeItem(atPath: link)
@@ -70,7 +76,21 @@ public extension SessionService {
             return .unmerged
         }
 
-        try await deleteWorktree(item: item)
+        // Merge-safe git as well as merge-safe checks: `git worktree
+        // remove` without `--force` and `git branch -d` refuse dirty
+        // or unmerged work themselves, so a wrong or raced check
+        // above cannot destroy anything.
+        let repository = Repository(name: worktree.repositoryName, path: worktree.repositoryPath)
+        let sessionName = item.session?.name
+            ?? SessionName.make(repository: worktree.repositoryName, branch: worktree.branch, agent: .claudeCode)
+        rememberResumeID(sessionName: sessionName, worktreePath: worktree.path)
+        try? await tmux.killSession(name: sessionName)
+        try await git.removeMergedWorktree(
+            repository: repository,
+            worktreePath: worktree.path,
+            branch: worktree.branch,
+        )
+        removeFriendlySymlink(worktree: worktree)
         return nil
     }
 

--- a/Sources/AgentIDEData/SessionService+Lifecycle.swift
+++ b/Sources/AgentIDEData/SessionService+Lifecycle.swift
@@ -47,6 +47,33 @@ public extension SessionService {
         try? FileManager.default.removeItem(atPath: link)
     }
 
+    /// Why a merge-safe cleanup refused a worktree, so the caller can
+    /// name what a forced deletion would destroy.
+    enum CleanupRefusal: Equatable, Sendable {
+        /// Uncommitted changes would be lost.
+        case dirty
+        /// Commits not on the base branch would be lost.
+        case unmerged
+    }
+
+    /// The merge-safe cleanup of a real worktree: refused outright
+    /// when the worktree is dirty or its branch has commits the base
+    /// branch lacks, so nothing this path does can lose work; the
+    /// force delete is a separate, confirmed action. Returns the
+    /// refusal, nil when the worktree was removed.
+    func cleanUpMergedWorktree(item: WorktreeItem, baseRef: String) async throws -> CleanupRefusal? {
+        let worktree = item.worktree
+        guard await git.isDirty(worktreePath: worktree.path) == false else {
+            return .dirty
+        }
+        guard await git.isMerged(worktreePath: worktree.path, branch: worktree.branch, into: baseRef) else {
+            return .unmerged
+        }
+
+        try await deleteWorktree(item: item)
+        return nil
+    }
+
     /// Deletes a path as the sandbox user through the launcher, for
     /// files the host user does not own.
     private func removeAsSandboxUser(path: String) async throws {

--- a/Sources/AgentIDEData/SessionService+Overview.swift
+++ b/Sources/AgentIDEData/SessionService+Overview.swift
@@ -190,4 +190,15 @@ public extension SessionService {
         let panes = await (try? tmux.panes()) ?? []
         return panes.contains { $0.sessionName == name }
     }
+
+    /// The bare branch name of a base ref: only the known remote and
+    /// ref prefixes come off, so a default branch that itself
+    /// contains slashes (`release/2026`) survives intact where
+    /// splitting on `/` would have left `2026`.
+    internal static func branchName(fromBaseRef baseRef: String) -> String {
+        for prefix in ["refs/remotes/origin/", "refs/heads/", "origin/"] where baseRef.hasPrefix(prefix) {
+            return String(baseRef.dropFirst(prefix.count))
+        }
+        return baseRef
+    }
 }

--- a/Sources/AgentIDEData/SessionService+PullRequests.swift
+++ b/Sources/AgentIDEData/SessionService+PullRequests.swift
@@ -40,6 +40,16 @@ public extension SessionService {
         await summariser.pullRequestDescription(fromCommits: commits)
     }
 
+    /// A commit message drafted from a worktree's uncommitted diff,
+    /// nil when the on-device model is unavailable or unhelpful.
+    func draftCommitMessage(worktreePath: String) async -> String? {
+        guard let diff = try? await git.uncommittedDiff(worktreePath: worktreePath), diff.isEmpty == false else {
+            return nil
+        }
+
+        return await summariser.commitMessage(fromDiff: diff)
+    }
+
     /// The pull request template completed from the commits by the
     /// on-device model, nil when it is unavailable or unhelpful.
     func fillPullRequestTemplate(fromCommits commits: [String], template: String) async -> String? {
@@ -65,7 +75,7 @@ public extension SessionService {
         }
 
         // defaultBaseRef answers `origin/main` or a bare local name.
-        let branch = base.hasPrefix("origin/") ? String(base.dropFirst("origin/".count)) : base
+        let branch = Self.branchName(fromBaseRef: base)
         guard branch != mergedBranch,
               await (try? git.checkout(worktreePath: worktree.path, branch: branch)) != nil
         else {

--- a/Sources/AgentIDEData/SessionService.swift
+++ b/Sources/AgentIDEData/SessionService.swift
@@ -100,7 +100,7 @@ public struct SessionService: Sendable {
             groups.append(RepositoryGroup(
                 repository: named,
                 items: sorted,
-                defaultBranch: baseRef?.split(separator: "/").last.map(String.init),
+                defaultBranch: baseRef.map(Self.branchName(fromBaseRef:)),
             ))
         }
         // Repositories order by their worktrees' activity; the main
@@ -281,7 +281,7 @@ public struct SessionService: Sendable {
             repositoryName: repository.name,
             repositoryPath: repository.path,
             branch: git.currentBranch(worktreePath: repository.path)
-                ?? baseRef?.split(separator: "/").last.map(String.init) ?? "main",
+                ?? baseRef.map(Self.branchName(fromBaseRef:)) ?? "main",
             path: repository.path,
         )
     }

--- a/Sources/AgentIDEDomain/DiffFile.swift
+++ b/Sources/AgentIDEDomain/DiffFile.swift
@@ -63,9 +63,10 @@ public struct DiffFile: Identifiable, Hashable, Sendable {
     /// Creates a file diff; the diffstat counts are computed once
     /// here rather than on every read, since the UI reads them per
     /// row on large diffs.
-    public init(path: String, hunks: [DiffHunk]) {
+    public init(path: String, hunks: [DiffHunk], isNew: Bool = false) {
         self.path = path
         self.hunks = hunks
+        self.isNew = isNew
         let lines = hunks.flatMap(\.lines)
         additions = lines.count { $0.kind == .addition }
         deletions = lines.count { $0.kind == .deletion }
@@ -75,6 +76,12 @@ public struct DiffFile: Identifiable, Hashable, Sendable {
 
     /// The file's path on the new side.
     public let path: String
+
+    /// Whether the file is new: added or untracked, so its whole
+    /// content is the diff and every line is an addition. The review
+    /// says so and collapses it, since a wall of additions otherwise
+    /// reads as a broken diff beside real hunks.
+    public let isNew: Bool
 
     /// The file's hunks in order.
     public let hunks: [DiffHunk]

--- a/Sources/AgentIDEDomain/DiffParser.swift
+++ b/Sources/AgentIDEDomain/DiffParser.swift
@@ -11,6 +11,7 @@ public enum DiffParser {
         var lines = [DiffLine]()
         var starts: (old: Int, new: Int) = (0, 0)
         var inHunk = false
+        var sawOldPath = false
 
         func closeHunk() {
             guard inHunk else {
@@ -27,8 +28,11 @@ public enum DiffParser {
             // Prefer the new path; fall back to the old path so deleted
             // files (whose new path is /dev/null) are still represented.
             if let path = newPath ?? oldPath {
-                files.append(DiffFile(path: path, hunks: hunks))
+                // `--- /dev/null` (a git-added file) and the synthetic
+                // untracked diff both leave the old path empty.
+                files.append(DiffFile(path: path, hunks: hunks, isNew: sawOldPath && oldPath == nil))
             }
+            sawOldPath = false
             newPath = nil
             oldPath = nil
             hunks = []
@@ -47,6 +51,7 @@ public enum DiffParser {
                     lines.append(parsed)
                 }
             } else if line.hasPrefix("--- ") {
+                sawOldPath = true
                 oldPath = strippedPath(String(line.dropFirst("--- ".count)))
             } else if line.hasPrefix("+++ ") {
                 newPath = strippedPath(String(line.dropFirst("+++ ".count)))

--- a/Sources/AgentIDEDomain/PasteableText.swift
+++ b/Sources/AgentIDEDomain/PasteableText.swift
@@ -15,6 +15,73 @@ public enum PasteableText {
             return strippingGutter(content)
         }
 
+        if let verbatim = codeBlock(content) {
+            return verbatim
+        }
+
+        let blocks = proseBlocks(content)
+        var result = ""
+        for (index, block) in blocks.enumerated() {
+            if index > 0 {
+                // Consecutive list items stay a tight list; anything
+                // else is a fresh paragraph.
+                result += block.isListItem && blocks[index - 1].isListItem ? "\n" : "\n\n"
+            }
+            result += block.text
+        }
+        return result
+    }
+
+    /// A line without its leading gutter marks (the block glyphs
+    /// terminal interfaces draw down their left edge) or
+    /// surrounding whitespace.
+    public static func strippingGutter(_ line: String) -> String {
+        var trimmed = line.trimmingCharacters(in: .whitespaces)
+        while let first = trimmed.first, Self.gutterMarks.contains(first) {
+            trimmed = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces)
+        }
+        return trimmed
+    }
+
+    /// Whether stripped lines read as commands or code rather than
+    /// prose: most non-blank lines carry a code signature (a shell
+    /// command word, a path, an option flag, a pipe or redirect, a
+    /// line continuation, or a prompt). Deliberately conservative
+    /// so an ordinary sentence mentioning `--verbose` still reflows.
+    public static func looksLikeCode(_ lines: [String]) -> Bool {
+        let meaningful = lines.filter { $0.isEmpty == false }
+        guard meaningful.count >= minimumCodeLines, let first = meaningful.first, hasCodeSignature(first) else {
+            return false
+        }
+
+        return meaningful.filter(hasCodeSignature).count * codeMajority > meaningful.count
+    }
+
+    // MARK: Private
+
+    /// One line alone is never a block; two can be.
+    private static let minimumCodeLines = 2
+
+    /// Signature lines times this must exceed the line count, so a
+    /// strict majority of lines must look like code.
+    private static let codeMajority = 2
+
+    /// The block glyphs terminal interfaces use as gutters and
+    /// borders.
+    private static let gutterMarks: Set<Character> = ["▎", "▏", "▍", "│", "┃"]
+
+    /// Shell command words that begin a code line; the list is small
+    /// on purpose and other lines qualify through their punctuation.
+    private static let commandWords: Set<String> = [
+        "cd", "git", "ls", "cat", "echo", "export", "sudo", "brew", "npm", "swift", "xcodebuild",
+        "make", "curl", "python", "python3", "ruby", "bundle", "rm", "mkdir", "cp", "mv", "tmux",
+        "gh", "docker", "ssh", "source", "exec", "printf", "grep", "sed", "awk", "find", "chmod",
+    ]
+
+    /// Gathers prose into paragraphs and list items: a blank line
+    /// ends a paragraph, a list marker starts its own item and any
+    /// other line continues the current block.
+    private static func proseBlocks(_ content: String) -> [(text: String, isListItem: Bool)] {
         var blocks = [(text: String, isListItem: Bool)]()
         var current: (text: String, isListItem: Bool)?
         for raw in content.split(separator: "\n", omittingEmptySubsequences: false) {
@@ -40,35 +107,34 @@ public enum PasteableText {
         if let block = current {
             blocks.append(block)
         }
-
-        var result = ""
-        for (index, block) in blocks.enumerated() {
-            if index > 0 {
-                // Consecutive list items stay a tight list; anything
-                // else is a fresh paragraph.
-                result += block.isListItem && blocks[index - 1].isListItem ? "\n" : "\n\n"
-            }
-            result += block.text
-        }
-        return result
+        return blocks
     }
 
-    /// A line without its leading gutter marks (the block glyphs
-    /// terminal interfaces draw down their left edge) or
-    /// surrounding whitespace.
-    public static func strippingGutter(_ line: String) -> String {
-        var trimmed = line.trimmingCharacters(in: .whitespaces)
-        while let first = trimmed.first, Self.gutterMarks.contains(first) {
-            trimmed = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces)
-        }
-        return trimmed
+    /// Reflowing is for prose. A copied command block or code
+    /// listing keeps its lines exactly, gutters stripped: joining
+    /// `git fetch` onto the `cd` before it once turned a runnable
+    /// script into one broken line. Nil when the text is prose.
+    private static func codeBlock(_ content: String) -> String? {
+        let stripped = content
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { strippingGutter(String($0)) }
+        return looksLikeCode(stripped) ? stripped.joined(separator: "\n") : nil
     }
 
-    // MARK: Private
-
-    /// The block glyphs terminal interfaces use as gutters and
-    /// borders.
-    private static let gutterMarks: Set<Character> = ["▎", "▏", "▍", "│", "┃"]
+    /// Whether one line carries a code signature.
+    private static func hasCodeSignature(_ line: String) -> Bool {
+        let first = line.split(separator: " ", maxSplits: 1).first.map(String.init) ?? ""
+        if commandWords.contains(first) || first.hasPrefix("$") || first.hasPrefix("./") || first.hasPrefix("~/") {
+            return true
+        }
+        if line.hasSuffix("\\") || line.hasPrefix("#!") || line.hasPrefix("//") {
+            return true
+        }
+        // Flags, pipes, redirects and assignments rarely appear in
+        // prose sentences and almost always in commands.
+        return line.contains(" --") || line.contains(" | ") || line.contains(" > ") || line.contains(" && ")
+            || line.contains(" -") && line.contains("/")
+    }
 
     /// Bullets, quotes and numbered items start their own lines and
     /// swallow their wrapped continuations.

--- a/Sources/DashboardFeature/AgentOptionPickers.swift
+++ b/Sources/DashboardFeature/AgentOptionPickers.swift
@@ -46,6 +46,11 @@ struct AgentOptionPickers: View {
             .hoverHelp("How much reasoning the agent spends; Default leaves it to the agent")
         }
         .labelsHidden()
+        // On appearance as well as on change: the agent, model and
+        // effort all persist across launches now, but discovery can
+        // change what a CLI offers between runs, and a persisted pair
+        // must never combine a model one agent knows with another.
+        .onAppear { resetUnavailableChoices() }
         .onChange(of: agent) { resetUnavailableChoices() }
     }
 

--- a/Sources/DashboardFeature/AgentSessionForm.swift
+++ b/Sources/DashboardFeature/AgentSessionForm.swift
@@ -60,7 +60,7 @@ struct AgentSessionForm: View {
             .labelsHidden()
             .hoverHelp("Where the prompt comes from: typed text, or an open issue or pull request")
             AgentOptionPickers(
-                agent: $agent,
+                agent: agent,
                 model: $agentModel,
                 effort: $agentEffort,
             ) { model.launchChoices(for: $0) }
@@ -85,7 +85,13 @@ struct AgentSessionForm: View {
     private static let contextHeight: CGFloat = 70
 
     @State private var source: PromptSource = .prompt
-    @State private var agent: AgentKind = .claudeCode
+    /// The last agent, model and effort come back next time: the
+    /// agent persists by name beside the model and effort that
+    /// always did, because a persisted Codex model over a fresh
+    /// default of Claude once launched Claude with a GPT id.
+    @AppStorage("agentKind")
+    private var agentKindName = AgentKind.claudeCode.rawValue
+
     @State private var number: Int?
 
     /// Guards against double submission: creating a worktree takes
@@ -102,6 +108,13 @@ struct AgentSessionForm: View {
     private var agentModel = ""
     @AppStorage("agentEffort")
     private var agentEffort = ""
+
+    private var agent: Binding<AgentKind> {
+        Binding(
+            get: { AgentKind(rawValue: agentKindName) ?? .claudeCode },
+            set: { agentKindName = $0.rawValue },
+        )
+    }
 
     private var submitDisabled: Bool {
         guard repository != nil else {
@@ -206,7 +219,7 @@ struct AgentSessionForm: View {
             number: number,
             prompt: prompt,
             context: context,
-            agent: agent,
+            agent: agent.wrappedValue,
             options: AgentLaunchOptions(
                 model: agentModel.isEmpty ? nil : agentModel,
                 effort: agentEffort.isEmpty ? nil : agentEffort,

--- a/Sources/DashboardFeature/DashboardModel+Cleanup.swift
+++ b/Sources/DashboardFeature/DashboardModel+Cleanup.swift
@@ -1,0 +1,71 @@
+import AgentIDEData
+import AgentIDEDomain
+import TerminalUI
+
+/// Cleanup after a merge, split from the model body for length: the
+/// one merge-safe path behind the Merge button, the context menu and
+/// the poll's own merge detection.
+public extension DashboardModel {
+    /// Tidies a worktree whose pull request has merged, merge-safely:
+    /// a real worktree is removed only when it is clean and its branch
+    /// is fully on the base branch (git's `-d` rule), otherwise the
+    /// refusal comes back for the caller to show; the main checkout is
+    /// returned to the default branch with the merged branch safely
+    /// deleted. The one path behind the Merge button, the context menu
+    /// and the poll's own merge detection: nothing here can lose
+    /// work, and only the explicit, confirmed Delete worktree forces.
+    @discardableResult
+    func cleanUp(item: WorktreeItem) async -> SessionService.CleanupRefusal? {
+        if item.worktree.path == item.worktree.repositoryPath {
+            await service.cleanUpAfterMerge(worktree: item.worktree, mergedBranch: item.worktree.branch)
+            await refresh()
+            return nil
+        }
+
+        guard let baseRef = baseRef(for: item) else {
+            ErrorLog.shared.report(
+                "Cannot tell whether \(item.worktree.branch) is merged: the repository has no default branch",
+            )
+            return .unmerged
+        }
+
+        deletingPaths.insert(item.worktree.path)
+        defer { deletingPaths.remove(item.worktree.path) }
+        do {
+            let refusal = try await service.cleanUpMergedWorktree(item: item, baseRef: baseRef)
+            if refusal == nil {
+                if selection?.id == item.id {
+                    selection = nil
+                }
+                await refresh()
+            }
+            return refusal
+        } catch {
+            ErrorLog.shared.report(error.localizedDescription)
+            return .unmerged
+        }
+    }
+
+    /// The remote default branch ref a worktree's branch merges into,
+    /// nil when the repository's default is unknown.
+    func baseRef(for item: WorktreeItem) -> String? {
+        groups.first { $0.repository.path == item.worktree.repositoryPath }?
+            .defaultBranch
+            .map { "origin/" + $0 }
+    }
+
+    /// Whether a main checkout sits on a branch other than its
+    /// repository's default, the only state in which cleaning it up
+    /// after a merge means anything; false when the default is
+    /// unknown, so the offer never appears on a guess.
+    func isOffDefaultBranch(_ item: WorktreeItem) -> Bool {
+        guard item.worktree.path == item.worktree.repositoryPath,
+              let group = groups.first(where: { $0.repository.path == item.worktree.repositoryPath }),
+              let defaultBranch = group.defaultBranch
+        else {
+            return false
+        }
+
+        return item.worktree.branch != defaultBranch
+    }
+}

--- a/Sources/DashboardFeature/DashboardModel+PullRequests.swift
+++ b/Sources/DashboardFeature/DashboardModel+PullRequests.swift
@@ -98,7 +98,23 @@ extension DashboardModel {
             return
         }
 
-        await cleanUp(item: item)
+        // The poll never prompts and never forces: a worktree the
+        // merge-safe path refuses stays, with a note saying why, for
+        // the user to clean up or delete by hand.
+        switch await cleanUp(item: item) {
+        case .dirty:
+            ErrorLog.shared.report(
+                "\(item.worktree.branch) merged but has uncommitted changes; left in place for you to review",
+            )
+
+        case .unmerged:
+            ErrorLog.shared.report(
+                "\(item.worktree.branch) merged but has commits not on the base branch; left in place",
+            )
+
+        case nil:
+            break
+        }
     }
 
     /// Whether a poll observed the branch's pull request go from

--- a/Sources/DashboardFeature/DashboardModel+PullRequests.swift
+++ b/Sources/DashboardFeature/DashboardModel+PullRequests.swift
@@ -93,7 +93,11 @@ extension DashboardModel {
         fresh: [PullRequestSummary],
     ) async {
         guard Self.observedMerge(previous: previous, fresh: fresh),
-              deletingPaths.contains(item.worktree.path) == false
+              deletingPaths.contains(item.worktree.path) == false,
+              // Never pull the ground from under the worktree being
+              // looked at: it would vanish mid-action and read as a
+              // crash. Its context menu still offers the cleanup.
+              selection?.worktree.path != item.worktree.path
         else {
             return
         }

--- a/Sources/DashboardFeature/DashboardModel+Sessions.swift
+++ b/Sources/DashboardFeature/DashboardModel+Sessions.swift
@@ -12,7 +12,7 @@ public extension DashboardModel {
         agent: AgentKind,
         options: AgentLaunchOptions = AgentLaunchOptions(),
     ) async {
-        await run {
+        await run(in: repository, placeholder: Self.placeholderName(from: prompt)) {
             try await service.createSession(
                 repository: repository,
                 prompt: prompt,
@@ -30,7 +30,7 @@ public extension DashboardModel {
         agent: AgentKind,
         options: AgentLaunchOptions = AgentLaunchOptions(),
     ) async {
-        await run {
+        await run(in: repository, placeholder: "issue-\(number)") {
             try await service.createSession(
                 fromIssue: number,
                 repository: repository,
@@ -49,7 +49,7 @@ public extension DashboardModel {
         agent: AgentKind,
         options: AgentLaunchOptions = AgentLaunchOptions(),
     ) async {
-        await run {
+        await run(in: repository, placeholder: "pr-\(number)") {
             try await service.createSession(
                 fromPullRequest: number,
                 repository: repository,
@@ -93,21 +93,103 @@ public extension DashboardModel {
 
     /// Runs a session-creation action, closing the page, refreshing
     /// and selecting the new session's worktree so the agent is on
-    /// screen immediately.
-    private func run(_ work: () async throws -> String) async {
+    /// screen immediately. Creation takes seconds (naming the branch
+    /// on device, `git worktree add`, launching the agent), so a
+    /// greyed placeholder row under a provisional name appears in
+    /// the repository the instant the click lands and is selected;
+    /// the real worktree replaces it on the refresh that follows.
+    private func run(
+        in repository: Repository? = nil,
+        placeholder: String? = nil,
+        _ work: () async throws -> String,
+    ) async {
+        // Only creation shows a placeholder: launching an agent in an
+        // existing worktree has a real row already.
+        let pending = repository.flatMap { repository in
+            placeholder.map { insertPlaceholder(in: repository, branch: $0) }
+        }
+        showsNewSession = false
+        if let pending {
+            selection = pending
+        }
+        defer {
+            if let pending {
+                removePlaceholder(pending)
+            }
+        }
         do {
             screenError = nil
             let sessionName = try await work()
-            showsNewSession = false
             await refresh()
             if let created = groups.flatMap(\.items).first(where: { $0.session?.name == sessionName }) {
                 selection = created
             }
         } catch {
-            // The new-session page is still on screen and cannot
-            // show the Errors tab, so the failure shows inline too.
+            // Back to the form with the failure inline: it cannot
+            // show the Errors tab from there.
+            showsNewSession = true
+            selection = nil
             screenError = error.localizedDescription
             ErrorLog.shared.report(error.localizedDescription)
         }
+    }
+
+    /// A provisional branch-style name from the prompt's first words,
+    /// in the same underscore style the real name will have.
+    static func placeholderName(from prompt: String) -> String {
+        let words = prompt.split { $0.isLetter == false && $0.isNumber == false }
+            .prefix(Self.placeholderWords)
+            .map { $0.lowercased() }
+        return words.isEmpty ? "new_session" : words.joined(separator: "_")
+    }
+
+    private static let placeholderWords = 4
+
+    /// The path segment marking a creation placeholder's synthetic
+    /// path; nothing real ever lives there.
+    static let placeholderMarker = "/.pending/"
+
+    /// Inserts a greyed placeholder row into the repository's group
+    /// and marks it pending so the sidebar dims it and refuses
+    /// re-selection while the real worktree is created.
+    private func insertPlaceholder(in repository: Repository, branch: String) -> WorktreeItem {
+        let path = repository.path + Self.placeholderMarker + branch
+        let item = WorktreeItem(
+            worktree: Worktree(
+                repositoryName: repository.name,
+                repositoryPath: repository.path,
+                branch: branch,
+                path: path,
+            ),
+            session: nil,
+            isDirty: false,
+            aheadOfUpstream: nil,
+            hasUnread: false,
+        )
+        deletingPaths.insert(path)
+        if let index = groups.firstIndex(where: { $0.repository.path == repository.path }) {
+            // Right under the main checkout, where the newest work
+            // sorts anyway.
+            groups[index].items.insert(item, at: min(1, groups[index].items.count))
+        }
+        return item
+    }
+
+    /// Drops the placeholder; a refresh has usually replaced the
+    /// whole group by then, so this only cleans up after a failure.
+    private func removePlaceholder(_ item: WorktreeItem) {
+        deletingPaths.remove(item.worktree.path)
+        for index in groups.indices {
+            groups[index].items.removeAll { $0.worktree.path == item.worktree.path }
+        }
+    }
+}
+
+public extension WorktreeItem {
+    /// Whether this is the greyed provisional row a new session
+    /// shows while its real worktree is created; the app's primary
+    /// pane shows creation progress for it instead of a worktree.
+    var isPlaceholder: Bool {
+        worktree.path.contains(DashboardModel.placeholderMarker)
     }
 }

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -119,6 +119,32 @@ public final class DashboardModel {
         ErrorLog.shared.report(message)
     }
 
+    /// Opens the new session form for a repository (nil leaves the
+    /// picker open) and points the sidebar at that repository's main
+    /// checkout: the form is a middle-pane action on the repository,
+    /// so the sidebar reflects it. Selection is set directly rather
+    /// than through `select`, which would cancel the form it opens.
+    public func openNewSession(for repository: Repository?) {
+        newSessionRepository = repository
+        showsNewSession = true
+        selectMainCheckout(of: repository)
+    }
+
+    /// Points the sidebar at a repository's main checkout without
+    /// touching whatever the middle pane shows; the picker in the
+    /// new session form calls this as its choice changes.
+    public func selectMainCheckout(of repository: Repository?) {
+        guard let repository,
+              let group = groups.first(where: { $0.repository.path == repository.path }),
+              let main = group.items.first,
+              selection?.id != main.id
+        else {
+            return
+        }
+
+        selection = main
+    }
+
     /// Selecting from the sidebar is a middle-pane action, so it
     /// cancels any form the middle pane is showing.
     public func select(_ item: WorktreeItem) {

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -48,7 +48,9 @@ public final class DashboardModel {
     // MARK: Public
 
     /// The grouped worktrees per repository.
-    public private(set) var groups: [RepositoryGroup] = []
+    /// Written by refresh and, for the placeholder row a new session
+    /// shows while it is created, the sessions extension.
+    public internal(set) var groups: [RepositoryGroup] = []
 
     /// Sessions not created by AgentIDE.
     public private(set) var foreign: [AgentSession] = []
@@ -100,7 +102,11 @@ public final class DashboardModel {
                 return
             }
 
-            UserDefaults.standard.set(selection.worktree.path, forKey: Self.selectedWorktreeKey)
+            // A creation placeholder is selected for seconds only and
+            // must not become the worktree the next launch restores.
+            if selection.isPlaceholder == false {
+                UserDefaults.standard.set(selection.worktree.path, forKey: Self.selectedWorktreeKey)
+            }
             service.markSeen(worktreePath: selection.worktree.path)
             clearUnread(at: selection.worktree.path)
             // The freshly selected branch jumps the polling queue.
@@ -221,35 +227,6 @@ public final class DashboardModel {
         } catch {
             ErrorLog.shared.report(error.localizedDescription)
         }
-    }
-
-    /// Tidies a worktree whose pull request has merged: a real
-    /// worktree is deleted outright, the main checkout is returned to
-    /// the default branch with the merged branch safely deleted. The
-    /// one path behind the Merge button, the context menu and the
-    /// poll's own merge detection.
-    public func cleanUp(item: WorktreeItem) async {
-        if item.worktree.path == item.worktree.repositoryPath {
-            await service.cleanUpAfterMerge(worktree: item.worktree, mergedBranch: item.worktree.branch)
-            await refresh()
-        } else {
-            await delete(item: item)
-        }
-    }
-
-    /// Whether a main checkout sits on a branch other than its
-    /// repository's default, the only state in which cleaning it up
-    /// after a merge means anything; false when the default is
-    /// unknown, so the offer never appears on a guess.
-    public func isOffDefaultBranch(_ item: WorktreeItem) -> Bool {
-        guard item.worktree.path == item.worktree.repositoryPath,
-              let group = groups.first(where: { $0.repository.path == item.worktree.repositoryPath }),
-              let defaultBranch = group.defaultBranch
-        else {
-            return false
-        }
-
-        return item.worktree.branch != defaultBranch
     }
 
     /// Flags the item unread until it is next viewed.

--- a/Sources/DashboardFeature/DashboardView.swift
+++ b/Sources/DashboardFeature/DashboardView.swift
@@ -1,3 +1,4 @@
+import AgentIDEData
 import AgentIDEDomain
 import AppKit
 import SwiftUI
@@ -71,6 +72,11 @@ public struct DashboardView: View {
 
     @AppStorage("collapsedRepositories")
     private var collapsedRepositories = ""
+
+    /// The pending confirmed deletion: which worktree, and what the
+    /// merge-safe path refused about it (nil for a plain Delete
+    /// worktree, which always confirms since it always forces).
+    @State private var pendingForceDelete: (path: String, refusal: SessionService.CleanupRefusal?)?
 
     private let model: DashboardModel
 
@@ -182,6 +188,19 @@ public struct DashboardView: View {
         )
         .padding(.leading, Self.rowIndent)
         .contextMenu { contextActions(for: item) }
+        .confirmationDialog(
+            forceDeleteTitle(for: item),
+            isPresented: forceDeleteBinding(for: item),
+            titleVisibility: .visible,
+        ) {
+            Button("Delete worktree and branch", role: .destructive) {
+                pendingForceDelete = nil
+                Task { await model.delete(item: item) }
+            }
+            Button("Cancel", role: .cancel) { pendingForceDelete = nil }
+        } message: {
+            Text(forceDeleteMessage(for: item))
+        }
     }
 
     @ViewBuilder
@@ -210,17 +229,18 @@ public struct DashboardView: View {
         // the poll has not noticed yet or made outside GitHub; on the
         // main checkout it only makes sense off the default branch.
         if item.worktree.path != item.worktree.repositoryPath || model.isOffDefaultBranch(item) {
-            Button("Clean up after merge") { Task { await model.cleanUp(item: item) } }
+            Button("Clean up after merge") { Task { await cleanUpOrOffer(item) } }
                 .hoverHelp(
                     item.worktree.path == item.worktree.repositoryPath
                         ? "Return to the default branch and safely delete this merged branch; "
                         + "dirty checkouts are left alone"
-                        : "Delete this worktree and its merged branch; conversations stay on the repository page",
+                        : "Remove this worktree once its branch is merged and clean; "
+                        + "anything that would lose work asks first",
                 )
         }
         if item.worktree.path != item.worktree.repositoryPath {
-            Button("Delete worktree") { Task { await model.delete(item: item) } }
-                .hoverHelp("Deletes the worktree and branch; conversations stay on the repository page")
+            Button("Delete worktree", role: .destructive) { pendingForceDelete = (item.worktree.path, nil) }
+                .hoverHelp("Force-deletes the worktree and branch after confirming what would be lost")
         }
     }
 
@@ -233,6 +253,45 @@ public struct DashboardView: View {
         .frame(width: Self.avatarSize, height: Self.avatarSize)
         .clipShape(RoundedRectangle(cornerRadius: Self.avatarCornerRadius))
         .accessibilityHidden(true)
+    }
+
+    private func forceDeleteBinding(for item: WorktreeItem) -> Binding<Bool> {
+        Binding(
+            get: { pendingForceDelete?.path == item.worktree.path },
+            set: { shown in
+                if shown == false, pendingForceDelete?.path == item.worktree.path {
+                    pendingForceDelete = nil
+                }
+            },
+        )
+    }
+
+    private func forceDeleteTitle(for item: WorktreeItem) -> String {
+        "Delete the worktree for \(item.worktree.branch)?"
+    }
+
+    /// Names exactly what forcing would destroy, so the choice is
+    /// never made on a generic warning.
+    private func forceDeleteMessage(for item: WorktreeItem) -> String {
+        var losses = [String]()
+        if item.isDirty || pendingForceDelete?.refusal == .dirty {
+            losses.append("its uncommitted changes")
+        }
+        if pendingForceDelete?.refusal == .unmerged || (item.aheadOfDefault ?? 0) > 0 {
+            losses.append("commits not on the default branch")
+        }
+        let loss = losses.isEmpty
+            ? "The worktree and its branch are removed."
+            : "This permanently discards " + losses.joined(separator: " and ") + "."
+        return loss + " Conversations stay readable on the repository page."
+    }
+
+    /// Cleans up merge-safely and, when refused, offers the confirmed
+    /// force delete instead of silently doing nothing.
+    private func cleanUpOrOffer(_ item: WorktreeItem) async {
+        if let refusal = await model.cleanUp(item: item) {
+            pendingForceDelete = (item.worktree.path, refusal)
+        }
     }
 
     private func isExpanded(_ path: String) -> Bool {

--- a/Sources/DashboardFeature/DashboardView.swift
+++ b/Sources/DashboardFeature/DashboardView.swift
@@ -109,8 +109,7 @@ public struct DashboardView: View {
             .buttonStyle(.plain)
             .hoverHelp("Click to show or hide this repository's worktrees")
             Button {
-                model.newSessionRepository = group.repository
-                model.showsNewSession = true
+                model.openNewSession(for: group.repository)
             } label: {
                 Image(systemName: "plus")
                     .font(.caption2.weight(.semibold))

--- a/Sources/DashboardFeature/NewSessionPane.swift
+++ b/Sources/DashboardFeature/NewSessionPane.swift
@@ -61,6 +61,12 @@ public struct NewSessionPane: View {
         // every appearance or a repository plus would show the
         // previous pick.
         .onAppear { repository = resolvedPreset ?? repository }
+        // Another repository's plus while the form is open changes
+        // the preset under it; the form and the sidebar both follow.
+        .onChange(of: model.newSessionRepository) {
+            repository = resolvedPreset ?? repository
+            model.selectMainCheckout(of: repository)
+        }
         // Picking here is a middle-pane action on that repository
         // too, so the sidebar follows the picker like it follows
         // the openers.

--- a/Sources/DashboardFeature/NewSessionPane.swift
+++ b/Sources/DashboardFeature/NewSessionPane.swift
@@ -61,6 +61,10 @@ public struct NewSessionPane: View {
         // every appearance or a repository plus would show the
         // previous pick.
         .onAppear { repository = resolvedPreset ?? repository }
+        // Picking here is a middle-pane action on that repository
+        // too, so the sidebar follows the picker like it follows
+        // the openers.
+        .onChange(of: repository) { model.selectMainCheckout(of: repository) }
     }
 
     // MARK: Private

--- a/Sources/DashboardFeature/WorktreeRowView.swift
+++ b/Sources/DashboardFeature/WorktreeRowView.swift
@@ -30,7 +30,7 @@ struct WorktreeRowView: View {
                         .hoverHelp(badgesExplanation)
                     pullRequestBadge
                 }
-                .font(.caption2)
+                .font(.caption)
                 .foregroundStyle(.secondary)
             }
             Spacer(minLength: 0)

--- a/Sources/PRFeature/PullRequestCreateForm.swift
+++ b/Sources/PRFeature/PullRequestCreateForm.swift
@@ -54,9 +54,9 @@ struct PullRequestCreateForm: View {
             HStack {
                 Text("Template").font(.caption).foregroundStyle(.secondary)
                 Spacer()
-                Button("Tick every box") { model.tickTemplateBoxes() }
-                    .buttonStyle(.borderless)
-                    .font(.caption)
+                Button("Tick every box", systemImage: "checklist") { model.tickTemplateBoxes() }
+                    .buttonStyle(.glass)
+                    .controlSize(.small)
                     .disabled(isGenerating || model.prTemplate.contains("[ ]") == false)
                     .hoverHelp("Tick every unticked checkbox in the template")
             }

--- a/Sources/PRFeature/PullRequestCreateForm.swift
+++ b/Sources/PRFeature/PullRequestCreateForm.swift
@@ -26,15 +26,7 @@ struct PullRequestCreateForm: View {
                 .border(.separator)
                 .disabled(isGenerating)
                 .hoverHelp("The description in your own words; the template below is appended after it")
-            if model.hasTemplate {
-                Text("Template").font(.caption).foregroundStyle(.secondary)
-                TextEditor(text: $model.prTemplate)
-                    .font(.body.monospaced())
-                    .frame(minHeight: Self.templateMinimumHeight)
-                    .border(.separator)
-                    .disabled(isGenerating)
-                    .hoverHelp("The repository's pull request template, editable; appended below the body")
-            }
+            templateSection
         }
         .padding(Self.spacing)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -55,6 +47,27 @@ struct PullRequestCreateForm: View {
     /// The cross-module signal that switches the utility pane's tab.
     @AppStorage("utilityTab")
     private var utilityTab = ""
+
+    /// The repository's template with its tick-all shortcut.
+    @ViewBuilder private var templateSection: some View {
+        if model.hasTemplate {
+            HStack {
+                Text("Template").font(.caption).foregroundStyle(.secondary)
+                Spacer()
+                Button("Tick every box") { model.tickTemplateBoxes() }
+                    .buttonStyle(.borderless)
+                    .font(.caption)
+                    .disabled(isGenerating || model.prTemplate.contains("[ ]") == false)
+                    .hoverHelp("Tick every unticked checkbox in the template")
+            }
+            TextEditor(text: $model.prTemplate)
+                .font(.body.monospaced())
+                .frame(minHeight: Self.templateMinimumHeight)
+                .border(.separator)
+                .disabled(isGenerating)
+                .hoverHelp("The repository's pull request template, editable; appended below the body")
+        }
+    }
 
     /// Sits inside the title field; drafting only ever fills empty
     /// fields, so any typed content dims it.

--- a/Sources/PRFeature/PullRequestListView.swift
+++ b/Sources/PRFeature/PullRequestListView.swift
@@ -206,16 +206,24 @@ struct PullRequestFooterView: View {
             prominent: true,
             // Trimmed like the validation, so a title of spaces
             // dims the button rather than failing on click; the
-            // push comes first, explicitly.
+            // push comes first, explicitly. A body drafted or typed
+            // is enough on its own, but a template still reading
+            // exactly as the repository wrote it is not: opening
+            // with its placeholders intact helps nobody.
             disabled: model.prTitle.trimmingCharacters(in: .whitespaces).isEmpty
-                || model.isFullyPushed == false,
+                || model.isFullyPushed == false
+                || model.templateUnedited,
         ) {
             if await model.createPullRequest() == false {
                 utilityTab = UtilityTabTarget.errors
             }
         }
         .keyboardShortcut(.return, modifiers: .command)
-        .hoverHelp("Open the pull request with the form's title and body (Cmd-Return); dimmed until pushed")
+        .hoverHelp(
+            model.templateUnedited
+                ? "Fill in the template before opening: it still reads as the repository wrote it"
+                : "Open the pull request with the form's title and body (Cmd-Return); dimmed until pushed",
+        )
     }
 
     /// The copy actions for the open conversation, in the footer's

--- a/Sources/PRFeature/PullRequestListView.swift
+++ b/Sources/PRFeature/PullRequestListView.swift
@@ -191,6 +191,7 @@ struct PullRequestFooterView: View {
             systemImage: "arrow.up",
             accessibilityLabel: "Push",
             disabled: model.canPush == false,
+            keepsTitle: true,
         ) {
             if await model.push() == false {
                 utilityTab = UtilityTabTarget.errors

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -188,6 +188,7 @@ extension PullRequestsModel {
             prBody = ""
             Self.requestSidebarRefresh()
             await reload(keepingSelection: true)
+            clearDraft()
             return true
         } catch {
             ErrorLog.shared.report(error.localizedDescription)

--- a/Sources/PRFeature/PullRequestsModel+Draft.swift
+++ b/Sources/PRFeature/PullRequestsModel+Draft.swift
@@ -1,0 +1,81 @@
+import AgentIDEData
+import AgentIDEDomain
+
+/// The creation form's draft persistence and template helpers, split
+/// from the model body for length: a branch's unfinished title, body
+/// and template survive leaving the tab and quitting the app.
+extension PullRequestsModel {
+    /// Whether the last fetch filled its limit, so more pages may
+    /// exist beyond what is loaded.
+    var hasMore: Bool {
+        summaries.isEmpty == false && summaries.count == fetchedLimit
+    }
+
+    /// Where a branch's draft is stored, nil without a branch.
+    var draftKey: String? {
+        listedBranch.map { repository.path + "#" + $0 }
+    }
+
+    /// Whether the template still reads as the repository's own: a
+    /// pull request opened with its placeholders intact helps nobody,
+    /// so Open PR waits for it to be filled in.
+    var templateUnedited: Bool {
+        hasTemplate && prTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
+            == originalTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Ticks every unticked markdown checkbox in the template, the
+    /// one thing every template review does by hand.
+    func tickTemplateBoxes() {
+        prTemplate = prTemplate
+            .replacing("- [ ]", with: "- [x]")
+            .replacing("* [ ]", with: "* [x]")
+    }
+
+    /// Saves the drafted title, body and template for this branch as
+    /// they change; the model itself is rebuilt whenever the branch
+    /// changes, which is what used to lose the writing.
+    func saveDraft() {
+        guard loadingDraft == false, let key = draftKey else {
+            return
+        }
+
+        var metadata = store.load()
+        metadata.pullRequestDrafts[key] = PullRequestFormDraft(
+            title: prTitle,
+            body: prBody,
+            template: prTemplate,
+        )
+        store.save(metadata)
+    }
+
+    /// Restores a saved draft, if any; reload calls this before the
+    /// template is fetched, so typed text always wins over it.
+    func loadDraft() {
+        guard let key = draftKey, let draft = store.load().pullRequestDrafts[key] else {
+            return
+        }
+
+        loadingDraft = true
+        prTitle = draft.title
+        prBody = draft.body
+        prTemplate = draft.template
+        loadingDraft = false
+    }
+
+    /// Forgets a branch's draft once its pull request exists.
+    func clearDraft() {
+        guard let key = draftKey else {
+            return
+        }
+
+        var metadata = store.load()
+        metadata.pullRequestDrafts.removeValue(forKey: key)
+        store.save(metadata)
+        loadingDraft = true
+        prTitle = ""
+        prBody = ""
+        prTemplate = ""
+        loadingDraft = false
+    }
+}

--- a/Sources/PRFeature/PullRequestsModel+Draft.swift
+++ b/Sources/PRFeature/PullRequestsModel+Draft.swift
@@ -11,6 +11,20 @@ extension PullRequestsModel {
         summaries.isEmpty == false && summaries.count == fetchedLimit
     }
 
+    /// Paints the stored listing for this scope, if any. A cached
+    /// listing decides the creation form as surely as a fetched one,
+    /// so returning to the tab shows it instantly rather than a
+    /// loading state.
+    func paintCachedListing() {
+        guard let cached = store.load().pullRequestListsCache[cacheKey]?.summaries else {
+            summaries = []
+            return
+        }
+
+        summaries = cached
+        hasLoaded = true
+    }
+
     /// Where a branch's draft is stored, nil without a branch.
     var draftKey: String? {
         listedBranch.map { repository.path + "#" + $0 }

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -133,12 +133,12 @@ final class PullRequestsModel {
     /// The selected conversation; the view writes nil to go back.
     var selected: PullRequestSummary?
 
-    private(set) var summaries: [PullRequestSummary] = []
+    var summaries: [PullRequestSummary] = []
     private(set) var isLoading = false
 
     /// True once the first listing answered; the creation form only
     /// appears after that, and mid-reload churn never hides it.
-    private(set) var hasLoaded = false
+    var hasLoaded = false
     private(set) var fetchedLimit = 0
     private(set) var hasMergeQueue = false
 
@@ -284,6 +284,10 @@ final class PullRequestsModel {
         currentBranch ?? branch
     }
 
+    var cacheKey: String {
+        repository.path + "#" + String(describing: scope) + "#" + (listedBranch ?? "")
+    }
+
     /// Where a branch's draft is stored, nil without a branch.
     func loadMergeQueue() async {
         hasMergeQueue = await fetchHasMergeQueue()
@@ -314,7 +318,7 @@ final class PullRequestsModel {
         if extending == false {
             page = 0
             selected = nil
-            summaries = store.load().pullRequestListsCache[cacheKey]?.summaries ?? []
+            paintCachedListing()
         }
         defer {
             isLoading = false
@@ -370,8 +374,4 @@ final class PullRequestsModel {
     /// Fetches stay one page ahead of the visible one, so the pager
     /// knows whether a next page exists.
     private static let pageLookahead = 2
-
-    private var cacheKey: String {
-        repository.path + "#" + String(describing: scope) + "#" + (listedBranch ?? "")
-    }
 }

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -146,11 +146,13 @@ final class PullRequestsModel {
     /// extension.
     var status: String?
 
-    /// The pull request creation form's fields; the template loads
-    /// from the repository on reload when the form shows.
-    var prTitle = ""
-    var prBody = ""
-    var prTemplate = ""
+    /// The template as the repository wrote it, so Open PR can wait
+    /// for it to be filled in rather than opened with placeholders.
+    var originalTemplate = ""
+
+    /// Suppresses saving while a draft is restored, so restoring
+    /// never writes back what it just read.
+    var loadingDraft = false
 
     /// Whether the repository has a pull request template; without
     /// one the form shows no template field at all.
@@ -175,6 +177,20 @@ final class PullRequestsModel {
     var performPush: (Worktree) async throws -> Void
     var performRebase: (Worktree) async throws -> Void
     var checkTipSigned: (String) async -> Bool
+
+    /// The pull request creation form's fields; the template loads
+    /// from the repository on reload when the form shows.
+    var prTitle = "" {
+        didSet { saveDraft() }
+    }
+
+    var prBody = "" {
+        didSet { saveDraft() }
+    }
+
+    var prTemplate = "" {
+        didSet { saveDraft() }
+    }
 
     /// Whether the list pane shows the creation form instead: the
     /// worktree scope with no open pull request for the branch.
@@ -212,10 +228,6 @@ final class PullRequestsModel {
 
     /// Whether the last fetch filled its limit, so more pages may
     /// exist beyond what is loaded.
-    var hasMore: Bool {
-        summaries.isEmpty == false && summaries.count == fetchedLimit
-    }
-
     var branchItem: WorktreeItem? {
         items.first { $0.worktree.branch == branch }
     }
@@ -272,6 +284,7 @@ final class PullRequestsModel {
         currentBranch ?? branch
     }
 
+    /// Where a branch's draft is stored, nil without a branch.
     func loadMergeQueue() async {
         hasMergeQueue = await fetchHasMergeQueue()
     }
@@ -288,8 +301,10 @@ final class PullRequestsModel {
             rebaseNeed = await fetchRebaseNeed(worktree)
             let template = fetchTemplate(worktree.path)
             hasTemplate = template != nil
+            loadDraft()
+            originalTemplate = template ?? ""
             if prTemplate.isEmpty {
-                prTemplate = template ?? ""
+                prTemplate = originalTemplate
             }
             await prefillFromSingleCommit(worktree)
             if let live = await fetchCurrentBranch(worktree.path) {

--- a/Sources/ReviewFeature/DiffFileView.swift
+++ b/Sources/ReviewFeature/DiffFileView.swift
@@ -69,27 +69,7 @@ struct DiffFileView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Self.lineSpacing) {
-            HStack {
-                FileCollapseCaret(isCollapsed: isCollapsed, onToggle: onToggleCollapse)
-                Text(file.path).font(.headline.monospaced())
-                Spacer()
-                DiffStatText(additions: file.additions, deletions: file.deletions)
-                Button {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(file.path, forType: .string)
-                } label: {
-                    Image(systemName: "doc.on.doc")
-                        .accessibilityLabel("Copy file path")
-                }
-                .buttonStyle(.borderless)
-                .hoverHelp("Copy this file's path to the clipboard")
-                Button(action: onEdit) {
-                    Image(systemName: "pencil")
-                        .accessibilityLabel("Edit file")
-                }
-                .buttonStyle(.borderless)
-                .hoverHelp("Open this file in the built-in editor for review-time fixes")
-            }
+            headerRow
             if isCollapsed == false {
                 ForEach(Array(file.hunks.enumerated()), id: \.offset) { hunkIndex, hunk in
                     hunkView(hunkIndex: hunkIndex, hunk: hunk)
@@ -102,6 +82,7 @@ struct DiffFileView: View {
     // MARK: Private
 
     private static let collapsedPadding: CGFloat = 1
+
     private static let lineSpacing: CGFloat = 2
     private static let gutterSpacing: CGFloat = 6
     private static let selectionBarWidth: CGFloat = 3
@@ -109,6 +90,38 @@ struct DiffFileView: View {
     private static let selectedOpacity = 0.35
     private static let filePadding: CGFloat = 8
     private static let numberWidth = 4
+
+    /// The file's name, its new-file marker, diffstat and the
+    /// copy and edit actions.
+    private var headerRow: some View {
+        HStack {
+            FileCollapseCaret(isCollapsed: isCollapsed, onToggle: onToggleCollapse)
+            Text(file.path).font(.headline.monospaced())
+            if file.isNew {
+                Text("new file")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .hoverHelp("Added or untracked: the whole file is the diff, so it starts collapsed")
+            }
+            Spacer()
+            DiffStatText(additions: file.additions, deletions: file.deletions)
+            Button {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(file.path, forType: .string)
+            } label: {
+                Image(systemName: "doc.on.doc")
+                    .accessibilityLabel("Copy file path")
+            }
+            .buttonStyle(.borderless)
+            .hoverHelp("Copy this file's path to the clipboard")
+            Button(action: onEdit) {
+                Image(systemName: "pencil")
+                    .accessibilityLabel("Edit file")
+            }
+            .buttonStyle(.borderless)
+            .hoverHelp("Open this file in the built-in editor for review-time fixes")
+        }
+    }
 
     /// Numbers and markers sit in a tappable gutter while the code
     /// itself is one selectable text block, so dragging copies
@@ -338,18 +351,27 @@ struct ReviewFileListView: View {
 
     @ViewBuilder
     private func fileSection(_ file: DiffFile) -> some View {
-        if model.showsUncommitted {
-            uncommittedFile(file)
-        } else {
-            DiffFileView(
-                file: file,
-                model: model,
-                isCollapsed: isCollapsed(file),
-                onToggleCollapse: { toggleCollapse(file) },
-                onEdit: {
-                    FileOpener.open(relativePath: file.path, line: nil, worktreePath: worktreePath)
-                },
+        // Every scope leads with the diff, uncommitted included: it
+        // once showed the whole file in an editor instead, which read
+        // as a broken diff. Uncommitted files keep that editor for
+        // fixing in place, below their diff.
+        DiffFileView(
+            file: file,
+            model: model,
+            isCollapsed: isCollapsed(file),
+            onToggleCollapse: { toggleCollapse(file) },
+            onEdit: {
+                FileOpener.open(relativePath: file.path, line: nil, worktreePath: worktreePath)
+            },
+        )
+        if model.showsUncommitted, isCollapsed(file) == false, file.isNew == false {
+            FileEditorView(
+                worktreePath: worktreePath,
+                relativePath: file.path,
+                service: service,
+                showsClose: false,
             )
+            .frame(minHeight: Self.editorMinimumHeight, maxHeight: Self.editorMaximumHeight)
         }
         if isCollapsed(file) == false {
             ForEach(model.threads(for: file.path)) { thread in
@@ -364,33 +386,10 @@ struct ReviewFileListView: View {
         }
     }
 
-    /// Uncommitted changes edit in place: the shared editor embeds
-    /// under the caret, so fixes are typed directly and saved with
-    /// Cmd-S or the save button.
-    @ViewBuilder
-    private func uncommittedFile(_ file: DiffFile) -> some View {
-        HStack {
-            FileCollapseCaret(isCollapsed: isCollapsed(file)) { toggleCollapse(file) }
-            if isCollapsed(file) {
-                Text(file.path).font(.headline.monospaced())
-            }
-            Spacer(minLength: 0)
-        }
-        if isCollapsed(file) == false {
-            FileEditorView(
-                worktreePath: worktreePath,
-                relativePath: file.path,
-                service: service,
-                showsClose: false,
-            )
-            .frame(minHeight: Self.editorMinimumHeight, maxHeight: Self.editorMaximumHeight)
-        }
-    }
-
     private func isCollapsed(_ file: DiffFile) -> Bool {
         // Generated files always start collapsed, whatever the
         // expand-all state says; only their own caret opens them.
-        collapseOverrides[file.path] ?? (hideAllByDefault || model.isGenerated(file.path))
+        collapseOverrides[file.path] ?? (hideAllByDefault || model.isGenerated(file.path) || file.isNew)
     }
 
     private func toggleCollapse(_ file: DiffFile) {

--- a/Sources/ReviewFeature/ReviewFooterView.swift
+++ b/Sources/ReviewFeature/ReviewFooterView.swift
@@ -51,7 +51,7 @@ struct ReviewFooterView: View {
     private static let subjectLimit = 50
     private static let bodyLimit = 72
 
-    private static let messageHeightRange: ClosedRange<Double> = 60 ... 400
+    private static let messageHeightRange: ClosedRange<Double> = 90 ... 600
     private static let fieldInset: CGFloat = 5
     private static let resizeHandleHeight: CGFloat = 7
 
@@ -62,7 +62,7 @@ struct ReviewFooterView: View {
     /// The footer's height, dragged by the handle above it and
     /// persisted like the pane widths.
     @AppStorage("reviewMessageHeight")
-    private var messageHeight = 88.0
+    private var messageHeight = 150.0
     @State private var messageDragBase: Double?
 
     /// The commit listing coloured like git log: hashes orange,
@@ -129,8 +129,14 @@ struct ReviewFooterView: View {
             "Draft the commit message from the uncommitted diff with the on-device model; "
                 + "only fills an empty message",
         )
-        BusyButton("Commit", busy: "Committing", disabled: canCommit == false, action: onCommit)
-            .hoverHelp("Commit everything uncommitted; enabled on the uncommitted scope with changes")
+        BusyButton(
+            "Commit",
+            busy: "Committing",
+            disabled: canCommit == false,
+            keepsTitle: true,
+            action: onCommit,
+        )
+        .hoverHelp("Commit everything uncommitted; enabled on the uncommitted scope with changes")
         BusyButton(
             "Amend",
             busy: "Amending",

--- a/Sources/ReviewFeature/ReviewFooterView.swift
+++ b/Sources/ReviewFeature/ReviewFooterView.swift
@@ -55,6 +55,10 @@ struct ReviewFooterView: View {
     private static let fieldInset: CGFloat = 5
     private static let resizeHandleHeight: CGFloat = 7
 
+    /// The cross-module signal that switches the utility pane's tab.
+    @AppStorage("utilityTab")
+    private var utilityTab = ""
+
     /// The footer's height, dragged by the handle above it and
     /// persisted like the pane widths.
     @AppStorage("reviewMessageHeight")
@@ -87,6 +91,52 @@ struct ReviewFooterView: View {
             get: { Self.messageBody(of: model.commitMessage) },
             set: { model.commitMessage = Self.message(subject: Self.subject(of: model.commitMessage), body: $0) },
         )
+    }
+
+    /// The message lengths and status beside the drafting,
+    /// commit and amend actions, in click order.
+    private var actionRow: some View {
+        HStack {
+            messageLengths
+            if let status = model.status {
+                // Selectable so failures can be copied out.
+                Text(status)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .textSelection(.enabled)
+            }
+            Spacer()
+            messageButtons
+        }
+    }
+
+    /// Drafting, committing and amending, in click order.
+    @ViewBuilder private var messageButtons: some View {
+        BusyButton(
+            "",
+            busy: "",
+            systemImage: "sparkles",
+            accessibilityLabel: "Draft commit message",
+            disabled: model.showsUncommitted == false
+                || model.commitMessage.trimmingCharacters(in: .whitespaces).isEmpty == false,
+        ) {
+            if await model.generateCommitMessage() == false {
+                utilityTab = UtilityTabTarget.errors
+            }
+        }
+        .hoverHelp(
+            "Draft the commit message from the uncommitted diff with the on-device model; "
+                + "only fills an empty message",
+        )
+        BusyButton("Commit", busy: "Committing", disabled: canCommit == false, action: onCommit)
+            .hoverHelp("Commit everything uncommitted; enabled on the uncommitted scope with changes")
+        BusyButton(
+            "Amend",
+            busy: "Amending",
+            disabled: model.showsUncommitted || model.messageEdited == false,
+        ) { await model.saveCommitMessage() }
+            .hoverHelp("Rewrite the last commit's message; dimmed until the text differs from it")
     }
 
     /// A slim grab area over the divider: dragging resizes the
@@ -154,26 +204,7 @@ struct ReviewFooterView: View {
         } else {
             VStack(alignment: .leading, spacing: Self.footerPadding) {
                 messageEditor
-                HStack {
-                    messageLengths
-                    if let status = model.status {
-                        // Selectable so failures can be copied out.
-                        Text(status)
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .textSelection(.enabled)
-                    }
-                    Spacer()
-                    BusyButton("Commit", busy: "Committing", disabled: canCommit == false, action: onCommit)
-                        .hoverHelp("Commit everything uncommitted; enabled on the uncommitted scope with changes")
-                    BusyButton(
-                        "Amend",
-                        busy: "Amending",
-                        disabled: model.showsUncommitted || model.messageEdited == false,
-                    ) { await model.saveCommitMessage() }
-                        .hoverHelp("Rewrite the last commit's message; dimmed until the text differs from it")
-                }
+                actionRow
             }
             .padding(Self.footerPadding)
         }

--- a/Sources/ReviewFeature/ReviewModel.swift
+++ b/Sources/ReviewFeature/ReviewModel.swift
@@ -17,6 +17,7 @@ final class ReviewModel {
         worktreePath: String,
         git: GitClient,
         baseRefProvider: @escaping () async -> String? = { nil },
+        draftMessage: @escaping () async -> String? = { nil },
         fetchThreads: @escaping () async -> [ReviewThread] = { [] },
         setThreadResolved: @escaping (String, Bool) async throws -> Void = { _, _ in
             // Without GitHub wiring resolve toggles are no-ops.
@@ -24,6 +25,7 @@ final class ReviewModel {
     ) {
         self.worktreePath = worktreePath
         self.git = git
+        self.draftMessage = draftMessage
         self.baseRefProvider = baseRefProvider
         self.fetchThreads = fetchThreads
         self.setThreadResolved = setThreadResolved
@@ -151,12 +153,35 @@ final class ReviewModel {
                 showsUncommitted = false
                 try await loadBranch()
             }
-            commitMessage = try await git.lastCommitMessage(worktreePath: worktreePath)
-            originalMessage = commitMessage
+            // Uncommitted work has no message yet: prefilling the
+            // last commit's invited amending it by accident, so the
+            // field stays as typed and the sparkles button drafts one.
+            if showsUncommitted {
+                originalMessage = ""
+            } else {
+                commitMessage = try await git.lastCommitMessage(worktreePath: worktreePath)
+                originalMessage = commitMessage
+            }
             threads = await fetchThreads()
         } catch {
             report(error.localizedDescription)
         }
+    }
+
+    /// Fills the commit message from the uncommitted diff using the
+    /// on-device model; false when it could not help, so the caller
+    /// can show the errors surface. Only ever fills a blank field.
+    func generateCommitMessage() async -> Bool {
+        guard commitMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return true
+        }
+        guard let drafted = await draftMessage() else {
+            report("The on-device model could not draft a commit message for these changes.")
+            return false
+        }
+
+        commitMessage = drafted
+        return true
     }
 
     /// Reports a failure into the app-wide error log; the local
@@ -216,6 +241,7 @@ final class ReviewModel {
 
     private let worktreePath: String
     private let git: GitClient
+    private let draftMessage: () async -> String?
     private let baseRefProvider: () async -> String?
     private let fetchThreads: () async -> [ReviewThread]
     private let setThreadResolved: (String, Bool) async throws -> Void

--- a/Sources/ReviewFeature/ReviewModel.swift
+++ b/Sources/ReviewFeature/ReviewModel.swift
@@ -157,6 +157,13 @@ final class ReviewModel {
             // last commit's invited amending it by accident, so the
             // field stays as typed and the sparkles button drafts one.
             if showsUncommitted {
+                // Switching scopes must not carry a commit's message
+                // into uncommitted work, where Commit would reuse it;
+                // anything typed here survives, since only an
+                // unedited message came from a commit.
+                if messageEdited == false {
+                    commitMessage = ""
+                }
                 originalMessage = ""
             } else {
                 commitMessage = try await git.lastCommitMessage(worktreePath: worktreePath)

--- a/Sources/ReviewFeature/ReviewView.swift
+++ b/Sources/ReviewFeature/ReviewView.swift
@@ -46,6 +46,7 @@ public struct ReviewView: View {
                 worktreePath: worktree.path,
                 git: git,
                 baseRefProvider: { await service.reviewBase(for: worktree) },
+                draftMessage: { await service.draftCommitMessage(worktreePath: worktree.path) },
                 fetchThreads: fetchThreads,
                 setThreadResolved: setThreadResolved,
             )

--- a/Sources/SessionFeature/RepositorySessionsView.swift
+++ b/Sources/SessionFeature/RepositorySessionsView.swift
@@ -12,7 +12,7 @@ public struct RepositorySessionsView: View {
     // MARK: Lifecycle
 
     /// Creates the browser; `worktreePath` scopes the list to one
-    /// worktree, `onNewSession` opens the new session page,
+    /// worktree,
     /// `onResumed` runs after a resume launches and
     /// `onWorktreeFocus` reports the selected conversation's still
     /// existing worktree, so other panes can follow along.
@@ -21,11 +21,9 @@ public struct RepositorySessionsView: View {
         repository: Repository,
         service: SessionService,
         worktreePath: String? = nil,
-        onNewSession: (@MainActor () -> Void)? = nil,
         onWorktreeFocus: (@MainActor (String?) -> Void)? = nil,
         onResumed: @escaping @MainActor () async -> Void,
     ) {
-        self.onNewSession = onNewSession
         self.onWorktreeFocus = onWorktreeFocus
         self.onResumed = onResumed
         identity = repository.id + "#" + (worktreePath ?? "")
@@ -92,7 +90,6 @@ public struct RepositorySessionsView: View {
     @State private var model: RepositorySessionsModel
 
     private let identity: String
-    private let onNewSession: (@MainActor () -> Void)?
     private let onWorktreeFocus: (@MainActor (String?) -> Void)?
     private let onResumed: @MainActor () async -> Void
     private let makeModel: () -> RepositorySessionsModel
@@ -106,11 +103,6 @@ public struct RepositorySessionsView: View {
             )
             .font(.subheadline.weight(.semibold))
             Spacer()
-            if let onNewSession {
-                Button("New session", action: onNewSession)
-                    .controlSize(.small)
-                    .hoverHelp("Start a fresh agent session in this repository instead of resuming")
-            }
             // One resume button: in place when the conversation's
             // worktree still exists, into a fresh worktree only when
             // it is gone and that is all that can be done.

--- a/Sources/TerminalUI/BusyButton.swift
+++ b/Sources/TerminalUI/BusyButton.swift
@@ -8,7 +8,9 @@ public struct BusyButton: View {
     // MARK: Lifecycle
 
     /// Creates the button; `busy` is the label shown while the
-    /// action runs, such as Fixing for Fix. With `systemImage` the
+    /// action runs, such as Fixing for Fix. `keepsTitle` holds the
+    /// label still and only dims, for surfaces whose status line
+    /// already narrates the work. With `systemImage` the
     /// icon leads and an empty title is fine, but VoiceOver then
     /// needs `accessibilityLabel`. `prominent` marks a surface's one
     /// primary action.
@@ -20,10 +22,11 @@ public struct BusyButton: View {
         accessibilityLabel: String? = nil,
         prominent: Bool = false,
         disabled: Bool = false,
+        keepsTitle: Bool = false,
         action: @escaping @MainActor () async -> Void,
     ) {
         self.title = title
-        busyTitle = busy
+        busyTitle = keepsTitle ? title : busy
         self.systemImage = systemImage
         spokenLabel = accessibilityLabel
         isProminent = prominent

--- a/Sources/TerminalUI/MarkdownText+Parsing.swift
+++ b/Sources/TerminalUI/MarkdownText+Parsing.swift
@@ -126,7 +126,34 @@ extension MarkdownText {
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace,
         )
-        return (try? AttributedString(markdown: text, options: options)) ?? AttributedString(text)
+        let source = ticked(text)
+        return (try? AttributedString(markdown: source, options: options)) ?? AttributedString(source)
+    }
+
+    /// Task list markers render as their box glyphs: markdown's
+    /// inline parser leaves `- [x]` as literal brackets, so a
+    /// checklist read as punctuation rather than state.
+    static func ticked(_ text: String) -> String {
+        text.split(separator: "\n", omittingEmptySubsequences: false)
+            .map { tickedLine(String($0)) }
+            .joined(separator: "\n")
+    }
+
+    /// One line's task marker as its box glyph, the indentation and
+    /// list marker kept so nesting still reads.
+    private static func tickedLine(_ line: String) -> String {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        for marker in ["- ", "* ", "+ "] where trimmed.hasPrefix(marker) {
+            let rest = String(trimmed.dropFirst(marker.count))
+            let indent = String(line.prefix(while: \.isWhitespace))
+            if rest.hasPrefix("[ ] ") {
+                return indent + marker + "\u{2610} " + rest.dropFirst("[ ] ".count)
+            }
+            if rest.lowercased().hasPrefix("[x] ") {
+                return indent + marker + "\u{2611} " + rest.dropFirst("[x] ".count)
+            }
+        }
+        return line
     }
 
     /// Merges consecutive prose into one block; the regenerated

--- a/Sources/TerminalUI/PaneTerminalView.swift
+++ b/Sources/TerminalUI/PaneTerminalView.swift
@@ -193,7 +193,12 @@ final class BlockSelector {
                 continue
             }
 
+            // Cells never written hold NUL; the pasteboard must carry
+            // spaces there, as SwiftTerm's own copy does, or a pasted
+            // script arrives peppered with ^@ where its indentation
+            // and word gaps were.
             let text = line.translateToString(trimRight: true, startCol: left, endCol: right + 1)
+                .replacing("\u{0}", with: " ")
             lines.append(PasteableText.strippingGutter(text))
         }
         let joined = lines.joined(separator: "\n")

--- a/Sources/TerminalUI/TerminalPaneView.swift
+++ b/Sources/TerminalUI/TerminalPaneView.swift
@@ -55,11 +55,18 @@ public struct TerminalPaneView: View {
             transport: transport,
             reflowsCopies: reflowsCopies,
             isActive: isActive,
+            clearRequest: clearShellRequest,
             onProcessTerminated: onProcessTerminated,
         )
     }
 
     // MARK: Private
+
+    /// Cmd-K's counter on the storage bus; only an active local
+    /// shell pane acts on it, never an agent pane, so clearing can
+    /// never wipe an agent's conversation from view.
+    @AppStorage("clearShellRequest")
+    private var clearShellRequest = 0
 
     private let transport: TerminalTransport
     private let reflowsCopies: Bool
@@ -86,6 +93,7 @@ struct TerminalRepresentable: NSViewRepresentable {
     let transport: TerminalTransport
     let reflowsCopies: Bool
     let isActive: Bool
+    let clearRequest: Int
     let onProcessTerminated: (@MainActor () -> Void)?
 
     /// Detaches the coordinator's client with the view.
@@ -124,6 +132,9 @@ struct TerminalRepresentable: NSViewRepresentable {
         applyTheme(to: view, context: context)
         context.coordinator.startWhenSized(transport, in: view)
         context.coordinator.updateFocus(isActive: isActive, of: view)
+        if case .shell = transport, isActive {
+            context.coordinator.clearIfRequested(clearRequest, in: view)
+        }
     }
 
     /// Creates the control mode coordinator.

--- a/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
+++ b/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
@@ -163,12 +163,26 @@ extension TerminalRepresentable {
             sendCommand(TmuxControl.resizeCommand(columns: newCols, rows: newRows), expecting: .acknowledgement)
         }
 
+        /// Bytes for the pane. A bracketed paste arrives as three
+        /// separate sends (start marker, text, end marker); shipped as
+        /// three commands, the pieces could straddle the agent's input
+        /// reads and Codex dropped the paste as unterminated. Bytes
+        /// are therefore gathered for one run loop turn and shipped
+        /// as one command, so a paste lands in a single write.
         func send(source _: TerminalView, data: ArraySlice<UInt8>) {
             guard data.isEmpty == false else {
                 return
             }
 
-            sendCommand(TmuxControl.sendKeysCommand(bytes: data), expecting: .acknowledgement)
+            outgoing.append(contentsOf: data)
+            guard flushScheduled == false else {
+                return
+            }
+
+            flushScheduled = true
+            DispatchQueue.main.async { [weak self] in
+                self?.flushOutgoing()
+            }
         }
 
         func setTerminalTitle(source _: TerminalView, title _: String) {
@@ -206,6 +220,8 @@ extension TerminalRepresentable {
 
         private var started = false
         private var seenClearRequest: Int?
+        private var outgoing: [UInt8] = []
+        private var flushScheduled = false
         private var startedTransport: TerminalTransport?
         private var blockMonitor: Any?
         private var frameObserver: NSObjectProtocol?
@@ -213,6 +229,19 @@ extension TerminalRepresentable {
         private var pendingTransport: TerminalTransport?
 
         private var pump: Task<Void, Never>?
+
+        /// Ships everything gathered since the last turn as one
+        /// `send-keys`, in order.
+        private func flushOutgoing() {
+            flushScheduled = false
+            let bytes = outgoing
+            outgoing.removeAll(keepingCapacity: true)
+            guard bytes.isEmpty == false else {
+                return
+            }
+
+            sendCommand(TmuxControl.sendKeysCommand(bytes: bytes), expecting: .acknowledgement)
+        }
 
         /// Drops the running client and resets the conversation
         /// state so a new command can attach through the same view;

--- a/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
+++ b/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
@@ -120,6 +120,26 @@ extension TerminalRepresentable {
             }
         }
 
+        /// Cmd-K on the shell: a full terminal reset wipes the screen
+        /// and local scrollback, then Ctrl-L asks the running shell to
+        /// redraw its prompt, which is what a terminal app's clear
+        /// does. Each raise of the counter clears once; the first
+        /// observed value only records the baseline, so a stale count
+        /// from a previous launch never clears on appearance.
+        func clearIfRequested(_ request: Int, in view: PaneTerminalView) {
+            guard let seen = seenClearRequest else {
+                seenClearRequest = request
+                return
+            }
+            guard request != seen else {
+                return
+            }
+
+            seenClearRequest = request
+            view.feed(text: "\u{1B}c")
+            view.send(txt: "\u{0C}")
+        }
+
         /// Releases keyboard focus when the pane goes invisible: the
         /// shell stays mounted behind other tabs to survive
         /// switches, and a hidden terminal holding first responder
@@ -185,6 +205,7 @@ extension TerminalRepresentable {
         // MARK: Private
 
         private var started = false
+        private var seenClearRequest: Int?
         private var startedTransport: TerminalTransport?
         private var blockMonitor: Any?
         private var frameObserver: NSObjectProtocol?

--- a/Tests/AgentIDEDataTests/FailingChecksTests.swift
+++ b/Tests/AgentIDEDataTests/FailingChecksTests.swift
@@ -1,0 +1,36 @@
+@testable import AgentIDEData
+import Testing
+
+/// Pins what a failing run's logs paste as: the copy button once
+/// produced the head of a long run log, which is setup noise, and
+/// carried every line's job and step prefix with it.
+struct FailingChecksTests {
+    @Test
+    func `the excerpt keeps the failure, not the start of the log`() {
+        let noise = (1 ... 200).map { "build\ttest\tstep line \($0)" }.joined(separator: "\n")
+        let log = noise + "\nbuild\ttest\terror: the thing broke\nbuild\ttest\ttrailing context"
+        let excerpt = GitHubClient.failureExcerpt(fromRunLog: log)
+        #expect(excerpt.contains("error: the thing broke"))
+        #expect(excerpt.contains("trailing context"))
+        // The head of the log is what used to fill the clipboard.
+        #expect(excerpt.contains("step line 1\n") == false)
+        // The repeated job and step prefix names the step once.
+        #expect(excerpt.hasPrefix("build / test\n"))
+        #expect(excerpt.contains("build\ttest\t") == false)
+    }
+
+    @Test
+    func `each failed step keeps its own tail`() {
+        let log = [
+            "build\tcompile\tcompiling",
+            "build\tcompile\terror: first failure",
+            "build\ttest\trunning",
+            "build\ttest\terror: second failure",
+        ].joined(separator: "\n")
+        let excerpt = GitHubClient.failureExcerpt(fromRunLog: log)
+        #expect(excerpt.contains("error: first failure"))
+        #expect(excerpt.contains("error: second failure"))
+        #expect(excerpt.contains("build / compile"))
+        #expect(excerpt.contains("build / test"))
+    }
+}

--- a/Tests/AgentIDEDataTests/SessionServiceIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/SessionServiceIntegrationTests.swift
@@ -129,6 +129,43 @@ struct SessionServiceIntegrationTests {
     }
 
     @Test
+    func `merge cleanup refuses dirty and unmerged worktrees and removes merged ones`() async throws {
+        let world = try await World.make()
+        defer { world.tearDown() }
+
+        let sessionName = try await world.service.createSession(
+            repository: world.repository,
+            prompt: "Anchor work",
+            agent: .claudeCode,
+        )
+        var overview = await world.service.overview()
+        var item = try #require(overview.groups.first?.items.first { $0.worktree.branch.hasPrefix("anchor_work") })
+        try await world.service.closeSession(sessionName: sessionName, worktreePath: item.worktree.path)
+        let git = GitClient(runner: FoundationProcessRunner())
+        let base = "main"
+
+        // Uncommitted changes: refused before anything runs.
+        try "draft\n".write(toFile: item.worktree.path + "/draft.txt", atomically: true, encoding: .utf8)
+        #expect(try await world.service.cleanUpMergedWorktree(item: item, baseRef: base) == .dirty)
+        #expect(FileManager.default.fileExists(atPath: item.worktree.path))
+
+        // A commit the base lacks: refused, since `-d` would refuse.
+        try await git.commitAll(worktreePath: item.worktree.path, message: "Unmerged work")
+        #expect(try await world.service.cleanUpMergedWorktree(item: item, baseRef: base) == .unmerged)
+        #expect(FileManager.default.fileExists(atPath: item.worktree.path))
+
+        // Once the base carries every commit, the safe path removes it:
+        // the fixture's main has no work of its own, so moving it to
+        // the branch tip is a fast-forward merge.
+        try await git.checkout(worktreePath: world.repository.path, branch: base)
+        try await git.resetHard(worktreePath: world.repository.path, ref: item.worktree.branch)
+        overview = await world.service.overview()
+        item = try #require(overview.groups.first?.items.first { $0.worktree.branch.hasPrefix("anchor_work") })
+        #expect(try await world.service.cleanUpMergedWorktree(item: item, baseRef: base) == nil)
+        #expect(FileManager.default.fileExists(atPath: item.worktree.path) == false)
+    }
+
+    @Test
     func `past sessions are discovered and resume into a new worktree with the transcript`() async throws {
         let world = try await World.make()
         defer { world.tearDown() }

--- a/Tests/AgentIDEDomainTests/PasteableTextTests.swift
+++ b/Tests/AgentIDEDomainTests/PasteableTextTests.swift
@@ -54,4 +54,33 @@ struct PasteableTextTests {
     func `blank runs collapse to one paragraph break`() {
         #expect(PasteableText.reflow("a\n\n\n\nb") == "a\n\nb")
     }
+
+    @Test
+    func `command blocks keep their lines instead of flowing together`() {
+        // The exact shape that once pasted as one broken line: a
+        // rectangle copy of an agent's suggested commands.
+        let script = """
+        ▎ cd /Users/Shared/sv-mike/worktrees/64f574f9/administrate-sentry-audit
+        ▎ git fetch --prune
+        ▎ git checkout sentry-errors-aug-16-backend
+        ▎ git rebase --gpg-sign --force-rebase origin/HEAD
+        ▎ git push -u origin sentry-errors-aug-16-backend sentry-errors-aug-16-integrations \\
+        ▎   sentry-errors-aug-16-legacy-ui sentry-errors-aug-16-workspaces
+        """
+        let reflowed = PasteableText.reflow(script)
+        #expect(reflowed.split(separator: "\n").count == 6)
+        let firstTwo = "cd /Users/Shared/sv-mike/worktrees/64f574f9/administrate-sentry-audit\ngit fetch --prune"
+        #expect(reflowed.hasPrefix(firstTwo))
+        #expect(reflowed.contains("\\\nsentry-errors-aug-16-legacy-ui"))
+    }
+
+    @Test
+    func `prose that merely mentions a flag still reflows`() {
+        let prose = """
+        ▎ You can pass --verbose to see more, and the wrapped line
+        ▎ continues here as ordinary explanation of the option.
+        """
+        #expect(PasteableText.reflow(prose).contains("\n") == false)
+        #expect(PasteableText.looksLikeCode(["one plain sentence", "another plain sentence"]) == false)
+    }
 }

--- a/Tests/DashboardFeatureTests/MergeCleanupTests.swift
+++ b/Tests/DashboardFeatureTests/MergeCleanupTests.swift
@@ -2,6 +2,8 @@ import AgentIDEDomain
 @testable import DashboardFeature
 import Testing
 
+// MARK: - MergeCleanupTests
+
 /// Pins the rule behind automatic cleanup: only a pull request seen
 /// open at one poll and merged at the next may trigger it, never a
 /// merely missing one, so a stale cache or a branch that never had a
@@ -42,5 +44,44 @@ struct MergeCleanupTests {
             checks: "",
             state: state,
         )
+    }
+}
+
+// MARK: - CreationPlaceholderTests
+
+/// Pins the provisional row a new session shows while its worktree
+/// is created: named from the prompt in the branch style, and never
+/// mistaken for a real worktree.
+@MainActor
+struct CreationPlaceholderTests {
+    @Test
+    func `placeholder names come from the prompt's first words`() {
+        #expect(DashboardModel.placeholderName(from: "Fix the crash on launch, please") == "fix_the_crash_on")
+        #expect(DashboardModel.placeholderName(from: "   ") == "new_session")
+    }
+
+    @Test
+    func `placeholder items are recognised by their synthetic path`() {
+        let placeholder = WorktreeItem(
+            worktree: Worktree(
+                repositoryName: "repo",
+                repositoryPath: "/repo",
+                branch: "fix_the_crash",
+                path: "/repo" + DashboardModel.placeholderMarker + "fix_the_crash",
+            ),
+            session: nil,
+            isDirty: false,
+            aheadOfUpstream: nil,
+            hasUnread: false,
+        )
+        #expect(placeholder.isPlaceholder)
+        let real = WorktreeItem(
+            worktree: Worktree(repositoryName: "repo", repositoryPath: "/repo", branch: "main", path: "/repo"),
+            session: nil,
+            isDirty: false,
+            aheadOfUpstream: nil,
+            hasUnread: false,
+        )
+        #expect(real.isPlaceholder == false)
     }
 }

--- a/script/analyze
+++ b/script/analyze
@@ -29,7 +29,25 @@ if [[ -n "${SV_SESSION_ID:-}" ]]; then
   )
 fi
 
-xcodebuild "${args[@]}" clean build >"$log" 2>&1
+# A failed build must never be analysed: SwiftLint and periphery
+# both read what the build produced, so a broken or stale build
+# reports a confident "0 violations" while CI, building cleanly,
+# finds real dead code. Xcode 27 beta's swift-plugin-server also
+# fails to expand SwiftUI macros now and then, which looks exactly
+# like a compile error, so one retry separates the flake from a
+# genuine failure before giving up.
+build() {
+  xcodebuild "${args[@]}" clean build >"$log" 2>&1
+}
+
+if ! build; then
+  echo "build failed; retrying once in case the macro plugin server flaked" >&2
+  if ! build; then
+    echo "analyze aborted: the build failed, so there is nothing trustworthy to analyse" >&2
+    grep -E "error:" "$log" | head -20 >&2
+    exit 1
+  fi
+fi
 if [[ -n "${SV_SESSION_ID:-}" ]]; then
   # The sandbox's SourceKit misreads one import as unused; the
   # baseline swallows exactly that known false positive so real

--- a/script/style
+++ b/script/style
@@ -35,7 +35,11 @@ github_actions_style() {
 }
 
 docs_style() {
-  awk 'length > 72 { print FILENAME ":" FNR ": longer than 72 characters"; failed = 1 } END { exit failed }' AGENTS.md
+  # Explicit status: this awk's failure was silently lost to errexit
+  # rules for non-final commands, so over-long lines never failed
+  # the run before.
+  awk 'length > 72 { print FILENAME ":" FNR ": longer than 72 characters"; failed = 1 } END { exit failed }' \
+    AGENTS.md || return 1
   if [[ "$(readlink CLAUDE.md)" != "AGENTS.md" ]]; then
     echo "CLAUDE.md must be a symlink to AGENTS.md" >&2
     return 1
@@ -71,7 +75,45 @@ swift_style() {
   swiftlint --strict --quiet
 }
 
-shell_style
-github_actions_style
-docs_style
-swift_style
+# The four families touch disjoint files with independent tools, so
+# they run concurrently and the run takes the slowest, not the sum;
+# swift_style keeps its own two fixers sequenced since both edit the
+# same files. Each family runs in a subshell with errexit re-asserted
+# (bash suspends errexit inside conditions, which once let a family
+# whose failing command was not its last report success), writes its
+# status to a file and keeps its output whole in a log printed as one
+# block, so nothing interleaves and no exit code has to survive the
+# trip through a background job.
+scratch="$(mktemp -d -t agentide-style)"
+trap 'rm -rf "${scratch}"' EXIT
+run_family() {
+  # Direct calls, so shellcheck sees every family invoked.
+  case "$1" in
+    shell) shell_style ;;
+    github_actions) github_actions_style ;;
+    docs) docs_style ;;
+    swift) swift_style ;;
+    *) return 1 ;;
+  esac
+}
+
+families=(shell github_actions docs swift)
+for family in "${families[@]}"; do
+  (
+    status=0
+    (
+      set -e
+      run_family "${family}"
+    ) >"${scratch}/${family}.log" 2>&1 || status=$?
+    echo "${status}" >"${scratch}/${family}.status"
+  ) &
+done
+wait
+failed=0
+for family in "${families[@]}"; do
+  cat "${scratch}/${family}.log"
+  if [[ "$(cat "${scratch}/${family}.status" 2>/dev/null || echo 1)" != "0" ]]; then
+    failed=1
+  fi
+done
+exit "${failed}"


### PR DESCRIPTION
- Offer merge cleanup via multiple paths and detect merged branches
- Route new sessions through consistent repository selection logic
- Run linters in parallel with full output and explicit failure tracking
- Reset shell panes reliably with Cmd-K and local state isolation
- Display uncommitted diffs with inline context and new file indicators
- Prompt for commit drafts using AI-generated messages on empty scopes
- Preserve pull request drafts with branch-specific templates and state
- Enforce merge-safe cleanup with dirty worktree checks and explicit deletes
- Copy commands atomically with precise formatting and bracketed integrity
- Show new sessions immediately with agent-aware progress and state persistence
- Improve merge cleanup by adding support for pull request merges and worktree context menu actions, ensuring cleanup runs only when observed merge transitions occur and respects branch state
- Standardize session opening by forcing repository selection through a unified opener route that synchronises sidebar and form state
- Parallelise linter execution across disjoint files using concurrent subshells, prioritise slowest family, and ensure full output visibility with explicit status propagation
- Replace shell pane reset with Cmd-K that triggers a dedicated storage-bus counter, resetting local shell and scrollback while allowing Ctrl-L redraws
- Transform uncommitted scope to show file-level diffs first, collapse new files, and display full content only when needed
- Eliminate prefill in commit drafts by introducing a sparkles button that generates messages from uncommitted changes via on-device AI
- Enhance pull request draft persistence by saving title, body, and template per branch, restoring state on reload without losing context
- Strengthen merge safety by rejecting dirty worktrees and base branches lacking proper structure before cleanup, with explicit confirmation for deletes
- Fix command pasting by preserving exact line breaks, removing invisible characters, and shipping bracketed commands as single, atomic units
- Accelerate session creation with instant placeholder rendering and agent-integrated state restoration across form and model layers