### PR TITLE
Tidy default branch, optimize paste delivery, cache icons, handle outages

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -526,9 +526,13 @@ Sendable` and `nonisolated(unsafe)` are banned.
    merge-safe by construction: a real worktree's branch is deleted
    with `git branch -d`, which git refuses for an unmerged branch, and
    a dirty worktree is refused before anything runs; the main checkout
-   is tidied in place instead: back to the default branch, a hard reset
-   to origin when the local default carries nothing of its own, and the
-   same safe `-d` delete. A refusal reports why rather than forcing.
+   is tidied in place instead: back to the default branch, brought level
+   with origin (a reset when the local default carries nothing of its
+   own, a signed rebase when it does, so nothing local is thrown away),
+   then every branch already merged into it deleted with the same safe
+   `-d`, not only the branch that prompted the cleanup. Each step's
+   outcome, including anything it could not do, goes to the messages
+   pane rather than happening silently. A refusal reports why rather than forcing.
    Only the explicit Delete worktree action force-deletes (`--force`,
    `git branch -D`), and it confirms first with a dialog naming exactly
    what would be lost (uncommitted changes, unmerged commits); the poll

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -614,6 +614,12 @@ can neither read nor corrupt it. Deleting it loses only unread state, prompt
 history, settings and the attribution of conversations to worktrees that no
 longer exist; everything else re-derives from the system (P1).
 
+Repository icons are GitHub owner avatars, cached one per owner (not per
+repository) in `~/Library/Application Support/AgentIDE/Avatars`, so a
+sidebar of many repositories under a few owners fetches a few times and a
+GitHub outage leaves the icons showing. A failed fetch is silent: the icon
+is decoration and the messages pane is for what the user can act on.
+
 ## Security model
 
 Trust boundaries, numbered:

--- a/App/UtilityTab.swift
+++ b/App/UtilityTab.swift
@@ -57,7 +57,7 @@ enum UtilityTab: String, CaseIterable {
             "An embedded browser for dev servers the agent starts and pull request pages; logins persist"
 
         case .errors:
-            "Every failure and status message this session, in full and copyable; appears on the first error"
+            "Every failure and status message this session, in full and copyable"
         }
     }
 }

--- a/App/UtilityTabStrip.swift
+++ b/App/UtilityTabStrip.swift
@@ -11,9 +11,7 @@ struct UtilityTabStrip: View {
         // The errors tab hides until the first failure of the
         // session, then sticks around even across a clear.
         ForEach(UtilityTab.allCases, id: \.self) { tab in
-            if tab != .errors || errorLog.everReported {
-                button(tab)
-            }
+            button(tab)
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ before shipping.
 - **Defers** idle sleep while agents or shells run and resumes sessions the
   sleep killed when the Mac wakes (so a long response survives you
   walking away; closing the lid still sleeps)
-- **Collects** every failure and status message into a Messages utility tab,
-  shown from the first error and inline on screens without the utility
-  pane (so background failures are never lost to a log you were not
-  watching)
+- **Collects** every failure and status message into a Messages utility tab
+  that is always there, and shows failures inline on screens without the
+  utility pane (so nothing is lost to a status line that scrolled past or
+  a log you were not watching)
 
 ## 🚫 Out of Scope Features
 

--- a/Sources/AgentIDEData/GitClient+Branches.swift
+++ b/Sources/AgentIDEData/GitClient+Branches.swift
@@ -81,6 +81,38 @@ public extension GitClient {
         _ = try? await git(["branch", "-d", branch], in: worktreePath, allowFailure: true)
     }
 
+    /// Every local branch already merged into a ref, excluding the
+    /// ref itself and the checked-out branch: exactly the branches
+    /// `git branch -d` would accept.
+    func mergedBranches(worktreePath: String, into ref: String) async -> [String] {
+        let result = try? await git(
+            ["branch", "--merged", ref, "--format=%(refname:short)"],
+            in: worktreePath,
+            allowFailure: true,
+        )
+        guard let result, result.succeeded else {
+            return []
+        }
+
+        let current = await currentBranch(worktreePath: worktreePath)
+        let base = Self.branchName(fromRef: ref)
+        return result.standardOutput
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { name in
+                name.isEmpty == false && name != current && name != base
+                    && name.hasPrefix("(") == false
+            }
+    }
+
+    /// The bare branch name of a possibly qualified ref.
+    static func branchName(fromRef ref: String) -> String {
+        for prefix in ["refs/remotes/origin/", "refs/heads/", "origin/"] where ref.hasPrefix(prefix) {
+            return String(ref.dropFirst(prefix.count))
+        }
+        return ref
+    }
+
     /// Whether every commit of a branch is reachable from a base ref,
     /// which is what makes deleting it lossless. False when either
     /// ref is unreadable, keeping the safe path shut when in doubt.

--- a/Sources/AgentIDEData/GitHubOutage.swift
+++ b/Sources/AgentIDEData/GitHubOutage.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Tells a GitHub outage from a real failure.
+///
+/// The difference matters because the answers differ: an outage is
+/// waited out, showing what was already fetched, while a genuine
+/// failure (no such pull request, bad credentials, a rejected push)
+/// needs the user. Reporting every doomed request during an outage
+/// buries the second kind under the first.
+public enum GitHubOutage {
+    // MARK: Public
+
+    /// Whether a failure reads as GitHub being unavailable rather
+    /// than the request being wrong: its own 5xx replies, the
+    /// GraphQL gateway's overload message, and the network failing
+    /// to reach it at all.
+    public static func isLikely(_ message: String) -> Bool {
+        let lowered = message.lowercased()
+        return markers.contains { lowered.contains($0) }
+    }
+
+    /// Whether an error reads that way; errors cross module
+    /// boundaries as their descriptions.
+    public static func isLikely(_ error: any Error) -> Bool {
+        isLikely(error.localizedDescription)
+    }
+
+    // MARK: Private
+
+    /// Deliberately narrow: anything not listed counts as a real
+    /// failure and reaches the user, since silence about a broken
+    /// request is worse than noise about an outage.
+    private static let markers = [
+        "http 500", "http 502", "http 503", "http 504",
+        "no server is currently available",
+        "service unavailable",
+        "bad gateway",
+        "gateway timeout",
+        "timed out",
+        "could not resolve host",
+        "connection refused",
+        "network is unreachable",
+        "the internet connection appears to be offline",
+    ]
+}

--- a/Sources/AgentIDEData/SessionService+PullRequests.swift
+++ b/Sources/AgentIDEData/SessionService+PullRequests.swift
@@ -1,7 +1,31 @@
 import AgentIDEDomain
 
-/// Pushing branches and inspecting pull
-/// requests.
+// MARK: - MergeCleanupReport
+
+/// What a post-merge cleanup did and what it could not do, so the
+/// caller can put both in the messages pane rather than the work
+/// happening silently.
+public struct MergeCleanupReport: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates an empty report.
+    public init() {
+        // Both lists fill as the cleanup runs.
+    }
+
+    // MARK: Public
+
+    /// What the cleanup did, in order.
+    public var notes: [String] = []
+
+    /// What it could not do, each naming the step and the reason.
+    public var failures: [String] = []
+}
+
+// MARK: - Pull requests
+
+/// Pushing branches, drafting and opening pull requests, and
+/// tidying up after a merge.
 public extension SessionService {
     /// Pushes the branch to origin without opening anything. An
     /// unsigned tip refuses: every pushed commit must be GPG signed
@@ -61,31 +85,84 @@ public extension SessionService {
     /// own, and delete the merged branch with `-d` so an unmerged
     /// branch survives. Dirty checkouts and worktrees other than
     /// the main checkout are left untouched.
-    func cleanUpAfterMerge(worktree: Worktree, mergedBranch: String) async {
-        guard worktree.path == worktree.repositoryPath,
-              await git.isDirty(worktreePath: worktree.path) == false
-        else {
-            return
+    func cleanUpAfterMerge(worktree: Worktree, mergedBranch _: String) async -> MergeCleanupReport {
+        var report = MergeCleanupReport()
+        guard worktree.path == worktree.repositoryPath else {
+            return report
+        }
+        guard await git.isDirty(worktreePath: worktree.path) == false else {
+            report.failures.append("\(worktree.repositoryName) has uncommitted changes, so it was left alone.")
+            return report
         }
 
         let repository = Repository(name: worktree.repositoryName, path: worktree.repositoryPath)
-        try? await git.fetch(repositoryPath: worktree.path)
+        do {
+            try await git.fetch(repositoryPath: worktree.path)
+        } catch {
+            report.failures.append("Fetching \(worktree.repositoryName) failed: " + error.localizedDescription)
+        }
         guard let base = await git.defaultBaseRef(of: repository) else {
-            return
+            report.failures.append("\(worktree.repositoryName) has no default branch to return to.")
+            return report
         }
 
         // defaultBaseRef answers `origin/main` or a bare local name.
         let branch = Self.branchName(fromBaseRef: base)
-        guard branch != mergedBranch,
-              await (try? git.checkout(worktreePath: worktree.path, branch: branch)) != nil
-        else {
+        if await git.currentBranch(worktreePath: worktree.path) != branch {
+            do {
+                try await git.checkout(worktreePath: worktree.path, branch: branch)
+                report.notes.append("Checked out \(branch) in \(worktree.repositoryName).")
+            } catch {
+                report.failures.append("Checking out \(branch) failed: " + error.localizedDescription)
+                return report
+            }
+        }
+        await catchUp(worktreePath: worktree.path, branch: branch, into: &report)
+        await deleteMerged(worktreePath: worktree.path, branch: branch, into: &report)
+        return report
+    }
+
+    /// Brings the default branch level with origin: a checkout with
+    /// nothing of its own fast-forwards by reset, one carrying local
+    /// commits rebases them on top so nothing is thrown away.
+    private func catchUp(worktreePath: String, branch: String, into report: inout MergeCleanupReport) async {
+        let upstream = "origin/" + branch
+        guard let counts = await git.aheadBehind(worktreePath: worktreePath, baseRef: upstream) else {
+            return
+        }
+        guard counts.behind > 0 || counts.ahead > 0 else {
             return
         }
 
-        let counts = await git.aheadBehind(worktreePath: worktree.path, baseRef: "origin/" + branch)
-        if counts?.ahead == 0 {
-            try? await git.resetHard(worktreePath: worktree.path, ref: "origin/" + branch)
+        do {
+            if counts.ahead == 0 {
+                try await git.resetHard(worktreePath: worktreePath, ref: upstream)
+                report.notes.append("Pulled \(branch) up to \(upstream).")
+            } else {
+                try await git.rebaseSigned(worktreePath: worktreePath, onto: upstream)
+                report.notes.append("Rebased \(counts.ahead) local commits onto \(upstream).")
+            }
+        } catch {
+            report.failures.append("Updating \(branch) failed: " + error.localizedDescription)
         }
-        await git.deleteMergedBranch(worktreePath: worktree.path, branch: mergedBranch)
+    }
+
+    /// Deletes every branch already merged into the default branch,
+    /// not just the one that prompted the cleanup; `-d` refuses
+    /// anything unmerged, so this cannot lose work.
+    private func deleteMerged(worktreePath: String, branch: String, into report: inout MergeCleanupReport) async {
+        let merged = await git.mergedBranches(worktreePath: worktreePath, into: branch)
+        for name in merged {
+            await git.deleteMergedBranch(worktreePath: worktreePath, branch: name)
+        }
+        let remaining = await git.mergedBranches(worktreePath: worktreePath, into: branch)
+        let deleted = merged.filter { remaining.contains($0) == false }
+        if deleted.isEmpty == false {
+            report.notes.append("Deleted merged \(deleted.count == 1 ? "branch" : "branches"): "
+                + deleted.joined(separator: ", ") + ".")
+        }
+        for name in remaining {
+            report.failures.append("Deleting merged branch \(name) failed; it is still there.")
+        }
     }
 }

--- a/Sources/AgentIDEDomain/TmuxControl.swift
+++ b/Sources/AgentIDEDomain/TmuxControl.swift
@@ -14,10 +14,59 @@ public enum TmuxControl {
     /// config, and the setting only shapes panes created after it.
     public static let historyLimitCommand = "set -g history-limit 50000"
 
-    /// Types raw bytes into the attached session's active pane;
-    /// `-H` sends each hexadecimal byte as a literal character.
-    public static func sendKeysCommand(bytes: some Sequence<UInt8>) -> String {
-        "send-keys -H " + bytes.map { String($0, radix: hexRadix) }.joined(separator: " ")
+    /// The commands that deliver bytes to the attached session's
+    /// active pane, in order.
+    ///
+    /// Text goes through `send-keys -l`, which takes literal UTF-8:
+    /// `-H` names a character per hexadecimal value, not a byte, so
+    /// sending a multi-byte character's bytes through it reached the
+    /// agent as mojibake. Control bytes still go through `-H`, where
+    /// one byte is one character anyway and escape sequences (the
+    /// bracketed paste markers, Return) must arrive exactly.
+    ///
+    /// Text is chunked because a tmux command line has a practical
+    /// length limit: past it the command is dropped in silence,
+    /// which is what swallowed large pastes whole.
+    public static func sendCommands(bytes: some Sequence<UInt8>) -> [String] {
+        var commands = [String]()
+        var text = [UInt8]()
+        var control = [UInt8]()
+
+        func flushText() {
+            guard text.isEmpty == false else {
+                return
+            }
+
+            // Undecodable bytes are not text; hex keeps them exact.
+            if let decoded = String(bytes: text, encoding: .utf8) {
+                commands += literalCommands(for: decoded)
+            } else {
+                commands.append(hexCommand(for: text))
+            }
+            text = []
+        }
+
+        func flushControl() {
+            guard control.isEmpty == false else {
+                return
+            }
+
+            commands.append(hexCommand(for: control))
+            control = []
+        }
+
+        for byte in bytes {
+            if byte < asciiSpace || byte == asciiDelete {
+                flushText()
+                control.append(byte)
+            } else {
+                flushControl()
+                text.append(byte)
+            }
+        }
+        flushText()
+        flushControl()
+        return commands
     }
 
     /// Sets the control client's size, which drives the pane's.
@@ -36,8 +85,48 @@ public enum TmuxControl {
         return trimmed.isEmpty ? "" : trimmed.joined(separator: "\r\n") + "\r\n"
     }
 
+    // MARK: Internal
+
+    /// One command per chunk of literal text, single-quoted the way
+    /// tmux parses arguments; `--` keeps text that starts with a
+    /// dash from reading as a flag.
+    static func literalCommands(for text: String) -> [String] {
+        var commands = [String]()
+        var chunk = ""
+        for character in text {
+            chunk.append(character)
+            if chunk.count >= literalChunkLength {
+                commands.append("send-keys -l -- " + quoted(chunk))
+                chunk = ""
+            }
+        }
+        if chunk.isEmpty == false {
+            commands.append("send-keys -l -- " + quoted(chunk))
+        }
+        return commands
+    }
+
+    /// A tmux argument: single quotes protect everything, and a
+    /// quote of its own closes, escapes and reopens them.
+    static func quoted(_ text: String) -> String {
+        "'" + text.replacing("'", with: "'\\''") + "'"
+    }
+
     // MARK: Private
 
     /// `send-keys -H` reads bytes as hexadecimal.
     private static let hexRadix = 16
+
+    /// Characters per literal command. tmux drops a command line
+    /// somewhere past a thousand characters without saying so, and
+    /// quoting can double a chunk's length, so this stays well
+    /// under half of it.
+    private static let literalChunkLength = 400
+
+    private static let asciiSpace: UInt8 = 0x20
+    private static let asciiDelete: UInt8 = 0x7F
+
+    private static func hexCommand(for bytes: [UInt8]) -> String {
+        "send-keys -H " + bytes.map { String($0, radix: hexRadix) }.joined(separator: " ")
+    }
 }

--- a/Sources/AgentIDEDomain/TmuxControl.swift
+++ b/Sources/AgentIDEDomain/TmuxControl.swift
@@ -44,15 +44,22 @@ public enum TmuxControl {
 
         var commands = [String]()
         var chunk = ""
+        var escapedLength = 0
         for character in text {
-            chunk.append(character)
-            if chunk.count >= literalChunkLength {
-                commands.append("send-keys -l -- " + quoted(chunk))
+            let piece = escaped(character)
+            // Measured on the escaped text, since that is what tmux
+            // reads: counting source characters split pastes that
+            // would have fitted in one command comfortably.
+            if escapedLength + piece.count > escapedBudget, chunk.isEmpty == false {
+                commands.append(command(for: chunk))
                 chunk = ""
+                escapedLength = 0
             }
+            chunk.append(character)
+            escapedLength += piece.count
         }
         if chunk.isEmpty == false {
-            commands.append("send-keys -l -- " + quoted(chunk))
+            commands.append(command(for: chunk))
         }
         return commands
     }
@@ -81,38 +88,39 @@ public enum TmuxControl {
     /// (quotes, backslashes, environment variables, home directory
     /// expansion, command separators and formats) is escaped.
     static func quoted(_ text: String) -> String {
-        var escaped = ""
-        for character in text {
-            switch character {
-            case "\\":
-                escaped += "\\\\"
+        "\"" + text.map(escaped).joined() + "\""
+    }
 
-            case "\"":
-                escaped += "\\\""
+    /// One character as tmux would need to read it back.
+    static func escaped(_ character: Character) -> String {
+        switch character {
+        case "\\":
+            "\\\\"
 
-            case ";",
-                 "#",
-                 "~",
-                 "$":
-                escaped += "\\" + String(character)
+        case "\"":
+            "\\\""
 
-            case "\n":
-                escaped += "\\n"
+        case ";",
+             "#",
+             "~",
+             "$":
+            "\\" + String(character)
 
-            case "\r":
-                escaped += "\\r"
+        case "\n":
+            "\\n"
 
-            case "\t":
-                escaped += "\\t"
+        case "\r":
+            "\\r"
 
-            case "\u{1B}":
-                escaped += "\\e"
+        case "\t":
+            "\\t"
 
-            default:
-                escaped += controlEscape(character) ?? String(character)
-            }
+        case "\u{1B}":
+            "\\e"
+
+        default:
+            controlEscape(character) ?? String(character)
         }
-        return "\"" + escaped + "\""
     }
 
     // MARK: Private
@@ -120,14 +128,20 @@ public enum TmuxControl {
     /// `send-keys -H` reads bytes as hexadecimal.
     private static let hexRadix = 16
 
-    /// Characters per command. tmux carried 32,000 in one command
-    /// in testing; this leaves generous room below that even when
-    /// escaping quadruples a chunk, while keeping all but the
-    /// largest pastes in a single write.
-    private static let literalChunkLength = 4_000
+    /// Escaped characters per command. tmux carried 32,000 in one
+    /// command in testing; half of that leaves room for the command
+    /// itself and for whatever the untested ceiling really is, while
+    /// keeping every ordinary paste to a single write.
+    private static let escapedBudget = 16_000
 
     private static let asciiSpace: UInt32 = 0x20
     private static let asciiDelete: UInt32 = 0x7F
+
+    /// The command that sends one chunk literally; `--` keeps text
+    /// starting with a dash from reading as a flag.
+    private static func command(for chunk: String) -> String {
+        "send-keys -l -- " + quoted(chunk)
+    }
 
     /// Any other control character as tmux's three-digit octal
     /// escape; nil for ordinary text, which needs none.

--- a/Sources/AgentIDEDomain/TmuxControl.swift
+++ b/Sources/AgentIDEDomain/TmuxControl.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Builds the command lines a control mode client sends to tmux,
 /// kept beside the parser so both speak the same dialect. Commands
 /// omit `-t`: a control client is attached to exactly one session
@@ -17,55 +19,41 @@ public enum TmuxControl {
     /// The commands that deliver bytes to the attached session's
     /// active pane, in order.
     ///
-    /// Text goes through `send-keys -l`, which takes literal UTF-8:
-    /// `-H` names a character per hexadecimal value, not a byte, so
-    /// sending a multi-byte character's bytes through it reached the
-    /// agent as mojibake. Control bytes still go through `-H`, where
-    /// one byte is one character anyway and escape sequences (the
-    /// bracketed paste markers, Return) must arrive exactly.
+    /// One command carries the whole paste wherever it fits, which
+    /// is nearly always: tmux accepts command lines far longer than
+    /// any paste (32,000 characters verified), and an agent's
+    /// interface redraws between separate writes, which is how a
+    /// split paste left the cursor stranded mid-text.
     ///
-    /// Text is chunked because a tmux command line has a practical
-    /// length limit: past it the command is dropped in silence,
-    /// which is what swallowed large pastes whole.
+    /// Text is literal UTF-8 through `send-keys -l`, since `-H`
+    /// names one character per hexadecimal value rather than one
+    /// byte and mangled every multi-byte character. Control bytes
+    /// ride along inside the same argument as tmux's own escapes,
+    /// so escape sequences and newlines arrive exactly.
     public static func sendCommands(bytes: some Sequence<UInt8>) -> [String] {
+        let raw = Array(bytes)
+        guard raw.isEmpty == false else {
+            return []
+        }
+
+        // Undecodable bytes are not text; hexadecimal keeps them
+        // exact, one character per byte being true below 0x80.
+        guard let text = String(bytes: raw, encoding: .utf8) else {
+            return ["send-keys -H " + raw.map { String($0, radix: hexRadix) }.joined(separator: " ")]
+        }
+
         var commands = [String]()
-        var text = [UInt8]()
-        var control = [UInt8]()
-
-        func flushText() {
-            guard text.isEmpty == false else {
-                return
-            }
-
-            // Undecodable bytes are not text; hex keeps them exact.
-            if let decoded = String(bytes: text, encoding: .utf8) {
-                commands += literalCommands(for: decoded)
-            } else {
-                commands.append(hexCommand(for: text))
-            }
-            text = []
-        }
-
-        func flushControl() {
-            guard control.isEmpty == false else {
-                return
-            }
-
-            commands.append(hexCommand(for: control))
-            control = []
-        }
-
-        for byte in bytes {
-            if byte < asciiSpace || byte == asciiDelete {
-                flushText()
-                control.append(byte)
-            } else {
-                flushControl()
-                text.append(byte)
+        var chunk = ""
+        for character in text {
+            chunk.append(character)
+            if chunk.count >= literalChunkLength {
+                commands.append("send-keys -l -- " + quoted(chunk))
+                chunk = ""
             }
         }
-        flushText()
-        flushControl()
+        if chunk.isEmpty == false {
+            commands.append("send-keys -l -- " + quoted(chunk))
+        }
         return commands
     }
 
@@ -87,29 +75,44 @@ public enum TmuxControl {
 
     // MARK: Internal
 
-    /// One command per chunk of literal text, single-quoted the way
-    /// tmux parses arguments; `--` keeps text that starts with a
-    /// dash from reading as a flag.
-    static func literalCommands(for text: String) -> [String] {
-        var commands = [String]()
-        var chunk = ""
+    /// One tmux argument: double quotes with tmux's own escapes, so
+    /// control characters travel inside the text rather than as
+    /// separate commands. Everything tmux would otherwise interpret
+    /// (quotes, backslashes, environment variables, home directory
+    /// expansion, command separators and formats) is escaped.
+    static func quoted(_ text: String) -> String {
+        var escaped = ""
         for character in text {
-            chunk.append(character)
-            if chunk.count >= literalChunkLength {
-                commands.append("send-keys -l -- " + quoted(chunk))
-                chunk = ""
+            switch character {
+            case "\\":
+                escaped += "\\\\"
+
+            case "\"":
+                escaped += "\\\""
+
+            case ";",
+                 "#",
+                 "~",
+                 "$":
+                escaped += "\\" + String(character)
+
+            case "\n":
+                escaped += "\\n"
+
+            case "\r":
+                escaped += "\\r"
+
+            case "\t":
+                escaped += "\\t"
+
+            case "\u{1B}":
+                escaped += "\\e"
+
+            default:
+                escaped += controlEscape(character) ?? String(character)
             }
         }
-        if chunk.isEmpty == false {
-            commands.append("send-keys -l -- " + quoted(chunk))
-        }
-        return commands
-    }
-
-    /// A tmux argument: single quotes protect everything, and a
-    /// quote of its own closes, escapes and reopens them.
-    static func quoted(_ text: String) -> String {
-        "'" + text.replacing("'", with: "'\\''") + "'"
+        return "\"" + escaped + "\""
     }
 
     // MARK: Private
@@ -117,16 +120,25 @@ public enum TmuxControl {
     /// `send-keys -H` reads bytes as hexadecimal.
     private static let hexRadix = 16
 
-    /// Characters per literal command. tmux drops a command line
-    /// somewhere past a thousand characters without saying so, and
-    /// quoting can double a chunk's length, so this stays well
-    /// under half of it.
-    private static let literalChunkLength = 400
+    /// Characters per command. tmux carried 32,000 in one command
+    /// in testing; this leaves generous room below that even when
+    /// escaping quadruples a chunk, while keeping all but the
+    /// largest pastes in a single write.
+    private static let literalChunkLength = 4_000
 
-    private static let asciiSpace: UInt8 = 0x20
-    private static let asciiDelete: UInt8 = 0x7F
+    private static let asciiSpace: UInt32 = 0x20
+    private static let asciiDelete: UInt32 = 0x7F
 
-    private static func hexCommand(for bytes: [UInt8]) -> String {
-        "send-keys -H " + bytes.map { String($0, radix: hexRadix) }.joined(separator: " ")
+    /// Any other control character as tmux's three-digit octal
+    /// escape; nil for ordinary text, which needs none.
+    private static func controlEscape(_ character: Character) -> String? {
+        guard let scalar = character.unicodeScalars.first,
+              character.unicodeScalars.count == 1,
+              scalar.value < asciiSpace || scalar.value == asciiDelete
+        else {
+            return nil
+        }
+
+        return "\\" + String(format: "%03o", scalar.value)
     }
 }

--- a/Sources/DashboardFeature/DashboardModel+Cleanup.swift
+++ b/Sources/DashboardFeature/DashboardModel+Cleanup.swift
@@ -17,7 +17,16 @@ public extension DashboardModel {
     @discardableResult
     func cleanUp(item: WorktreeItem) async -> SessionService.CleanupRefusal? {
         if item.worktree.path == item.worktree.repositoryPath {
-            await service.cleanUpAfterMerge(worktree: item.worktree, mergedBranch: item.worktree.branch)
+            let report = await service.cleanUpAfterMerge(
+                worktree: item.worktree,
+                mergedBranch: item.worktree.branch,
+            )
+            for note in report.notes {
+                ErrorLog.shared.note(note)
+            }
+            for failure in report.failures {
+                ErrorLog.shared.report(failure)
+            }
             await refresh()
             return nil
         }

--- a/Sources/DashboardFeature/DashboardModel+PullRequests.swift
+++ b/Sources/DashboardFeature/DashboardModel+PullRequests.swift
@@ -36,6 +36,11 @@ extension DashboardModel {
                 if await isFinal(branchPullRequests[key].flatMap(\.self), for: item) {
                     continue
                 }
+                // An outage answers every branch identically, so one
+                // branch probes for a recovery and the rest wait.
+                if ServiceStatus.shared.isUnavailable, item.id != selection?.id {
+                    continue
+                }
 
                 nextPullRequestFetch[key] = Date().addingTimeInterval(interval(for: item, collapsed: collapsed))
                 do {
@@ -48,8 +53,12 @@ extension DashboardModel {
                     branchPullRequests[key] = summary
                     persist(summary, key: key)
                     await cleanUpIfMerged(item, previous: previous, fresh: summaries)
+                    ServiceStatus.shared.recordSuccess()
                 } catch {
-                    ErrorLog.shared.report("Pull requests for \(group.repository.name): " + error.localizedDescription)
+                    ServiceStatus.shared.record(
+                        failure: error,
+                        doing: "Pull requests for " + group.repository.name,
+                    )
                 }
             }
         }

--- a/Sources/DashboardFeature/DashboardModel+Repositories.swift
+++ b/Sources/DashboardFeature/DashboardModel+Repositories.swift
@@ -65,6 +65,7 @@ public extension DashboardModel {
         do {
             screenError = nil
             status = "Cloning \(fullName)…"
+            ErrorLog.shared.note("Cloning \(fullName)…")
             _ = try await service.cloneRepository(fullName: fullName)
             await refresh()
             _ = selectMainCheckout(fullName: fullName, name: name)

--- a/Sources/DashboardFeature/DashboardView.swift
+++ b/Sources/DashboardFeature/DashboardView.swift
@@ -244,15 +244,11 @@ public struct DashboardView: View {
         }
     }
 
+    /// One image per owner, cached on disk: every repository of an
+    /// owner shares it, and a GitHub outage leaves the icons alone.
     private func avatar(for repository: Repository) -> some View {
-        AsyncImage(url: avatarURL(for: repository)) { image in
-            image.resizable()
-        } placeholder: {
-            Image(systemName: "folder.fill").font(.caption2)
-        }
-        .frame(width: Self.avatarSize, height: Self.avatarSize)
-        .clipShape(RoundedRectangle(cornerRadius: Self.avatarCornerRadius))
-        .accessibilityHidden(true)
+        OwnerAvatar(owner: repository.owner, size: Self.avatarSize)
+            .clipShape(RoundedRectangle(cornerRadius: Self.avatarCornerRadius))
     }
 
     private func forceDeleteBinding(for item: WorktreeItem) -> Binding<Bool> {
@@ -308,9 +304,5 @@ public struct DashboardView: View {
             collapsed.insert(path)
         }
         collapsedRepositories = collapsed.sorted().joined(separator: "\n")
-    }
-
-    private func avatarURL(for repository: Repository) -> URL? {
-        repository.owner.flatMap { URL(string: "https://github.com/" + $0 + ".png?size=64") }
     }
 }

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -7,6 +7,13 @@ import TerminalUI
 /// The footer's branch actions, split from the model body for
 /// length.
 extension PullRequestsModel {
+    /// Shows a status in the footer and keeps it in the messages
+    /// pane, where a line that scrolls past can still be read.
+    func setStatus(_ message: String) {
+        status = message
+        ErrorLog.shared.note(message)
+    }
+
     /// The branch item's worktree with the checked-out branch
     /// substituted, so pushes and pull requests act on what is
     /// actually checked out.
@@ -206,7 +213,7 @@ extension PullRequestsModel {
         do {
             try await performPush(worktree)
             isPushed = true
-            status = "Pushed."
+            setStatus("Pushed.")
             ErrorLog.shared.note("Pushed " + worktree.branch + ".")
             Self.requestSidebarRefresh()
             await reload(keepingSelection: true)
@@ -226,7 +233,7 @@ extension PullRequestsModel {
 
         do {
             try await performRebase(worktree)
-            status = "Rebased and signed."
+            setStatus("Rebased and signed.")
             ErrorLog.shared.note("Rebased and signed " + worktree.branch + ".")
             Self.requestSidebarRefresh()
             await reload(keepingSelection: true)
@@ -296,7 +303,7 @@ extension PullRequestsModel {
     func act(_ work: () async throws -> Void) async -> Bool {
         do {
             try await work()
-            status = "Done."
+            setStatus("Done.")
             await reload(keepingSelection: true)
             return true
         } catch {

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -9,9 +9,12 @@ import TerminalUI
 extension PullRequestsModel {
     /// Shows a status in the footer and keeps it in the messages
     /// pane, where a line that scrolls past can still be read.
-    func setStatus(_ message: String) {
+    /// `detail` is what the messages pane keeps when the footer's
+    /// wording is too terse to mean anything later; without it the
+    /// footer's own line is kept, once.
+    func setStatus(_ message: String, detail: String? = nil) {
         status = message
-        ErrorLog.shared.note(message)
+        ErrorLog.shared.note(detail ?? message)
     }
 
     /// The branch item's worktree with the checked-out branch
@@ -213,8 +216,7 @@ extension PullRequestsModel {
         do {
             try await performPush(worktree)
             isPushed = true
-            setStatus("Pushed.")
-            ErrorLog.shared.note("Pushed " + worktree.branch + ".")
+            setStatus("Pushed.", detail: "Pushed " + worktree.branch + ".")
             Self.requestSidebarRefresh()
             await reload(keepingSelection: true)
             return true
@@ -233,8 +235,7 @@ extension PullRequestsModel {
 
         do {
             try await performRebase(worktree)
-            setStatus("Rebased and signed.")
-            ErrorLog.shared.note("Rebased and signed " + worktree.branch + ".")
+            setStatus("Rebased and signed.", detail: "Rebased and signed " + worktree.branch + ".")
             Self.requestSidebarRefresh()
             await reload(keepingSelection: true)
             return true

--- a/Sources/PRFeature/PullRequestsModel+Draft.swift
+++ b/Sources/PRFeature/PullRequestsModel+Draft.swift
@@ -5,6 +5,13 @@ import AgentIDEDomain
 /// from the model body for length: a branch's unfinished title, body
 /// and template survive leaving the tab and quitting the app.
 extension PullRequestsModel {
+    /// Whether the list pane shows the creation form instead: the
+    /// worktree scope with no open pull request for the branch.
+    var needsCreateForm: Bool {
+        scope == .worktree && branchItem != nil && hasLoaded
+            && summaries.contains { $0.headBranch == listedBranch && $0.state == "OPEN" } == false
+    }
+
     /// Whether the last fetch filled its limit, so more pages may
     /// exist beyond what is loaded.
     var hasMore: Bool {

--- a/Sources/PRFeature/PullRequestsModel+Draft.swift
+++ b/Sources/PRFeature/PullRequestsModel+Draft.swift
@@ -5,6 +5,12 @@ import AgentIDEDomain
 /// from the model body for length: a branch's unfinished title, body
 /// and template survive leaving the tab and quitting the app.
 extension PullRequestsModel {
+    /// The worktree item this tab acts on: the one checked out on
+    /// the branch the tab lists.
+    var branchItem: WorktreeItem? {
+        items.first { $0.worktree.branch == branch }
+    }
+
     /// Whether the list pane shows the creation form instead: the
     /// worktree scope with no open pull request for the branch.
     var needsCreateForm: Bool {

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -225,12 +225,6 @@ final class PullRequestsModel {
         }
     }
 
-    /// Whether the last fetch filled its limit, so more pages may
-    /// exist beyond what is loaded.
-    var branchItem: WorktreeItem? {
-        items.first { $0.worktree.branch == branch }
-    }
-
     /// Push makes sense with unpushed commits that this tab has not
     /// already pushed and a GPG-signed tip; nil upstream means
     /// nothing was ever pushed.
@@ -346,8 +340,9 @@ final class PullRequestsModel {
                     select(chosen)
                 }
             }
+            ServiceStatus.shared.recordSuccess()
         } catch {
-            ErrorLog.shared.report(error.localizedDescription)
+            ServiceStatus.shared.record(failure: error, doing: "Pull requests for " + repository.name)
         }
     }
 

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -74,7 +74,13 @@ final class PullRequestsModel {
             }
         }
         performPostMergeCleanup = { worktree, mergedBranch in
-            await service.cleanUpAfterMerge(worktree: worktree, mergedBranch: mergedBranch)
+            let report = await service.cleanUpAfterMerge(worktree: worktree, mergedBranch: mergedBranch)
+            for note in report.notes {
+                ErrorLog.shared.note(note)
+            }
+            for failure in report.failures {
+                ErrorLog.shared.report(failure)
+            }
         }
         fetchCurrentBranch = { path in
             await service.currentBranch(worktreePath: path)
@@ -190,13 +196,6 @@ final class PullRequestsModel {
 
     var prTemplate = "" {
         didSet { saveDraft() }
-    }
-
-    /// Whether the list pane shows the creation form instead: the
-    /// worktree scope with no open pull request for the branch.
-    var needsCreateForm: Bool {
-        scope == .worktree && branchItem != nil && hasLoaded
-            && summaries.contains { $0.headBranch == listedBranch && $0.state == "OPEN" } == false
     }
 
     /// The repository's worktree items, refreshed by the view as the

--- a/Sources/ReviewFeature/ReviewModel.swift
+++ b/Sources/ReviewFeature/ReviewModel.swift
@@ -191,6 +191,13 @@ final class ReviewModel {
         return true
     }
 
+    /// Shows a status in the footer and keeps it in the messages
+    /// pane, where a line that scrolls past can still be read.
+    func setStatus(_ message: String) {
+        status = message
+        ErrorLog.shared.note(message)
+    }
+
     /// Reports a failure into the app-wide error log; the local
     /// status line keeps success reports only.
     func report(_ message: String) {
@@ -222,7 +229,7 @@ final class ReviewModel {
             if showsUncommitted == false {
                 try await git.amend(worktreePath: worktreePath, message: nil)
             }
-            status = "Rejected selected lines."
+            setStatus("Rejected selected lines.")
             await reload()
         } catch {
             report(error.localizedDescription)
@@ -234,7 +241,7 @@ final class ReviewModel {
         do {
             try await git.amend(worktreePath: worktreePath, message: commitMessage)
             originalMessage = commitMessage
-            status = "Commit message updated."
+            setStatus("Commit message updated.")
         } catch {
             report(error.localizedDescription)
         }
@@ -258,7 +265,7 @@ final class ReviewModel {
     private func loadUpstream(currentBranch: String?) async throws {
         branchCommits = []
         guard let currentBranch, hasUpstream else {
-            status = "This branch has not been pushed yet."
+            setStatus("This branch has not been pushed yet.")
             files = []
             return
         }
@@ -277,7 +284,7 @@ final class ReviewModel {
     private func loadBranch() async throws {
         branchCommits = []
         guard let baseRef = await baseRefProvider() else {
-            status = "No base branch to diff against."
+            setStatus("No base branch to diff against.")
             files = []
             return
         }

--- a/Sources/TerminalUI/ErrorLog.swift
+++ b/Sources/TerminalUI/ErrorLog.swift
@@ -42,11 +42,6 @@ public final class ErrorLog {
     /// The messages reported this session, oldest first.
     public private(set) var entries: [Entry] = []
 
-    /// Whether a failure was ever reported this session; the
-    /// messages tab appears on the first failure and then stays,
-    /// even across a clear.
-    public private(set) var everReported = false
-
     /// How many failures the log holds, for the tab's badge; plain
     /// status notes deliberately carry no number.
     public var errorCount: Int {
@@ -56,7 +51,6 @@ public final class ErrorLog {
     /// Appends a failure to the log, dropping the oldest entries
     /// beyond the cap so a noisy session never grows without bound.
     public func report(_ message: String) {
-        everReported = true
         append(message, isError: true)
     }
 
@@ -66,7 +60,7 @@ public final class ErrorLog {
         append(message, isError: false)
     }
 
-    /// Empties the log; the errors tab stays for the session.
+    /// Empties the log; the messages tab stays either way.
     public func clear() {
         entries = []
     }

--- a/Sources/TerminalUI/OwnerAvatar.swift
+++ b/Sources/TerminalUI/OwnerAvatar.swift
@@ -46,8 +46,9 @@ public final class OwnerAvatarStore {
 
     // MARK: Private
 
-    /// An avatar that is not a 200 is not an avatar.
-    private static let httpOK = 200
+    /// An avatar that is not a 200 is not an avatar; nonisolated so
+    /// the off-main download can read it.
+    private nonisolated static let httpOK = 200
 
     private static var directory: URL {
         let base = URL(fileURLWithPath: NSHomeDirectory())
@@ -76,6 +77,22 @@ public final class OwnerAvatarStore {
         return NSImage(data: data)
     }
 
+    /// Fetches an avatar and keeps a copy, away from the main
+    /// actor: `@concurrent` because a plain nonisolated async
+    /// function would run on its caller's actor, which is the one
+    /// drawing the sidebar.
+    @concurrent
+    private nonisolated static func download(from url: URL, to file: URL) async -> Data? {
+        guard let (data, response) = try? await URLSession.shared.data(from: url),
+              (response as? HTTPURLResponse)?.statusCode == httpOK
+        else {
+            return nil
+        }
+
+        try? data.write(to: file, options: .atomic)
+        return data
+    }
+
     /// Fetches an owner's avatar and keeps it. A failure is silent
     /// on purpose: the icon is decoration, the disk copy covers an
     /// outage, and the messages pane is for things the user can act
@@ -89,15 +106,15 @@ public final class OwnerAvatarStore {
 
         inFlight.insert(owner)
         Task { [weak self] in
-            defer { self?.inFlight.remove(owner) }
-            guard let (data, response) = try? await URLSession.shared.data(from: url),
-                  (response as? HTTPURLResponse)?.statusCode == Self.httpOK,
-                  let image = NSImage(data: data)
-            else {
+            // The fetch and the disk write run off the main actor;
+            // only the small decode and the state update come back
+            // to it, so a sidebar of owners cannot stutter the UI.
+            let data = await Self.download(from: url, to: Self.file(for: owner))
+            self?.inFlight.remove(owner)
+            guard let data, let image = NSImage(data: data) else {
                 return
             }
 
-            try? data.write(to: Self.file(for: owner), options: .atomic)
             self?.images[owner] = image
         }
     }

--- a/Sources/TerminalUI/OwnerAvatar.swift
+++ b/Sources/TerminalUI/OwnerAvatar.swift
@@ -1,0 +1,140 @@
+import AppKit
+import SwiftUI
+
+// MARK: - OwnerAvatarStore
+
+/// GitHub owner avatars, fetched once per owner and kept on disk.
+///
+/// Every repository of an owner shares one image, so a sidebar of
+/// twenty repositories under three owners fetches three times, not
+/// twenty. The disk copy is the point of the cache rather than a
+/// nicety: GitHub goes down, and an outage should not blank the
+/// sidebar's icons.
+@preconcurrency
+@Observable
+@MainActor
+public final class OwnerAvatarStore {
+    // MARK: Lifecycle
+
+    private init() {
+        // One store for the whole app.
+    }
+
+    deinit {
+        // The store lives for the process.
+    }
+
+    // MARK: Public
+
+    /// The one store every sidebar row reads.
+    public static let shared: OwnerAvatarStore = .init()
+
+    /// The owner's avatar when one is known: memory first, then the
+    /// disk copy, then a fetch that fills both.
+    public func image(for owner: String) -> NSImage? {
+        if let image = images[owner] {
+            return image
+        }
+        if let image = Self.diskImage(for: owner) {
+            images[owner] = image
+            return image
+        }
+
+        fetch(owner)
+        return nil
+    }
+
+    // MARK: Private
+
+    /// An avatar that is not a 200 is not an avatar.
+    private static let httpOK = 200
+
+    private static var directory: URL {
+        let base = URL(fileURLWithPath: NSHomeDirectory())
+            .appending(path: "Library/Application Support/AgentIDE/Avatars")
+        try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        return base
+    }
+
+    /// Owners already being fetched, so a redrawing sidebar asks
+    /// once rather than once per row per frame.
+    private var inFlight: Set<String> = []
+    private var images: [String: NSImage] = [:]
+
+    /// The cached file for an owner; the name is percent encoded, so
+    /// an owner with a slash or a dot cannot escape the directory.
+    private static func file(for owner: String) -> URL {
+        let safe = owner.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? owner
+        return directory.appending(path: safe + ".png")
+    }
+
+    private static func diskImage(for owner: String) -> NSImage? {
+        guard let data = try? Data(contentsOf: file(for: owner)) else {
+            return nil
+        }
+
+        return NSImage(data: data)
+    }
+
+    /// Fetches an owner's avatar and keeps it. A failure is silent
+    /// on purpose: the icon is decoration, the disk copy covers an
+    /// outage, and the messages pane is for things the user can act
+    /// on.
+    private func fetch(_ owner: String) {
+        guard inFlight.contains(owner) == false,
+              let url = URL(string: "https://github.com/" + owner + ".png?size=64")
+        else {
+            return
+        }
+
+        inFlight.insert(owner)
+        Task { [weak self] in
+            defer { self?.inFlight.remove(owner) }
+            guard let (data, response) = try? await URLSession.shared.data(from: url),
+                  (response as? HTTPURLResponse)?.statusCode == Self.httpOK,
+                  let image = NSImage(data: data)
+            else {
+                return
+            }
+
+            try? data.write(to: Self.file(for: owner), options: .atomic)
+            self?.images[owner] = image
+        }
+    }
+}
+
+// MARK: - OwnerAvatar
+
+/// One owner's avatar, from the shared per-owner cache, falling back
+/// to a folder glyph until an image exists.
+public struct OwnerAvatar: View {
+    // MARK: Lifecycle
+
+    /// Creates the avatar for an owner, nil when the repository has
+    /// no known owner.
+    public init(owner: String?, size: CGFloat) {
+        self.owner = owner
+        self.size = size
+    }
+
+    // MARK: Public
+
+    public var body: some View {
+        Group {
+            if let image = owner.flatMap({ store.image(for: $0) }) {
+                Image(nsImage: image).resizable()
+            } else {
+                Image(systemName: "folder.fill").font(.caption)
+            }
+        }
+        .frame(width: size, height: size)
+        .accessibilityHidden(true)
+    }
+
+    // MARK: Private
+
+    private var store: OwnerAvatarStore = .shared
+
+    private let owner: String?
+    private let size: CGFloat
+}

--- a/Sources/TerminalUI/ServiceStatus.swift
+++ b/Sources/TerminalUI/ServiceStatus.swift
@@ -1,0 +1,93 @@
+import AgentIDEData
+import Foundation
+import Observation
+
+/// Whether GitHub is answering, so an outage is reported once and
+/// waited out rather than retried and re-reported per request.
+///
+/// Polling asks about every branch of every repository, so a single
+/// outage otherwise fills the messages pane with the same failure
+/// dozens of times a minute and keeps hammering a service that is
+/// already down. Everything fetched before an outage stays on
+/// screen: stale pull request state is far more useful than none.
+@preconcurrency
+@Observable
+@MainActor
+public final class ServiceStatus {
+    // MARK: Lifecycle
+
+    private init() {
+        // One status for the whole app.
+    }
+
+    deinit {
+        // The status lives for the process.
+    }
+
+    // MARK: Public
+
+    /// The one status every GitHub caller reports through.
+    public static let shared: ServiceStatus = .init()
+
+    /// Whether GitHub last failed in a way that reads as an outage;
+    /// callers poll far less while this holds.
+    public private(set) var isUnavailable = false
+
+    /// When the outage was first noticed, for saying how long the
+    /// shown state has been stale.
+    public private(set) var unavailableSince: Date?
+
+    /// Records a failure. An outage is announced once and then kept
+    /// quiet; anything else is a real failure and always reported,
+    /// since a broken request the user could fix must not be
+    /// swallowed by an outage's silence.
+    public func record(failure error: any Error, doing what: String) {
+        guard GitHubOutage.isLikely(error) else {
+            ErrorLog.shared.report(what + ": " + error.localizedDescription)
+            return
+        }
+        guard isUnavailable == false else {
+            return
+        }
+
+        isUnavailable = true
+        unavailableSince = Date()
+        ErrorLog.shared.report(
+            "GitHub is not answering, so pull request state is what was last fetched. "
+                + "Retrying quietly; the first success says so. (" + error.localizedDescription + ")",
+        )
+    }
+
+    /// Records a success, which ends an outage and says so once.
+    public func recordSuccess() {
+        guard isUnavailable else {
+            return
+        }
+
+        let since = unavailableSince
+        isUnavailable = false
+        unavailableSince = nil
+        let waited = since.map { " after " + Self.duration(since: $0) } ?? ""
+        ErrorLog.shared.note("GitHub is answering again" + waited + "; pull request state is refreshing.")
+    }
+
+    // MARK: Private
+
+    private static let secondsPerMinute = 60.0
+
+    /// A rough human duration; the exact seconds of an outage are
+    /// nobody's business.
+    private static func duration(since start: Date) -> String {
+        let minutes = Int(Date().timeIntervalSince(start) / secondsPerMinute)
+        switch minutes {
+        case 0:
+            return "less than a minute"
+
+        case 1:
+            return "a minute"
+
+        default:
+            return String(minutes) + " minutes"
+        }
+    }
+}

--- a/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
+++ b/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
@@ -240,7 +240,11 @@ extension TerminalRepresentable {
                 return
             }
 
-            sendCommand(TmuxControl.sendKeysCommand(bytes: bytes), expecting: .acknowledgement)
+            // A paste becomes several commands: literal text in
+            // chunks tmux will not drop, control bytes exactly.
+            for command in TmuxControl.sendCommands(bytes: bytes) {
+                sendCommand(command, expecting: .acknowledgement)
+            }
         }
 
         /// Drops the running client and resets the conversation

--- a/Tests/AgentIDEDataTests/GitHubOutageTests.swift
+++ b/Tests/AgentIDEDataTests/GitHubOutageTests.swift
@@ -1,0 +1,37 @@
+import AgentIDEData
+import Testing
+
+/// Pins which failures count as an outage. The classification has
+/// to stay narrow: an outage is announced once and then waited out
+/// quietly, so anything misfiled as one goes unheard.
+struct GitHubOutageTests {
+    @Test
+    func `github's own failures read as an outage`() {
+        let outages = [
+            "gh pr list failed (1): HTTP 503: No server is currently available to service your request.",
+            "HTTP 502: Bad gateway (https://api.github.com/graphql)",
+            "gh api failed (1): HTTP 500: Internal server error",
+            "error connecting to api.github.com: operation timed out",
+            "could not resolve host: api.github.com",
+            "The Internet connection appears to be offline.",
+        ]
+        for message in outages {
+            #expect(GitHubOutage.isLikely(message), "\(message.prefix(40))")
+        }
+    }
+
+    @Test
+    func `real failures stay real`() {
+        let failures = [
+            "gh pr create failed (1): pull request already exists for branch",
+            "HTTP 404: Not Found (https://api.github.com/repos/x/y)",
+            "HTTP 401: Bad credentials",
+            "gh auth status failed (1): You are not logged into any GitHub hosts",
+            "! [rejected] main -> main (non-fast-forward)",
+            "The tip commit is not GPG signed",
+        ]
+        for message in failures {
+            #expect(GitHubOutage.isLikely(message) == false, "\(message.prefix(40))")
+        }
+    }
+}

