### PR TITLE
Show a cleaned-up branch's state at once

### DIFF
--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -166,7 +166,18 @@ public final class DashboardModel {
         if let selection {
             service.acknowledgeActivity(worktreePath: selection.worktree.path)
         }
+        // Reading the whole system takes a while, and the poll is
+        // always doing it too. Without this the poll's older reading
+        // could land after an action's newer one and put the state
+        // it just changed back on screen: a cleaned-up branch would
+        // reappear in the sidebar until the next tick.
+        refreshGeneration += 1
+        let generation = refreshGeneration
         let overview = await service.overview()
+        guard generation == refreshGeneration else {
+            return
+        }
+
         notifyChanges(from: groups, to: overview.groups)
         groups = overview.groups
         foreign = overview.foreign
@@ -322,6 +333,10 @@ public final class DashboardModel {
 
     /// Models each CLI reported at startup; absent agents fall back.
     private var discoveredModels: [AgentKind: [String]] = [:]
+
+    /// Counts refreshes, so a slower one that started earlier can
+    /// tell it has been superseded and drop its reading.
+    private var refreshGeneration = 0
 
     /// Whether the persisted selection has been re-applied, tried on
     /// the first refresh only so a deliberate deselection sticks.

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -295,7 +295,6 @@ extension PullRequestsModel {
         let succeeded = await act { try await performMergeChange(selected) }
         if succeeded, merges, let worktree = actionWorktree {
             await performPostMergeCleanup(worktree, selected.headBranch)
-            Self.requestSidebarRefresh()
         }
         await refreshSummary(selected.number)
     }

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -81,6 +81,11 @@ final class PullRequestsModel {
             for failure in report.failures {
                 ErrorLog.shared.report(failure)
             }
+            // The cleanup changed the checked-out branch and deleted
+            // others, so the sidebar's rows are stale the moment it
+            // finishes; waiting for the next poll showed a branch
+            // that no longer exists.
+            Self.requestSidebarRefresh()
         }
         fetchCurrentBranch = { path in
             await service.currentBranch(worktreePath: path)


### PR DESCRIPTION
- After a merge cleanup the sidebar kept showing the branch that
  had just been checked away from and the branches just deleted,
  until the next poll happened to redraw it
- Reading the whole system takes a while and the poll is always
  doing it too, so the poll's older reading could land after the
  cleanup's newer one and put the old rows back; a refresh now
  drops its reading when a newer refresh has started since
- The cleanup itself asks for the refresh rather than the merge
  action remembering to, so every caller of it gets one and the
  merge no longer asks twice