--- a/Tests/AgentIDEDataTests/TmuxControlChannelIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/TmuxControlChannelIntegrationTests.swift
@@ -6,6 +6,8 @@ import Testing
 /// Exercises the control mode channel against a real tmux server on
 /// a private socket: the round trip the terminal panes are built on.
 struct TmuxControlChannelIntegrationTests {
+    // MARK: Internal
+
     @Test
     func `attaching streams history, live output and typed keys`() async throws {
         let (tmux, socket) = try TestSupport.makeTmuxClient()
@@ -49,7 +51,7 @@ struct TmuxControlChannelIntegrationTests {
             case let .response(lines, isError):
                 if isError == false, lines.contains(where: { $0.contains("ready") }), sawHistory == false {
                     sawHistory = true
-                    channel.send(TmuxControl.sendKeysCommand(bytes: Array("ping\r".utf8)))
+                    Self.type("ping\r", into: channel)
                 }
 
             case let .output(_, bytes):
@@ -69,5 +71,15 @@ struct TmuxControlChannelIntegrationTests {
         await channel.stop()
         #expect(sawHistory, "capture-pane should report the pane's history")
         #expect(sawEcho, "typed keys should echo back as pane output")
+    }
+
+    // MARK: Private
+
+    /// Types text the way a pane does, as the commands the paste
+    /// builder produces.
+    private static func type(_ text: String, into channel: TmuxControlChannel) {
+        for command in TmuxControl.sendCommands(bytes: Array(text.utf8)) {
+            channel.send(command)
+        }
     }
 }

--- a/Tests/AgentIDEDomainTests/TmuxControlParserTests.swift
+++ b/Tests/AgentIDEDomainTests/TmuxControlParserTests.swift
@@ -92,7 +92,8 @@ struct TmuxControlParserTests {
 
     @Test
     func `command builders emit the documented forms`() {
-        #expect(TmuxControl.sendKeysCommand(bytes: [0x68, 0x0D]) == "send-keys -H 68 d")
+        // Text goes literally, the carriage return exactly.
+        #expect(TmuxControl.sendCommands(bytes: [0x68, 0x0D]) == ["send-keys -l -- 'h'", "send-keys -H d"])
         #expect(TmuxControl.resizeCommand(columns: 120, rows: 40) == "refresh-client -C 120x40")
         #expect(TmuxControl.seedText(lines: ["one", "two", "", ""]) == "one\r\ntwo\r\n")
         #expect(TmuxControl.seedText(lines: []).isEmpty)

--- a/Tests/AgentIDEDomainTests/TmuxControlParserTests.swift
+++ b/Tests/AgentIDEDomainTests/TmuxControlParserTests.swift
@@ -92,8 +92,7 @@ struct TmuxControlParserTests {
 
     @Test
     func `command builders emit the documented forms`() {
-        // Text goes literally, the carriage return exactly.
-        #expect(TmuxControl.sendCommands(bytes: [0x68, 0x0D]) == ["send-keys -l -- 'h'", "send-keys -H d"])
+        // Key delivery has its own suite; this pins the rest.
         #expect(TmuxControl.resizeCommand(columns: 120, rows: 40) == "refresh-client -C 120x40")
         #expect(TmuxControl.seedText(lines: ["one", "two", "", ""]) == "one\r\ntwo\r\n")
         #expect(TmuxControl.seedText(lines: []).isEmpty)

--- a/Tests/AgentIDEDomainTests/TmuxPasteTests.swift
+++ b/Tests/AgentIDEDomainTests/TmuxPasteTests.swift
@@ -50,11 +50,22 @@ struct TmuxPasteTests {
     }
 
     @Test
-    func `a paste beyond one command still splits rather than being dropped`() {
-        let commands = TmuxControl.sendCommands(bytes: Array(String(repeating: "x", count: 9_000).utf8))
-        #expect(commands.count > 1)
-        // Comfortably inside what tmux carried in testing.
-        #expect(commands.allSatisfy { $0.count < 32_000 })
+    func `a paste splits only when the command itself would not fit`() {
+        // Chunking once counted source characters, so a paste this
+        // size split into several commands despite fitting easily.
+        let moderate = TmuxControl.sendCommands(bytes: Array(String(repeating: "x", count: 9_000).utf8))
+        #expect(moderate.count == 1)
+
+        // Past the budget it splits rather than being dropped, and
+        // every command stays inside what tmux carried in testing.
+        let huge = TmuxControl.sendCommands(bytes: Array(String(repeating: "x", count: 40_000).utf8))
+        #expect(huge.count > 1)
+        #expect(huge.allSatisfy { $0.count < 32_000 })
+
+        // Escaping is what fills the budget, so text that escapes
+        // to four characters each splits sooner than plain text.
+        let escaping = TmuxControl.sendCommands(bytes: Array(String(repeating: "\u{1}", count: 9_000).utf8))
+        #expect(escaping.count > 1)
     }
 
     // MARK: Private

--- a/Tests/AgentIDEDomainTests/TmuxPasteTests.swift
+++ b/Tests/AgentIDEDomainTests/TmuxPasteTests.swift
@@ -3,12 +3,13 @@ import Testing
 
 // MARK: - TmuxPasteTests
 
-/// Pins how a paste reaches an agent. Both failures here were real:
-/// hexadecimal delivery mangled every multi-byte character, and one
-/// long command line was dropped by tmux without a word, so large
-/// pastes vanished entirely. The property that matters is that the
-/// commands reconstruct the pasted bytes exactly, whatever the
-/// chunking, so these tests decode them back.
+/// Pins how a paste reaches an agent. All three failures here were
+/// real: hexadecimal delivery mangled every multi-byte character, an
+/// over-long command line was dropped by tmux without a word, and a
+/// paste split across commands left the cursor stranded mid-text
+/// because the agent redrew between writes. The property that
+/// matters is that the commands reconstruct the pasted bytes
+/// exactly, so these tests decode them back.
 struct TmuxPasteTests {
     // MARK: Internal
 
@@ -20,8 +21,10 @@ struct TmuxPasteTests {
             "plain ascii",
             "line one\nline two\r\n",
             "\u{1B}[200~pasted\u{1B}[201~",
-            String(repeating: "x", count: 3_000),
-            String(repeating: "é", count: 900),
+            "tabs\tand $HOME and ~user and #hash and ;semi and \\slash",
+            "\u{1}\u{7F} control bytes",
+            String(repeating: "x", count: 9_000),
+            String(repeating: "é", count: 3_000),
             "-- leading dashes",
         ]
         for text in cases {
@@ -31,29 +34,38 @@ struct TmuxPasteTests {
     }
 
     @Test
-    func `text goes literally and control bytes go exactly`() {
-        #expect(TmuxControl.sendCommands(bytes: Array("héllo 🙂".utf8)) == ["send-keys -l -- 'héllo 🙂'"])
-        #expect(TmuxControl.sendCommands(bytes: Array("don't".utf8)) == ["send-keys -l -- 'don'\\''t'"])
-        #expect(TmuxControl.sendCommands(bytes: [0x68, 0x0D]) == ["send-keys -l -- 'h'", "send-keys -H d"])
+    func `an ordinary paste travels as a single command`() {
+        // Splitting a paste is what stranded the cursor, so one
+        // write is the point, markers and newlines included.
+        let paste = "\u{1B}[200~a multi-line\npaste with 🙂\u{1B}[201~"
+        #expect(TmuxControl.sendCommands(bytes: Array(paste.utf8)).count == 1)
     }
 
     @Test
-    func `a long paste splits into commands tmux will accept`() {
-        let commands = TmuxControl.sendCommands(bytes: Array(String(repeating: "x", count: 3_000).utf8))
+    func `text is literal and control characters ride with it`() {
+        #expect(TmuxControl.sendCommands(bytes: Array("héllo 🙂".utf8)) == ["send-keys -l -- \"héllo 🙂\""])
+        #expect(TmuxControl.sendCommands(bytes: [0x68, 0x0D]) == ["send-keys -l -- \"h\\r\""])
+        #expect(TmuxControl.sendCommands(bytes: Array("a\u{1B}b".utf8)) == ["send-keys -l -- \"a\\eb\""])
+        #expect(TmuxControl.sendCommands(bytes: []).isEmpty)
+    }
+
+    @Test
+    func `a paste beyond one command still splits rather than being dropped`() {
+        let commands = TmuxControl.sendCommands(bytes: Array(String(repeating: "x", count: 9_000).utf8))
         #expect(commands.count > 1)
-        // tmux drops a command line somewhere past a thousand
-        // characters without reporting it.
-        #expect(commands.allSatisfy { $0.count < 1_000 })
+        // Comfortably inside what tmux carried in testing.
+        #expect(commands.allSatisfy { $0.count < 32_000 })
     }
 
     // MARK: Private
 
-    /// The bytes a tmux server would deliver for these commands.
+    /// The bytes a tmux server would deliver for these commands,
+    /// undoing the parser's own quoting and escapes.
     private static func bytes(from commands: [String]) -> [UInt8] {
         var result = [UInt8]()
         for command in commands {
             if let literal = command.after("send-keys -l -- ") {
-                result += Array(unquoted(literal).utf8)
+                result += Array(unescaped(String(literal.dropFirst().dropLast())).utf8)
             } else if let hex = command.after("send-keys -H ") {
                 result += hex.split(separator: " ").compactMap { UInt8($0, radix: 16) }
             }
@@ -61,9 +73,46 @@ struct TmuxPasteTests {
         return result
     }
 
-    /// Undoes the single quoting tmux's parser would undo.
-    private static func unquoted(_ argument: String) -> String {
-        String(argument.dropFirst().dropLast()).replacing("'\\''", with: "'")
+    /// Undoes tmux's double-quoted escapes.
+    private static func unescaped(_ argument: String) -> String {
+        var result = ""
+        var characters = Array(argument)
+        var index = 0
+        while index < characters.count {
+            guard characters[index] == "\\", index + 1 < characters.count else {
+                result.append(characters[index])
+                index += 1
+                continue
+            }
+
+            let next = characters[index + 1]
+            switch next {
+            case "n":
+                result.append("\n")
+
+            case "r":
+                result.append("\r")
+
+            case "t":
+                result.append("\t")
+
+            case "e":
+                result.append("\u{1B}")
+
+            case "0" ... "7":
+                let digits = String(characters[(index + 1) ... min(index + 3, characters.count - 1)])
+                if let value = UInt32(digits, radix: 8), let scalar = Unicode.Scalar(value) {
+                    result.append(Character(scalar))
+                }
+                index += 4
+                continue
+
+            default:
+                result.append(next)
+            }
+            index += 2
+        }
+        return result
     }
 }
 

--- a/Tests/AgentIDEDomainTests/TmuxPasteTests.swift
+++ b/Tests/AgentIDEDomainTests/TmuxPasteTests.swift
@@ -1,0 +1,75 @@
+import AgentIDEDomain
+import Testing
+
+// MARK: - TmuxPasteTests
+
+/// Pins how a paste reaches an agent. Both failures here were real:
+/// hexadecimal delivery mangled every multi-byte character, and one
+/// long command line was dropped by tmux without a word, so large
+/// pastes vanished entirely. The property that matters is that the
+/// commands reconstruct the pasted bytes exactly, whatever the
+/// chunking, so these tests decode them back.
+struct TmuxPasteTests {
+    // MARK: Internal
+
+    @Test
+    func `every paste reconstructs byte for byte`() {
+        let cases = [
+            "héllo 🙂",
+            "don't",
+            "plain ascii",
+            "line one\nline two\r\n",
+            "\u{1B}[200~pasted\u{1B}[201~",
+            String(repeating: "x", count: 3_000),
+            String(repeating: "é", count: 900),
+            "-- leading dashes",
+        ]
+        for text in cases {
+            let bytes = Array(text.utf8)
+            #expect(Self.bytes(from: TmuxControl.sendCommands(bytes: bytes)) == bytes, "\(text.prefix(20))")
+        }
+    }
+
+    @Test
+    func `text goes literally and control bytes go exactly`() {
+        #expect(TmuxControl.sendCommands(bytes: Array("héllo 🙂".utf8)) == ["send-keys -l -- 'héllo 🙂'"])
+        #expect(TmuxControl.sendCommands(bytes: Array("don't".utf8)) == ["send-keys -l -- 'don'\\''t'"])
+        #expect(TmuxControl.sendCommands(bytes: [0x68, 0x0D]) == ["send-keys -l -- 'h'", "send-keys -H d"])
+    }
+
+    @Test
+    func `a long paste splits into commands tmux will accept`() {
+        let commands = TmuxControl.sendCommands(bytes: Array(String(repeating: "x", count: 3_000).utf8))
+        #expect(commands.count > 1)
+        // tmux drops a command line somewhere past a thousand
+        // characters without reporting it.
+        #expect(commands.allSatisfy { $0.count < 1_000 })
+    }
+
+    // MARK: Private
+
+    /// The bytes a tmux server would deliver for these commands.
+    private static func bytes(from commands: [String]) -> [UInt8] {
+        var result = [UInt8]()
+        for command in commands {
+            if let literal = command.after("send-keys -l -- ") {
+                result += Array(unquoted(literal).utf8)
+            } else if let hex = command.after("send-keys -H ") {
+                result += hex.split(separator: " ").compactMap { UInt8($0, radix: 16) }
+            }
+        }
+        return result
+    }
+
+    /// Undoes the single quoting tmux's parser would undo.
+    private static func unquoted(_ argument: String) -> String {
+        String(argument.dropFirst().dropLast()).replacing("'\\''", with: "'")
+    }
+}
+
+private extension String {
+    /// The remainder after a prefix, nil when it is not there.
+    func after(_ prefix: String) -> String? {
+        hasPrefix(prefix) ? String(dropFirst(prefix.count)) : nil
+    }
+}


### PR DESCRIPTION
- Clean up default branch state after merge by restoring origin alignment, preserving local commits via signed rebase, removing merged branches with `-d`, and reporting every action or failure; ensure message pane visibility and status tracking.
- Improve agent text ingestion by using `send-keys -l` in chunks with quoted formatting and hex control byte preservation, eliminating mojibake from multi-byte characters and preventing large pastes from being lost due to tmux line limits.
- Bundle entire pastes into single command by embedding control bytes as tmux escapes within the payload, allowing full text and escape sequences to be sent as one `send-keys -l` operation, verified via decoded test comparison.
- Cache owner avatars locally in Application Support, fetching once per owner to reduce redundant fetches and avoid sidebar icon loss during outages, treating icons as decoration and silencing failed fetches.
- Suppress noisy retry loops during GitHub outages by detecting 5xx errors and GraphQL overload messages, announcing one outage event, waiting silently, and prioritizing cached state over repeated polling, while preserving real failures like credential issues.