### PR TITLE
Keep worktree state and pane lifecycle intact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ conventional-commit prefixes such as `feat:`, `fix:` or `chore:`.
 - `Package.swift`, `Sources/`, `Tests/`: the Swift package targets
 - `App/`: the app shell; `project.yml` defines the XcodeGen target
   (the generated `.xcodeproj` stays gitignored)
+- `bin/`: commands shipped inside the app bundle (the `agentide`
+  editor shim a shell pane puts on its `PATH`)
 - `script/`: development tasks
 - `Brewfile`: development dependencies
 - `.github/workflows/tests.yml`: CI

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -505,9 +505,12 @@ Sendable` and `nonisolated(unsafe)` are banned.
    a one-commit branch defaults to that commit's own message, and a
    generate button inside the title field summarises several through
    the on-device model, locking the fields while it drafts; typed
-   text is never overwritten. A repository without a template shows
-   no template field, and with one the generate button also
-   completes the template from the commits.
+   text is never overwritten. A commit's body arrives unwrapped: commit
+   messages are hand-wrapped to a narrow column, which a pull request
+   reflows for its own width, so the hard wraps read as broken bullets
+   until the continuations are joined back on. A repository without a
+   template shows no template field, and with one the generate button
+   also completes the template from the commits.
 6. The listing and the footer act on the branch actually checked out in the
    worktree, asked of git on each reload, because agents sometimes switch
    branches inside a worktree.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -177,6 +177,15 @@ select and scroll natively with no modifier.
 
 Two visually unmistakable flavours ride that one client:
 
+- **Pasting into an agent**: a paste goes into a tmux buffer and is pasted
+  from there (`set-buffer`, appending for anything long, then `paste-buffer
+  -d -p`), never typed in as keys. tmux brackets it when the pane's own
+  application asked for bracketed paste, which is knowledge the local
+  terminal does not reliably have: it learns modes from output it has seen,
+  and a pane attached mid-session never saw bracketed paste being enabled.
+  Without the markers an agent read a multi-line paste as several lines of
+  typing, which is how the cursor ended up inside the pasted text. Typing
+  still travels as `send-keys -l`.
 - **Sandbox terminal**: the launch shape with payload
   `exec tmux -C attach-session -t <name>`. The attaching client runs
   inside the sandbox too; tmux sockets are owner-only, so no attach

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -183,15 +183,13 @@ Two visually unmistakable flavours ride that one client:
   path can skip sudo. Closing the view detaches and never kills the
   session.
 - **Host terminal** (Review): a plain login shell on the pane's own
-  PTY as the host user, no sudo, no sandbox, full `gh` credentials and
-  no tmux at all: shells live and die with the app, a deliberate trade
-  after tmux-backed shells kept wedging their control clients. Because
-  a shell dies with its pane, every running shell stays mounted
-  whatever the window shows, and only the selected worktree's is
-  visible and takes keys: switching tabs, worktrees or pages leaves
-  shells running, and a shell ends only when the tab bar's Close shell
-  ends it, the shell itself exits, its worktree is destroyed or the
-  app quits. Both
+  PTY as the host user, no sudo, no sandbox, full `gh` credentials, the
+  editor variables pointing at the app's own shim and no tmux at all:
+  shells live and die with the app, a deliberate trade after
+  tmux-backed shells kept wedging their control clients. The pane a
+  shell runs in stays mounted whatever else the window shows, as the
+  panes section above describes, and the tab bar's Close shell ends
+  one instantly. Both
   terminals share one theme (black on white in light mode, white on
   black in dark); what separates them visually is position, the agent
   pane on the left and the shell in the utility pane. External attaches
@@ -473,6 +471,66 @@ Sendable` and `nonisolated(unsafe)` are banned.
    refresh via file watches.
 6. The pre-amend commit remains in the reflog and is surfaced as "revert last
    rejection".
+
+### Panes that outlive what is on screen (Review)
+
+Shells and browser pages die with their pane, so panes are mounted for as
+long as the thing inside them should live, not for as long as it is visible:
+
+1. Every running shell and every browser page opened so far stays mounted
+   whichever tab, worktree or middle page is on screen, with only the
+   selected worktree's shown and taking keys. The middle pages cover the
+   split rather than replacing it for the same reason.
+2. A shell ends when its Close button ends it, when the shell itself exits,
+   when its worktree is destroyed or when the app quits. A browser page ends
+   the same way, and its address is remembered per worktree, so a page closed
+   deliberately or lost to a restart opens again where it was.
+3. Because they accumulate, the session manager lists them beside the tmux
+   sessions: each browser page with what it is showing, the CPU and memory of
+   the web content process rendering it, and a Close. WebKit does not name
+   that process in public API, so it is asked for through the runtime only
+   when the view answers to the question, and a page it will not name shows
+   no figures rather than wrong ones.
+
+### Editing what a command is waiting on (Review)
+
+Commands run in a shell pane regularly want an editor: `git rebase -i` for
+its todo list, `git commit` for a message. They get the app's own, through a
+shim rather than a protocol:
+
+1. The shim is `bin/agentide` in the repository, shipped as a folder
+   reference inside the app bundle, so the script a shell runs is always the
+   one the running app was built with and the linters cover it like any other
+   script. A shell pane starts with that directory on `PATH`, `EDITOR`,
+   `VISUAL` and `GIT_EDITOR` naming it with `--wait`, `AGENTIDE=1` and
+   `AGENTIDE_EDITS` pointing at the spool to use. `GIT_SEQUENCE_EDITOR` is
+   deliberately left alone, so a `sequence.editor` chosen in git config still
+   wins for rebase todo lists. A login shell rebuilds `PATH` and re-exports
+   its own editor variables after all this, which is what `AGENTIDE` is for:
+   shell configuration can test for it and defer to the app. Dev builds hand
+   their panes their own spool, so a build under test never answers the
+   installed app's shells.
+2. The shim spools one request per file into the spool it was given, or
+   `~/.agentide/edits` when it was run from an ordinary terminal: a JSON file
+   named for a fresh uuid, carrying the file, the physical working directory
+   and its own process id, written to one side and renamed into place so the
+   app never reads half of one. Nothing inside the sandbox can reach that
+   directory, so an agent cannot queue an edit or see what is being edited.
+3. The window polls the spool (a small directory listing, off the main
+   actor), selects the worktree the command ran in, opens the utility pane on
+   its editor tab and shows the file, then writes an `.open` file. An
+   unclaimed request is how the shim knows no app is running: it says so and
+   exits non-zero rather than hanging.
+4. Saving and closing writes a `.done` file holding the exit status the shim
+   takes: zero when the file was saved, non-zero when the edit was cancelled,
+   which is how git is told to abort a rebase. The shim removes the files it
+   read, and a request whose process has gone is swept instead, so a shell
+   closed mid-rebase leaves nothing behind.
+5. The editor is the same one the review pane uses, with git's own files
+   highlighted by name rather than extension: rebase todo lists colour their
+   commands and commits, and commit messages colour the block git strips.
+   The file itself is regularly outside every worktree, since git keeps a
+   linked worktree's rebase state in the repository's own `.git` directory.
 
 ### Pull request dashboard (Ship)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -477,8 +477,18 @@ Sendable` and `nonisolated(unsafe)` are banned.
    the message was edited too). Failed validation degrades to whole-hunk
    rejection. Uncommitted changes skip the amend.
 5. Manual edits happen in the same editor surface; saves trigger a diff
-   refresh via file watches.
-6. The pre-amend commit remains in the reflog and is surfaced as "revert last
+   refresh via file watches. Every text surface in the app has macOS text
+   substitution turned off, in the app's own defaults for the SwiftUI fields
+   and on the editor's text view directly: curly quotes and em dashes are
+   wrong in code, commit messages and pull request bodies alike.
+6. Cmd-F goes to whatever holds focus. The editor is an `NSTextView` and both
+   terminals answer `performTextFinderAction`, so they get the system find
+   bar, Cmd-G and Cmd-Shift-G for free. A diff is a list of views rather than
+   one text view, so when nothing on the responder chain takes the action the
+   menu falls back to the storage bus and the review pane opens its own bar:
+   it tints every match in place and walks the hunks holding one, since a
+   hunk is the smallest thing the list can scroll to.
+7. The pre-amend commit remains in the reflog and is surfaced as "revert last
    rejection".
 
 ### Panes that outlive what is on screen (Review)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -184,10 +184,14 @@ Two visually unmistakable flavours ride that one client:
   session.
 - **Host terminal** (Review): a plain login shell on the pane's own
   PTY as the host user, no sudo, no sandbox, full `gh` credentials and
-  no tmux at all: shells stay mounted across tab switches but live and
-  die with the app, a deliberate trade after tmux-backed shells kept
-  wedging their control clients; the tab bar's Close shell ends one
-  instantly. Both
+  no tmux at all: shells live and die with the app, a deliberate trade
+  after tmux-backed shells kept wedging their control clients. Because
+  a shell dies with its pane, every running shell stays mounted
+  whatever the window shows, and only the selected worktree's is
+  visible and takes keys: switching tabs, worktrees or pages leaves
+  shells running, and a shell ends only when the tab bar's Close shell
+  ends it, the shell itself exits, its worktree is destroyed or the
+  app quits. Both
   terminals share one theme (black on white in light mode, white on
   black in dark); what separates them visually is position, the agent
   pane on the left and the shell in the utility pane. External attaches
@@ -217,6 +221,16 @@ the launch shape, tolerating "no server running"), a `ps` scan for session
 ids in process arguments, `git worktree list` across tracked repositories,
 transcript directory scans and finally its own metadata store. Unmatched
 sessions surface as foreign rather than being hidden.
+
+Deriving is not the same as trusting one reading. A reading that loses a
+worktree or a repository is never taken as proof it went away: its listing
+can fail, and `git worktree list` reports a worktree as detached rather than
+on a branch for the whole of a rebase. A row the newest reading dropped is
+kept while its directory is there, and only its removal from disk takes the
+row away. This is a display rule, not a cache: nothing is persisted and the
+next reading that lists the worktree wins. It matters because a row holds
+its worktree's panes open, and a pane holds a running shell (P1 still
+applies; disk is one of the sources).
 
 There is no separate notification daemon in v1. The app switches to accessory
 activation policy when its last window closes, staying resident in the menu

--- a/App/AgentIDEApp.swift
+++ b/App/AgentIDEApp.swift
@@ -9,6 +9,22 @@ struct AgentIDEApp: App {
         // A single-window app: disabling window tabs also removes the
         // stock Show Tab Bar and Show All Tabs items from View.
         NSWindow.allowsAutomaticWindowTabbing = false
+        // Every field here holds code, a commit message or a pull
+        // request body, and text substitution turns quotes into
+        // curly ones and double dashes into em dashes in all of
+        // them. The app's own defaults turn it off for the SwiftUI
+        // fields, whose text views it cannot otherwise reach; the
+        // code editor sets the same switches on itself.
+        for key in [
+            "NSAutomaticQuoteSubstitutionEnabled",
+            "NSAutomaticDashSubstitutionEnabled",
+            "NSAutomaticTextReplacementEnabled",
+            "NSAutomaticSpellingCorrectionEnabled",
+            "NSAutomaticCapitalizationEnabled",
+            "NSAutomaticPeriodSubstitutionEnabled",
+        ] {
+            UserDefaults.standard.set(false, forKey: key)
+        }
     }
 
     // MARK: Internal

--- a/App/AppCommands.swift
+++ b/App/AppCommands.swift
@@ -1,3 +1,4 @@
+import AppKit
 import DashboardFeature
 import SwiftUI
 
@@ -34,6 +35,14 @@ struct AppCommands: Commands {
             Divider()
             Button("Refresh") { bump("dashboardRefreshRequest") }
                 .keyboardShortcut("r", modifiers: .command)
+        }
+        CommandGroup(after: .textEditing) {
+            Button("Find…") { find(.showFindInterface) }
+                .keyboardShortcut("f", modifiers: .command)
+            Button("Find Next") { find(.nextMatch) }
+                .keyboardShortcut("g", modifiers: .command)
+            Button("Find Previous") { find(.previousMatch) }
+                .keyboardShortcut("g", modifiers: [.command, .shift])
         }
         CommandGroup(after: .sidebar) {
             // The repository sidebar never hides, only resizes, so
@@ -75,6 +84,33 @@ struct AppCommands: Commands {
     /// action observes it and runs.
     private func bump(_ key: String) {
         UserDefaults.standard.set(UserDefaults.standard.integer(forKey: key) + 1, forKey: key)
+    }
+
+    /// Finding goes to whatever is focused: the editor and the
+    /// terminals answer AppKit's standard action, and the review
+    /// pane, which is a list of views rather than a text view, gets
+    /// the request through the storage bus when nothing else took it.
+    private func find(_ action: NSTextFinder.Action) {
+        let item = NSMenuItem()
+        item.tag = action.rawValue
+        guard NSApp.sendAction(
+            #selector(NSResponder.performTextFinderAction(_:)),
+            to: nil,
+            from: item,
+        ) == false else {
+            return
+        }
+
+        switch action {
+        case .nextMatch:
+            bump("reviewFindNextRequest")
+
+        case .previousMatch:
+            bump("reviewFindPreviousRequest")
+
+        default:
+            bump("reviewFindRequest")
+        }
     }
 
     private func show(_ tab: UtilityTab) {

--- a/App/RootView+Panes.swift
+++ b/App/RootView+Panes.swift
@@ -1,10 +1,67 @@
 import AgentIDEDomain
+import SessionFeature
 import SwiftUI
 
 // MARK: - Shell layers
 
 /// The shell tab's layers, split from the view for length.
 extension RootView {
+    /// A running shell stays mounted whichever tab, worktree or page
+    /// shows, so its terminal survives everything short of destroying
+    /// the worktree it runs in. Both layers always fill the pane, so
+    /// switches never resize a hidden terminal; a resize would make
+    /// the shell reprint its prompt, which reads as stray newlines.
+    /// Shells start only from their button, and a quit shell (Ctrl-D)
+    /// returns to it.
+    func utilityContent(for item: WorktreeItem) -> some View {
+        let showsShell = utilityTab == .shell
+        let showsBrowser = utilityTab == .browser
+        let path = item.worktree.path
+        return ZStack {
+            shellLayers(for: item)
+                .opacity(showsShell ? 1 : 0)
+                .allowsHitTesting(showsShell)
+            if showsShell == false, showsBrowser == false {
+                // Identity keyed by worktree, so switching in the
+                // sidebar always rebuilds the pane's state. The
+                // backgrounds must not expand into the ignored
+                // titlebar safe area, where they would paint over
+                // the tab header above.
+                switchedUtility(for: item, conversationPath: conversationWorktree)
+                    .id("utility-" + path)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    .background(.background, ignoresSafeAreaEdges: [])
+            }
+            // Like the shells, every browser opened so far stays
+            // mounted, so a page survives tab and worktree switches
+            // without reloading; only this worktree's is shown.
+            browserLayers(for: item)
+                .opacity(showsBrowser ? 1 : 0)
+                .allowsHitTesting(showsBrowser)
+        }
+        .task(id: item.id + utilityTabName) {
+            if utilityTab == .browser {
+                visitBrowser(at: path)
+            }
+        }
+    }
+
+    /// Every browser page opened so far, kept loaded whichever
+    /// worktree is being worked in: the session manager lists what
+    /// they cost and closes the ones that are not worth it.
+    @ViewBuilder
+    func browserLayers(for item: WorktreeItem) -> some View {
+        let path = item.worktree.path
+        ForEach(visitedBrowserPaths, id: \.self) { browserPath in
+            let isShown = browserPath == path
+            BrowserView(worktreePath: browserPath, isActive: isShown && utilityTab == .browser)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(.background, ignoresSafeAreaEdges: [])
+                .opacity(isShown ? 1 : 0)
+                .allowsHitTesting(isShown)
+        }
+    }
+
     /// Every running shell, not just the selected worktree's: a shell
     /// dies with its pane, and switching worktrees or opening a page
     /// is not destroying a worktree. Only the selected worktree's

--- a/App/RootView+Panes.swift
+++ b/App/RootView+Panes.swift
@@ -1,0 +1,50 @@
+import AgentIDEDomain
+import SwiftUI
+
+// MARK: - Shell layers
+
+/// The shell tab's layers, split from the view for length.
+extension RootView {
+    /// Every running shell, not just the selected worktree's: a shell
+    /// dies with its pane, and switching worktrees or opening a page
+    /// is not destroying a worktree. Only the selected worktree's
+    /// shell shows and takes keys. The close button hard-terminates
+    /// shells that cannot Ctrl-D out.
+    @ViewBuilder
+    func shellLayers(for item: WorktreeItem) -> some View {
+        let path = item.worktree.path
+        ForEach(runningShellPaths, id: \.self) { shellPath in
+            let isShown = shellPath == path
+            // The closure stays a non-final argument: the formatter
+            // rewrites a trailing one after a multiline call.
+            shellTerminal(
+                at: shellPath,
+                onExit: { closeShell(at: shellPath) },
+                isActive: isShown && utilityTab == .shell && isCovered == false,
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .opacity(isShown ? 1 : 0)
+            .allowsHitTesting(isShown)
+        }
+        if hasRunningShell(at: path) == false {
+            StartShellButton { startShell(at: path) }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+// MARK: - StartShellButton
+
+/// The shell tab's empty state: one button that starts the shell.
+private struct StartShellButton: View {
+    let onStart: () -> Void
+
+    var body: some View {
+        Button(action: onStart) {
+            Label("Start shell", systemImage: "terminal")
+        }
+        .buttonStyle(.glass)
+        .controlSize(.large)
+        .hoverHelp("Open a host-user shell here; it runs until you close it or the app quits")
+    }
+}

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -221,25 +221,27 @@ extension RootView {
 extension RootView {
     /// The agent terminal: copies are prose, so multi-line copies
     /// reflow for pasting into chat and pull request bodies.
-    func agentTerminal(for session: AgentSession) -> TerminalPaneView {
+    func agentTerminal(for session: AgentSession, isActive: Bool) -> TerminalPaneView {
         TerminalPaneView(
             command: dependencies.service.attachCommand(sessionName: session.name),
             reflowsCopies: true,
+            isActive: isActive,
         )
     }
 
     /// The host shell terminal, a plain local shell on the pane's
     /// own PTY: no server to wedge and nothing left behind when the
     /// app quits. Copies stay verbatim for code. The pane stays
-    /// mounted behind other tabs, so it reports whether it is the
-    /// visible one and yields keyboard focus otherwise.
+    /// mounted behind other tabs, worktrees and pages, so it reports
+    /// whether it is the visible one and yields keyboard focus
+    /// otherwise.
     func shellTerminal(
-        for worktree: Worktree,
-        isActive: Bool,
+        at path: String,
         onExit: @escaping @MainActor () -> Void,
+        isActive: Bool,
     ) -> TerminalPaneView {
         TerminalPaneView(
-            shellIn: worktree.path,
+            shellIn: path,
             isActive: isActive,
             onProcessTerminated: onExit,
         )

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -76,6 +76,34 @@ extension RootView {
         .padding(Self.stripSpacing)
     }
 
+    /// Everything the app has running, listed with what it costs.
+    var sessionManager: some View {
+        SessionManagerSheet(
+            service: dependencies.service,
+            onCloseBrowser: { closeBrowser(at: $0) },
+            onDismiss: { dependencies.dashboard.showsSessionManager = false },
+        )
+    }
+
+    /// A repository page's conversations, across all its worktrees.
+    func repositoryConversations(for item: WorktreeItem) -> some View {
+        RepositorySessionsView(
+            repository: repository(of: item),
+            service: dependencies.service,
+            onWorktreeFocus: { focusConversation(at: $0) },
+            onResumed: { await dependencies.dashboard.refresh() },
+        )
+    }
+
+    /// One worktree's own past conversations.
+    func worktreeConversations(for item: WorktreeItem) -> some View {
+        RepositorySessionsView(
+            repository: repository(of: item),
+            service: dependencies.service,
+            worktreePath: item.worktree.path,
+        ) { await sessionStarted() }
+    }
+
     func repository(of item: WorktreeItem) -> Repository {
         Repository(
             name: item.worktree.repositoryName,
@@ -242,6 +270,7 @@ extension RootView {
     ) -> TerminalPaneView {
         TerminalPaneView(
             shellIn: path,
+            environment: dependencies.service.shellEnvironment(),
             isActive: isActive,
             onProcessTerminated: onExit,
         )
@@ -266,7 +295,10 @@ extension RootView {
     func switchedUtility(for item: WorktreeItem, conversationPath: String?) -> some View {
         let target = reviewTarget(for: item, conversationPath: conversationPath)
         switch utilityTab {
-        case .shell:
+        // Both keep their own always-mounted layers, so the
+        // switched content has nothing to show for them.
+        case .browser,
+             .shell:
             EmptyView()
 
         case .review:
@@ -278,7 +310,11 @@ extension RootView {
             )
 
         case .editor:
-            EditorPane(worktreePath: item.worktree.path, service: dependencies.service)
+            EditorPane(
+                worktreePath: item.worktree.path,
+                service: dependencies.service,
+                waitingEdit: waitingEdit(in: item.worktree.path),
+            )
 
         case .pullRequests:
             PullRequestsView(
@@ -290,9 +326,6 @@ extension RootView {
                 branch: target.worktree.branch,
                 isMainCheckout: target.worktree.path == target.worktree.repositoryPath,
             )
-
-        case .browser:
-            BrowserView()
 
         case .errors:
             ErrorsPane()

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -2,7 +2,6 @@ import AgentIDEDomain
 import DashboardFeature
 import SessionFeature
 import SwiftUI
-import TerminalUI
 
 // MARK: - RootView
 
@@ -23,6 +22,19 @@ struct RootView: View {
     /// Internal so the extension file's toggle button can drive it.
     @AppStorage("showsUtilityPane")
     var showsUtilityPane = true
+
+    /// Whether a middle page covers the split: its panes stay
+    /// mounted underneath and must not take clicks or keystrokes.
+    var isCovered: Bool {
+        dependencies.dashboard.showsNewSession || dependencies.dashboard.showsRepositoryFinder
+    }
+
+    /// The shells running now, in a stable order so mounting one
+    /// more never remounts the rest; internal accessors because the
+    /// extension files cannot see the view's own state.
+    var runningShellPaths: [String] {
+        runningShells.sorted()
+    }
 
     var body: some View {
         // Plain panes with our own dividers: the navigation split
@@ -76,6 +88,12 @@ struct RootView: View {
         .onChange(of: dashboardRefreshRequest) {
             Task { await dependencies.dashboard.refresh() }
         }
+        // A destroyed worktree takes its shell with it; a worktree
+        // the sidebar merely stopped listing keeps its row, so
+        // nothing else closes a shell pane behind the user's back.
+        .onChange(of: dependencies.dashboard.worktreePaths) { _, paths in
+            runningShells.formIntersection(paths)
+        }
         // Reopening the app resumes the restored worktree's most
         // recent conversation: the default workflow is picking up
         // where the last session left off. Only the launch's
@@ -105,10 +123,14 @@ struct RootView: View {
         }
     }
 
-    /// Whether a worktree's shell runs; internal accessors because
-    /// the extension file's tab bar cannot see the private state.
+    /// Whether a worktree's shell runs.
     func hasRunningShell(at path: String) -> Bool {
         runningShells.contains(path)
+    }
+
+    /// Starts a worktree's shell by mounting its pane.
+    func startShell(at path: String) {
+        runningShells.insert(path)
     }
 
     /// Ends a worktree's shell instantly: unmounting the pane kills
@@ -161,10 +183,14 @@ struct RootView: View {
     @AppStorage("dashboardRefreshRequest")
     private var dashboardRefreshRequest = 0
 
+    /// Worktrees whose browser has been opened; it stays mounted so
+    /// its page survives tab switches.
+    @State private var visitedBrowsers: Set<String> = []
+
     /// Worktrees whose shell is running; started explicitly, removed
-    /// when the shell process exits or is closed, so the start
-    /// button returns. Shells are plain local processes now, so
-    /// nothing persists across launches.
+    /// when the shell process exits, is closed or its worktree is
+    /// destroyed, so the start button returns. Shells are plain
+    /// local processes, so nothing persists across launches.
     @State private var runningShells: Set<String> = []
 
     /// Each worktree's last utility tab, persisted as
@@ -172,10 +198,6 @@ struct RootView: View {
     @AppStorage("worktreeTabs")
     private var worktreeTabs = ""
     @State private var rememberedTabs: [String: String] = [:]
-
-    /// Worktrees whose browser has been opened; it stays mounted so
-    /// its page survives tab switches.
-    @State private var visitedBrowsers: Set<String> = []
 
     /// Pane widths, persisted so the layout restores on relaunch;
     /// the dividers write them directly.
@@ -189,20 +211,28 @@ struct RootView: View {
         runningShells.isEmpty == false || runningWorktreePaths.isEmpty == false
     }
 
-    @ViewBuilder private var detail: some View {
-        if dependencies.dashboard.showsNewSession {
-            // The middle pane, never a sheet.
-            NewSessionPane(model: dependencies.dashboard)
-        } else if dependencies.dashboard.showsRepositoryFinder {
-            RepositoryFinderPane(model: dependencies.dashboard)
-        } else if let item = dependencies.dashboard.selection {
-            split(for: item)
-        } else {
-            ContentUnavailableView(
-                "No worktree selected",
-                systemImage: "rectangle.stack",
-                description: Text("Pick a worktree on the left or create a session."),
-            )
+    /// The middle pages, never sheets, cover the split rather than
+    /// replacing it: unmounting the split takes its panes with it,
+    /// and a pane can hold a running shell, which only destroying
+    /// its worktree should end.
+    private var detail: some View {
+        ZStack {
+            if let item = dependencies.dashboard.selection {
+                split(for: item)
+                    .opacity(isCovered ? 0 : 1)
+                    .allowsHitTesting(isCovered == false)
+            } else if isCovered == false {
+                ContentUnavailableView(
+                    "No worktree selected",
+                    systemImage: "rectangle.stack",
+                    description: Text("Pick a worktree on the left or create a session."),
+                )
+            }
+            if dependencies.dashboard.showsNewSession {
+                NewSessionPane(model: dependencies.dashboard)
+            } else if dependencies.dashboard.showsRepositoryFinder {
+                RepositoryFinderPane(model: dependencies.dashboard)
+            }
         }
     }
 
@@ -280,7 +310,7 @@ struct RootView: View {
             ProgressView("Resuming conversation…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let session = item.session {
-            agentTerminal(for: session)
+            agentTerminal(for: session, isActive: isCovered == false)
                 .id(session.name)
                 // Dropped files stage into the shared workspace (the
                 // sandbox cannot read host paths) and their staged
@@ -315,19 +345,19 @@ struct RootView: View {
         }
     }
 
-    /// A running shell stays mounted whichever tab shows, so its
-    /// terminal survives tab switches; host tmux additionally keeps
-    /// the shell alive across app restarts. Both layers always fill
-    /// the pane, so tab switches never resize the hidden terminal; a
-    /// resize would make the shell reprint its prompt, which reads as
-    /// stray newlines. Shells start only from their button, and a
-    /// quit shell (Ctrl-D) returns to it.
+    /// A running shell stays mounted whichever tab, worktree or page
+    /// shows, so its terminal survives everything short of destroying
+    /// the worktree it runs in. Both layers always fill the pane, so
+    /// switches never resize a hidden terminal; a resize would make
+    /// the shell reprint its prompt, which reads as stray newlines.
+    /// Shells start only from their button, and a quit shell (Ctrl-D)
+    /// returns to it.
     private func utilityContent(for item: WorktreeItem) -> some View {
         let showsShell = utilityTab == .shell
         let showsBrowser = utilityTab == .browser
         let path = item.worktree.path
         return ZStack {
-            shellLayer(for: item)
+            shellLayers(for: item)
                 .opacity(showsShell ? 1 : 0)
                 .allowsHitTesting(showsShell)
             if showsShell == false, showsBrowser == false {
@@ -357,41 +387,5 @@ struct RootView: View {
                 visitedBrowsers.insert(path)
             }
         }
-    }
-
-    /// The shell tab's layer, always mounted while its shell runs so
-    /// the terminal survives tab switches at a constant size. The
-    /// close button hard-terminates shells that cannot Ctrl-D out.
-    @ViewBuilder
-    private func shellLayer(for item: WorktreeItem) -> some View {
-        let path = item.worktree.path
-        if runningShells.contains(path) {
-            shellTerminal(for: item.worktree, isActive: utilityTab == .shell) {
-                runningShells.remove(path)
-            }
-            .id("shell-" + path)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
-            StartShellButton {
-                runningShells.insert(path)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-    }
-}
-
-// MARK: - StartShellButton
-
-/// The shell tab's empty state: one button that starts the shell.
-private struct StartShellButton: View {
-    let onStart: () -> Void
-
-    var body: some View {
-        Button(action: onStart) {
-            Label("Start shell", systemImage: "terminal")
-        }
-        .buttonStyle(.glass)
-        .controlSize(.large)
-        .hoverHelp("Open a host-user shell here; it lives and dies with the app")
     }
 }

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -1,6 +1,5 @@
 import AgentIDEDomain
 import DashboardFeature
-import SessionFeature
 import SwiftUI
 
 // MARK: - RootView
@@ -36,6 +35,17 @@ struct RootView: View {
         runningShells.sorted()
     }
 
+    /// The worktree whose conversation the review surfaces follow,
+    /// and the browsers already opened; internal accessors because
+    /// the extension files cannot see the view's own state.
+    var conversationWorktree: String? {
+        conversationWorktreePath
+    }
+
+    var visitedBrowserPaths: [String] {
+        visitedBrowsers.sorted()
+    }
+
     var body: some View {
         // Plain panes with our own dividers: the navigation split
         // view's floating toggle covered nearby controls and split
@@ -56,16 +66,18 @@ struct RootView: View {
         }
         .ignoresSafeArea(.container, edges: .top)
         .background(WindowConfigurator())
-        .sheet(isPresented: sessionManagerBinding) {
-            SessionManagerSheet(service: dependencies.service) {
-                dependencies.dashboard.showsSessionManager = false
-            }
-        }
+        .sheet(isPresented: sessionManagerBinding) { sessionManager }
         .task {
             FlavourIcon.apply()
             finderFocusRequest = 0
             rememberedTabs = Self.decodeTabs(worktreeTabs)
             await dependencies.dashboard.poll()
+        }
+        // A shell command waiting on an editor is stopped until this
+        // window shows it the file, so it is watched for separately
+        // from the dashboard's own slower poll.
+        .task {
+            await waiting.watch(service: dependencies.service, dashboard: dependencies.dashboard)
         }
         // Sleep sometimes kills the sandbox tmux server; sessions
         // running at sleep that are gone at wake resume themselves,
@@ -88,11 +100,12 @@ struct RootView: View {
         .onChange(of: dashboardRefreshRequest) {
             Task { await dependencies.dashboard.refresh() }
         }
-        // A destroyed worktree takes its shell with it; a worktree
-        // the sidebar merely stopped listing keeps its row, so
-        // nothing else closes a shell pane behind the user's back.
+        // A destroyed worktree takes its shell and browser page with
+        // it; a worktree the sidebar merely stopped listing keeps its
+        // row, so nothing else closes a pane behind the user's back.
         .onChange(of: dependencies.dashboard.worktreePaths) { _, paths in
             runningShells.formIntersection(paths)
+            visitedBrowsers.formIntersection(paths)
         }
         // Reopening the app resumes the restored worktree's most
         // recent conversation: the default workflow is picking up
@@ -121,6 +134,29 @@ struct RootView: View {
                 isAutoResuming = false
             }
         }
+    }
+
+    /// The file a command is waiting on in a worktree, which its
+    /// editor pane shows instead of the finder.
+    func waitingEdit(in worktreePath: String) -> ExternalEdit? {
+        waiting.edit(in: worktreePath)
+    }
+
+    func visitBrowser(at path: String) {
+        visitedBrowsers.insert(path)
+    }
+
+    /// Closes a browser page: unmounting the pane ends the web
+    /// process it costs, and the address stays remembered so opening
+    /// the tab again brings the page back.
+    func closeBrowser(at path: String) {
+        visitedBrowsers.remove(path)
+    }
+
+    /// Points the review surfaces at the conversation picked on a
+    /// repository page, so clicking around retargets Review and PRs.
+    func focusConversation(at path: String?) {
+        conversationWorktreePath = path
     }
 
     /// Whether a worktree's shell runs.
@@ -186,6 +222,10 @@ struct RootView: View {
     /// Worktrees whose browser has been opened; it stays mounted so
     /// its page survives tab switches.
     @State private var visitedBrowsers: Set<String> = []
+
+    /// The files commands are waiting on, which take the utility
+    /// pane over until they are dealt with.
+    @State private var waiting: WaitingEdits = .init()
 
     /// Worktrees whose shell is running; started explicitly, removed
     /// when the shell process exits, is closed or its worktree is
@@ -319,21 +359,9 @@ struct RootView: View {
                     dropFiles(urls, into: session.name)
                 }
         } else if item.worktree.path == item.worktree.repositoryPath {
-            RepositorySessionsView(
-                repository: repository(of: item),
-                service: dependencies.service,
-                // The review surfaces follow the selected
-                // conversation's worktree, so clicking around the
-                // repository page retargets Review and PRs.
-                onWorktreeFocus: { conversationWorktreePath = $0 },
-                onResumed: { await dependencies.dashboard.refresh() },
-            )
+            repositoryConversations(for: item)
         } else if item.pastSessions.isEmpty == false {
-            RepositorySessionsView(
-                repository: repository(of: item),
-                service: dependencies.service,
-                worktreePath: item.worktree.path,
-            ) { await sessionStarted() }
+            worktreeConversations(for: item)
         } else {
             CreateSessionPane(
                 worktree: item.worktree,
@@ -342,50 +370,6 @@ struct RootView: View {
                 onResume: { await resumeLatest(in: item) },
                 onStarted: { await sessionStarted() },
             )
-        }
-    }
-
-    /// A running shell stays mounted whichever tab, worktree or page
-    /// shows, so its terminal survives everything short of destroying
-    /// the worktree it runs in. Both layers always fill the pane, so
-    /// switches never resize a hidden terminal; a resize would make
-    /// the shell reprint its prompt, which reads as stray newlines.
-    /// Shells start only from their button, and a quit shell (Ctrl-D)
-    /// returns to it.
-    private func utilityContent(for item: WorktreeItem) -> some View {
-        let showsShell = utilityTab == .shell
-        let showsBrowser = utilityTab == .browser
-        let path = item.worktree.path
-        return ZStack {
-            shellLayers(for: item)
-                .opacity(showsShell ? 1 : 0)
-                .allowsHitTesting(showsShell)
-            if showsShell == false, showsBrowser == false {
-                // Identity keyed by worktree, so switching in the
-                // sidebar always rebuilds the pane's state. The
-                // backgrounds must not expand into the ignored
-                // titlebar safe area, where they would paint over
-                // the tab header above.
-                switchedUtility(for: item, conversationPath: conversationWorktreePath)
-                    .id("utility-" + path)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                    .background(.background, ignoresSafeAreaEdges: [])
-            }
-            // Like the shell, a visited browser stays mounted so its
-            // page survives tab switches without reloading.
-            if visitedBrowsers.contains(path) {
-                BrowserView()
-                    .id("browser-" + path)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(.background, ignoresSafeAreaEdges: [])
-                    .opacity(showsBrowser ? 1 : 0)
-                    .allowsHitTesting(showsBrowser)
-            }
-        }
-        .task(id: item.id + utilityTabName) {
-            if utilityTab == .browser {
-                visitedBrowsers.insert(path)
-            }
         }
     }
 }

--- a/App/WaitingEdits.swift
+++ b/App/WaitingEdits.swift
@@ -1,0 +1,78 @@
+import AgentIDEData
+import AgentIDEDomain
+import DashboardFeature
+import Foundation
+import Observation
+import TerminalUI
+
+/// The files commands outside the app are waiting to have edited,
+/// watched for and brought to the front. A shell running `git rebase
+/// -i` is stopped until one of them is dealt with, so a request
+/// takes over the window rather than waiting to be noticed.
+@Observable
+@MainActor
+final class WaitingEdits {
+    // MARK: Lifecycle
+
+    deinit {
+        // The watching task is owned by the window.
+    }
+
+    // MARK: Internal
+
+    /// Every request still waiting, oldest first.
+    private(set) var all: [ExternalEdit] = []
+
+    /// The file a command is waiting on in a worktree, which its
+    /// editor pane shows instead of the finder.
+    func edit(in worktreePath: String) -> ExternalEdit? {
+        all.first { $0.belongs(toWorktree: worktreePath) }
+    }
+
+    /// Watches the spool for as long as the window lives, bringing
+    /// each new request to the front and telling its shim the app
+    /// has the file. Whatever the pane was showing comes back once
+    /// nothing is waiting, so a rebase returns to its own shell.
+    func watch(service: SessionService, dashboard: DashboardModel) async {
+        for await edits in service.pendingEdits() {
+            all = edits
+            if edits.isEmpty {
+                restorePane()
+            }
+            guard let edit = edits.first, edit.id != shown else {
+                continue
+            }
+
+            shown = edit.id
+            takeOverPane(for: edit, dashboard: dashboard)
+            await service.claimEdit(edit)
+        }
+    }
+
+    // MARK: Private
+
+    /// The request already brought to the front, so each one
+    /// interrupts once, and the tab to go back to afterwards.
+    private var shown: String?
+    private var previousTab: String?
+
+    private func takeOverPane(for edit: ExternalEdit, dashboard: DashboardModel) {
+        let items = dashboard.groups.flatMap(\.items)
+        if let item = items.first(where: { edit.belongs(toWorktree: $0.worktree.path) }) {
+            dashboard.select(item)
+        }
+        let defaults = UserDefaults.standard
+        previousTab = previousTab ?? defaults.string(forKey: UtilityTabTarget.key)
+        defaults.set(true, forKey: UtilityTabTarget.visibilityKey)
+        defaults.set(UtilityTabTarget.editor, forKey: UtilityTabTarget.key)
+    }
+
+    private func restorePane() {
+        guard let previousTab else {
+            return
+        }
+
+        self.previousTab = nil
+        UserDefaults.standard.set(previousTab, forKey: UtilityTabTarget.key)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ before shipping.
   remembers its address for the next time and lists every loaded page in
   the session manager with what it costs and a Close (so a dev server stays
   logged in and mid-flow, and a page eating memory is easy to find and end)
+- **Finds** with Cmd-F wherever you are: the editor and both terminals get
+  the system find bar, and the diff gets its own with match highlighting and
+  Cmd-G walking the matches; nothing anywhere turns your quotes curly or your
+  dashes long (so code and commit messages survive being typed)
 - **Edits** whatever that terminal's commands open, a `git rebase -i` todo list
   or a commit message, in the same editor with their own highlighting, because
   an `agentide` command on its `PATH` blocks until you save and close and

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ before shipping.
   than the app (so agents survive AgentIDE quitting, crashing or
   updating, expectedly or not; the host shell tab deliberately does not,
   living and dying with the app)
+- **Keeps** every running shell alive while you move around the app and
+  keeps a worktree listed until it is really gone, rebases and failed
+  listings included (so only closing a shell or destroying its worktree
+  ends it)
 - **Defers** idle sleep while agents or shells run and resumes sessions the
   sleep killed when the Mac wakes (so a long response survives you
   walking away; closing the lid still sleeps)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ before shipping.
 - **Previews** web pages and rendered Markdown in an embedded browser and opens an
   embedded terminal running as your own user (so you can verify behaviour and
   use `git`, `gh` and other CLI tools without leaving the window)
+- **Keeps** each worktree's page loaded as you work in other worktrees,
+  remembers its address for the next time and lists every loaded page in
+  the session manager with what it costs and a Close (so a dev server stays
+  logged in and mid-flow, and a page eating memory is easy to find and end)
+- **Edits** whatever that terminal's commands open, a `git rebase -i` todo list
+  or a commit message, in the same editor with their own highlighting, because
+  an `agentide` command on its `PATH` blocks until you save and close and
+  `EDITOR`, `VISUAL` and `GIT_EDITOR` there name it (so interactive rebasing
+  needs no terminal editor, and cancelling aborts the rebase as `:cq` would)
 
 ### 🚢 Ship
 
@@ -167,6 +176,18 @@ open /Applications/AgentIDE.app
   for quick development runs.
 - **Features** land slice by slice (see [Status](#-status)); the app launches
   to an empty dashboard until the first slices fill it.
+
+A shell pane runs your login shell, so anything your shell configuration
+exports wins over what the pane was started with. It sets `AGENTIDE=1` and
+puts the bundled `agentide` command on `PATH`, so shell files that set an
+editor of their own can hand those panes back to the app:
+
+```bash
+if [ -n "${AGENTIDE}" ]; then
+  export EDITOR="$(command -v agentide) --wait"
+  export VISUAL="${EDITOR}"
+fi
+```
 
 ## 🚧 Status
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ before shipping.
   whether a rebase would move the base, sign commits or both, then opens
   pull requests from an in-app form that fills in the project's own
   template below your title and body, defaulting both from a single
-  commit or drafting them from many with the on-device model (so
-  shipping needs no retyping)
+  commit, unwrapped from the narrow column commit messages are written
+  to, or drafting them from many with the on-device model (so shipping
+  needs no retyping)
 - **Copies** unresolved review comments, or failing CI steps with their
   actual log output, straight into a prompt, resolves conversations one
   by one, resolves merge conflicts and enables automerge or merges,

--- a/Sources/AgentIDEData/EditorShim.swift
+++ b/Sources/AgentIDEData/EditorShim.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// The `agentide` editor shim: a script inside the app bundle that a
+/// shell pane finds on its `PATH`, so `git rebase -i` and `git
+/// commit` there edit their files in the app's own editor and wait
+/// for them. Shipping it in the bundle means the script the shell
+/// runs is always the one the running app was built with.
+struct EditorShim {
+    // MARK: Lifecycle
+
+    /// Creates the shim for a workspace. `directory` is the bundled
+    /// `bin` by default, and the repository's own copy under test,
+    /// where there is no app bundle to look in.
+    init(paths: WorkspacePaths, directory: String? = nil) {
+        self.paths = paths
+        self.directory = directory ?? (Bundle.main.resourcePath ?? ".") + "/bin"
+    }
+
+    // MARK: Internal
+
+    /// Where the shim is, which is what `which agentide` answers in
+    /// a shell pane.
+    var path: String {
+        directory + "/agentide"
+    }
+
+    /// What a host shell needs to reach it: the shim's directory on
+    /// `PATH`, the editor variables naming it, the spool it should
+    /// write to and a flag shell configuration can test for. A login
+    /// shell runs its own files after this, so anything it sets for
+    /// itself wins; `AGENTIDE` is there so it can decide to.
+    var environment: [String: String] {
+        let command = path + " --wait"
+        return [
+            "AGENTIDE": "1",
+            "AGENTIDE_EDITS": paths.editsDirectory,
+            "EDITOR": command,
+            "VISUAL": command,
+            "GIT_EDITOR": command,
+            // A login shell rebuilds its own PATH from this, so the
+            // standard directories are here for the moment before it
+            // does, and for a shell whose files never get that far.
+            "PATH": directory + ":" + Self.standardPath,
+        ]
+    }
+
+    // MARK: Private
+
+    /// What a shell starts with when nothing hands it a PATH.
+    private static let standardPath = "/usr/bin:/bin:/usr/sbin:/sbin"
+
+    private let paths: WorkspacePaths
+    private let directory: String
+}

--- a/Sources/AgentIDEData/ExternalEditSpool.swift
+++ b/Sources/AgentIDEData/ExternalEditSpool.swift
@@ -1,0 +1,89 @@
+import AgentIDEDomain
+import Foundation
+
+/// The editor shim's spool: one request file per file a command is
+/// waiting on, answered by a status file the shim reads and removes.
+/// It lives in the host user's own directory, so nothing inside the
+/// sandbox can queue an edit or read what is being edited.
+struct ExternalEditSpool {
+    // MARK: Lifecycle
+
+    /// Creates a spool for a directory.
+    init(directory: String) {
+        self.directory = directory
+    }
+
+    // MARK: Internal
+
+    /// Every request still waiting, oldest first. Requests whose
+    /// command has gone (the shell it ran in closed, or the user
+    /// interrupted it) are swept, so a dead command never holds a
+    /// pane open.
+    func pending() -> [ExternalEdit] {
+        let manager = FileManager.default
+        let names = (try? manager.contentsOfDirectory(atPath: directory)) ?? []
+        var edits = [(edit: ExternalEdit, requestedAt: Date)]()
+        for name in names.sorted() where name.hasSuffix(Self.requestSuffix) {
+            let id = String(name.dropLast(Self.requestSuffix.count))
+            let path = directory + "/" + name
+            guard let data = manager.contents(atPath: path),
+                  let edit = ExternalEdit(id: id, json: data),
+                  kill(edit.processIdentifier, 0) == 0 || errno == EPERM
+            else {
+                remove(id: id)
+                continue
+            }
+            guard manager.fileExists(atPath: self.path(id: id, suffix: Self.doneSuffix)) == false else {
+                continue
+            }
+
+            let attributes = try? manager.attributesOfItem(atPath: path)
+            edits.append((edit, attributes?[.creationDate] as? Date ?? .distantPast))
+        }
+        return edits.sorted { $0.requestedAt < $1.requestedAt }.map(\.edit)
+    }
+
+    /// Tells the shim the app has the file on screen, so a shim that
+    /// is never claimed can report that the app is not running
+    /// rather than waiting for an editor that will never appear.
+    func claim(_ edit: ExternalEdit) {
+        write("", to: path(id: edit.id, suffix: Self.openSuffix))
+    }
+
+    /// Answers a request: a saved file lets the command carry on, a
+    /// cancelled one fails it, which is how git is told to abort a
+    /// rebase. The shim removes the files it read, and a request
+    /// whose shim has gone is swept rather than answered.
+    func finish(_ edit: ExternalEdit, saved: Bool) {
+        write(saved ? "0" : "1", to: path(id: edit.id, suffix: Self.doneSuffix))
+    }
+
+    // MARK: Private
+
+    private static let requestSuffix = ".request"
+    private static let openSuffix = ".open"
+    private static let doneSuffix = ".done"
+
+    private let directory: String
+
+    private func path(id: String, suffix: String) -> String {
+        directory + "/" + id + suffix
+    }
+
+    /// Answers land in one rename, so the shim never reads half of
+    /// one.
+    private func write(_ contents: String, to path: String) {
+        let partial = path + ".partial"
+        guard (try? contents.write(toFile: partial, atomically: false, encoding: .utf8)) != nil else {
+            return
+        }
+
+        try? FileManager.default.moveItem(atPath: partial, toPath: path)
+    }
+
+    private func remove(id: String) {
+        for suffix in [Self.requestSuffix, Self.openSuffix, Self.doneSuffix] {
+            try? FileManager.default.removeItem(atPath: path(id: id, suffix: suffix))
+        }
+    }
+}

--- a/Sources/AgentIDEData/GitClient.swift
+++ b/Sources/AgentIDEData/GitClient.swift
@@ -64,21 +64,41 @@ public struct GitClient: Sendable {
     public func worktrees(of repository: Repository) async throws -> [Worktree] {
         let output = try await git(["worktree", "list", "--porcelain"], in: repository.path).standardOutput
         var path: String?
+        var branch: String?
         var index = -1
         var results = [Worktree]()
+
+        func flush() {
+            guard let currentPath = path, index > 0 else {
+                return
+            }
+
+            results.append(Worktree(
+                repositoryName: repository.name,
+                repositoryPath: repository.path,
+                // A worktree with no branch line is detached, which
+                // is how git leaves one throughout a rebase. Its
+                // directory is named for its branch, which is what it
+                // was and will be again; requiring the branch line
+                // dropped the worktree from the sidebar mid-rebase,
+                // and taking its row away killed the shell running
+                // in it.
+                branch: branch ?? URL(fileURLWithPath: currentPath).lastPathComponent,
+                path: currentPath,
+            ))
+        }
+
         for line in output.split(separator: "\n", omittingEmptySubsequences: false) {
             if line.hasPrefix("worktree ") {
+                flush()
                 path = String(line.dropFirst("worktree ".count))
+                branch = nil
                 index += 1
-            } else if line.hasPrefix("branch refs/heads/"), let currentPath = path, index > 0 {
-                results.append(Worktree(
-                    repositoryName: repository.name,
-                    repositoryPath: repository.path,
-                    branch: String(line.dropFirst("branch refs/heads/".count)),
-                    path: currentPath,
-                ))
+            } else if line.hasPrefix("branch refs/heads/") {
+                branch = String(line.dropFirst("branch refs/heads/".count))
             }
         }
+        flush()
         return results
     }
 

--- a/Sources/AgentIDEData/SessionService+Edits.swift
+++ b/Sources/AgentIDEData/SessionService+Edits.swift
@@ -1,0 +1,62 @@
+import AgentIDEDomain
+
+/// The files commands outside the app are waiting to have edited.
+public extension SessionService {
+    /// The environment a host shell needs for its editors to open
+    /// here, and for `agentide` to work as a command in it.
+    func shellEnvironment() -> [String: String] {
+        EditorShim(paths: paths).environment
+    }
+
+    /// Every file a command is waiting on, in the order they were
+    /// asked for, published again whenever the set changes. Reading
+    /// the spool is a directory listing, so it polls rather than
+    /// watching: a request has to reach the screen in the time it
+    /// takes to notice a shell has stopped echoing.
+    func pendingEdits() -> AsyncStream<[ExternalEdit]> {
+        let spool = ExternalEditSpool(directory: paths.editsDirectory)
+        return AsyncStream { continuation in
+            let task = Task {
+                var previous = [ExternalEdit]()
+                var hasRead = false
+                while Task.isCancelled == false {
+                    let current = await Self.pending(in: spool)
+                    if hasRead == false || current != previous {
+                        previous = current
+                        hasRead = true
+                        continuation.yield(current)
+                    }
+                    try? await Task.sleep(for: .milliseconds(Self.editPollMilliseconds))
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    /// Tells the waiting command's shim the app has its file.
+    @concurrent
+    func claimEdit(_ edit: ExternalEdit) async {
+        ExternalEditSpool(directory: paths.editsDirectory).claim(edit)
+    }
+
+    /// Releases the waiting command: a saved file lets it carry on,
+    /// a cancelled one fails it.
+    @concurrent
+    func finishEdit(_ edit: ExternalEdit, saved: Bool) async {
+        ExternalEditSpool(directory: paths.editsDirectory).finish(edit, saved: saved)
+    }
+
+    // MARK: Private
+
+    /// How often the spool is read; the shim polls for its answer at
+    /// the same rate, so the whole round trip stays under a second.
+    private static let editPollMilliseconds = 300
+
+    /// Off the caller's actor: the poll runs while the window is
+    /// being used, so it must never touch the main thread.
+    @concurrent
+    private static func pending(in spool: ExternalEditSpool) async -> [ExternalEdit] {
+        spool.pending()
+    }
+}

--- a/Sources/AgentIDEData/SessionService+Overview.swift
+++ b/Sources/AgentIDEData/SessionService+Overview.swift
@@ -96,6 +96,28 @@ public extension SessionService {
         }
     }
 
+    /// The usage of processes the app runs itself rather than tmux,
+    /// a browser page's web content process above all, in one `ps`
+    /// pass so a list of them costs no more than one session does.
+    func usage(ofProcesses identifiers: [Int32]) async -> [Int32: (cpuPercent: Double, memoryMegabytes: Int)] {
+        guard identifiers.isEmpty == false else {
+            return [:]
+        }
+
+        let listing = try? await processes.run(
+            ["ps", "-axo", "pid=,ppid=,%cpu=,rss="],
+            workingDirectory: nil,
+            environment: [:],
+        )
+        let samples = Self.processSamples(fromPS: listing?.standardOutput ?? "")
+        var usage = [Int32: (cpuPercent: Double, memoryMegabytes: Int)]()
+        for identifier in identifiers {
+            let tree = Self.treeUsage(root: Int(identifier), samples: samples)
+            usage[identifier] = (tree.cpuPercent, tree.megabytes)
+        }
+        return usage
+    }
+
     // MARK: Internal
 
     /// One `ps` row of the fields the usage sums need.

--- a/Sources/AgentIDEData/WorkspacePaths.swift
+++ b/Sources/AgentIDEData/WorkspacePaths.swift
@@ -11,11 +11,13 @@ public struct WorkspacePaths: Sendable {
         sharedWorkspace: String,
         sandboxHome: String,
         metadataFile: String,
+        appDirectory: String? = nil,
     ) {
         self.hostUser = hostUser
         self.sharedWorkspace = sharedWorkspace
         self.sandboxHome = sandboxHome
         self.metadataFile = metadataFile
+        self.appDirectory = appDirectory ?? NSHomeDirectory() + "/.agentide"
     }
 
     // MARK: Public
@@ -45,6 +47,17 @@ public struct WorkspacePaths: Sendable {
 
     /// Where the app's own metadata file lives.
     public let metadataFile: String
+
+    /// The app's directory in the running user's home, holding the
+    /// files that shell commands have to reach by path.
+    public let appDirectory: String
+
+    /// Where the editor shim spools the files commands wait on. Dev
+    /// builds keep their own, so a build under test never answers
+    /// the installed app's shells.
+    public var editsDirectory: String {
+        appDirectory + (Self.isProductionBuild ? "/edits" : "/edits-dev")
+    }
 
     /// Where full repository checkouts live.
     public var repositoriesDirectory: String {

--- a/Sources/AgentIDEDomain/ExternalEdit.swift
+++ b/Sources/AgentIDEDomain/ExternalEdit.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// A file a command outside the app is waiting to have edited: one
+/// request from the `agentide` editor shim, which host shells point
+/// `EDITOR`, `VISUAL` and `GIT_EDITOR` at.
+public struct ExternalEdit: Identifiable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a request.
+    public init(id: String, path: String, workingDirectory: String, processIdentifier: Int32) {
+        self.id = id
+        self.path = path
+        self.workingDirectory = workingDirectory
+        self.processIdentifier = processIdentifier
+    }
+
+    /// Decodes one spooled request, whose file name is its id; nil
+    /// when the file is not a request this version understands.
+    public init?(id: String, json: Data) {
+        guard let payload = try? JSONDecoder().decode(Payload.self, from: json) else {
+            return nil
+        }
+
+        self.init(
+            id: id,
+            path: payload.path,
+            workingDirectory: payload.workingDirectory,
+            processIdentifier: payload.processIdentifier,
+        )
+    }
+
+    // MARK: Public
+
+    /// The request's identity, which is its spool file's name.
+    public let id: String
+
+    /// The absolute path of the file to edit. It is regularly
+    /// outside every worktree: a linked worktree's rebase todo list
+    /// lives in the repository's own `.git` directory.
+    public let path: String
+
+    /// The directory the command ran in, which locates the worktree
+    /// whose pane shows the file.
+    public let workingDirectory: String
+
+    /// The shim's process, so a request whose command has gone can
+    /// be swept: the shim always waits, so its process being alive
+    /// is exactly the request still mattering.
+    public let processIdentifier: Int32
+
+    /// The file's name, for the editor's header.
+    public var name: String {
+        URL(fileURLWithPath: path).lastPathComponent
+    }
+
+    /// Whether the command ran inside a worktree, so that the
+    /// worktree's editor pane is the one that should show the file.
+    public func belongs(toWorktree worktreePath: String) -> Bool {
+        workingDirectory == worktreePath || workingDirectory.hasPrefix(worktreePath + "/")
+    }
+
+    // MARK: Private
+
+    /// The shim writes exactly these fields.
+    private struct Payload: Decodable {
+        let path: String
+        let workingDirectory: String
+        let processIdentifier: Int32
+    }
+}

--- a/Sources/AgentIDEDomain/SyntaxHighlighter+Git.swift
+++ b/Sources/AgentIDEDomain/SyntaxHighlighter+Git.swift
@@ -1,0 +1,59 @@
+/// The files git hands an editor: a rebase todo list and the message
+/// buffers. Both are read positionally rather than by the general
+/// tokenizer, which would take an apostrophe for a string and colour
+/// the rest of the line with it.
+extension SyntaxHighlighter {
+    /// Rebase todo lines are `<command> <commit> <subject>`, under a
+    /// block of instructions git appends as comments. Highlighting
+    /// the command and the commit is what makes such a list scannable
+    /// while it is being rearranged.
+    static func rebaseTokens(line: String) -> [SyntaxToken] {
+        let indent = line.prefix { $0 == " " || $0 == "\t" }
+        let body = line.dropFirst(indent.count)
+        guard body.isEmpty == false else {
+            return [SyntaxToken(kind: .plain, text: line)]
+        }
+        guard body.first != "#" else {
+            return [SyntaxToken(kind: .comment, text: line)]
+        }
+
+        // Each piece keeps its own spacing, so the tokens still
+        // reproduce the line exactly.
+        let command = body.prefix { $0 != " " }
+        let afterCommand = body.dropFirst(command.count)
+        let spacing = afterCommand.prefix { $0 == " " }
+        let target = afterCommand.dropFirst(spacing.count).prefix { $0 != " " }
+        let subject = afterCommand.dropFirst(spacing.count + target.count)
+
+        var tokens = indent.isEmpty ? [] : [SyntaxToken(kind: .plain, text: String(indent))]
+        let isCommand = SyntaxLanguage.rebaseCommands.contains(String(command))
+        tokens.append(SyntaxToken(kind: isCommand ? .keyword : .plain, text: String(command)))
+        if spacing.isEmpty == false {
+            tokens.append(SyntaxToken(kind: .plain, text: String(spacing)))
+        }
+        if target.isEmpty == false {
+            tokens.append(SyntaxToken(kind: isCommit(target) ? .number : .plain, text: String(target)))
+        }
+        if subject.isEmpty == false {
+            tokens.append(SyntaxToken(kind: .plain, text: String(subject)))
+        }
+        return merge(tokens)
+    }
+
+    /// Commit messages colour only the block git appends and strips,
+    /// so what is left is what will be committed.
+    static func messageTokens(line: String) -> [SyntaxToken] {
+        line.drop { $0 == " " || $0 == "\t" }.first == "#"
+            ? [SyntaxToken(kind: .comment, text: line)]
+            : [SyntaxToken(kind: .plain, text: line)]
+    }
+
+    /// Whether a word reads as an abbreviated commit, which is what
+    /// separates `pick a1b2c3d` from `label branch-name`.
+    private static func isCommit(_ word: Substring) -> Bool {
+        word.count >= commitPrefixLength && word.allSatisfy(\.isHexDigit)
+    }
+
+    /// The shortest abbreviated commit git will print.
+    private static let commitPrefixLength = 4
+}

--- a/Sources/AgentIDEDomain/SyntaxHighlighter.swift
+++ b/Sources/AgentIDEDomain/SyntaxHighlighter.swift
@@ -48,11 +48,13 @@ public enum SyntaxLanguage: Hashable, Sendable {
     case dockerfile
     case yaml
     case markdown
+    case gitRebaseTodo
+    case gitMessage
 
     // MARK: Public
 
-    /// The language for a file path, judged by extension, nil when
-    /// unknown.
+    /// The language for a file path, judged by extension, or by whole
+    /// name for the files that have none; nil when unknown.
     public static func language(forPath path: String) -> Self? {
         let name = path.split(separator: "/").last.map(String.init) ?? path
         let extensionName = name.split(separator: ".").last.map(String.init) ?? ""
@@ -91,14 +93,34 @@ public enum SyntaxLanguage: Hashable, Sendable {
             return .markdown
 
         default:
-            if name == "Dockerfile" || name.hasPrefix("Dockerfile.") {
-                return .dockerfile
-            }
-            return name == "Gemfile" || name == "Rakefile" || name == "Brewfile" ? .ruby : nil
+            return language(forName: name)
         }
     }
 
+    /// The language of a file whose name carries it, git's own
+    /// editable files included.
+    public static func language(forName name: String) -> Self? {
+        if name == "Dockerfile" || name.hasPrefix("Dockerfile.") {
+            return .dockerfile
+        }
+        if name == "git-rebase-todo" || name == "git-rebase-todo.backup" {
+            return .gitRebaseTodo
+        }
+        if ["COMMIT_EDITMSG", "MERGE_MSG", "NOTES_EDITMSG", "SQUASH_MSG", "TAG_EDITMSG"].contains(name) {
+            return .gitMessage
+        }
+        return name == "Gemfile" || name == "Rakefile" || name == "Brewfile" ? .ruby : nil
+    }
+
     // MARK: Internal
+
+    /// Every rebase todo command, long and short, which are what a
+    /// todo list is edited by.
+    static let rebaseCommands: Set<String> = [
+        "p", "pick", "r", "reword", "e", "edit", "s", "squash", "f", "fixup",
+        "x", "exec", "b", "break", "d", "drop", "l", "label", "t", "reset",
+        "m", "merge", "u", "update-ref",
+    ]
 
     /// The line-comment introducer, empty for languages without one.
     var commentPrefix: String {
@@ -108,6 +130,8 @@ public enum SyntaxLanguage: Hashable, Sendable {
             "//"
 
         case .dockerfile,
+             .gitMessage,
+             .gitRebaseTodo,
              .python,
              .ruby,
              .shell,
@@ -182,7 +206,11 @@ public enum SyntaxLanguage: Hashable, Sendable {
         case .yaml:
             ["true", "false", "null", "yes", "no", "on", "off"]
 
-        case .markdown:
+        case .gitRebaseTodo:
+            Self.rebaseCommands
+
+        case .gitMessage,
+             .markdown:
             []
         }
     }
@@ -198,12 +226,30 @@ public enum SyntaxHighlighter {
     // MARK: Public
 
     /// Splits one line into coloured tokens; concatenating the token
-    /// texts reproduces the line.
+    /// texts reproduces the line. Languages whose lines mean
+    /// something by their shape are read positionally instead of by
+    /// the general tokenizer.
     public static func highlight(line: String, language: SyntaxLanguage) -> [SyntaxToken] {
-        if language == .markdown {
-            return markdownTokens(line: line)
-        }
+        switch language {
+        case .markdown:
+            markdownTokens(line: line)
 
+        case .gitRebaseTodo:
+            rebaseTokens(line: line)
+
+        case .gitMessage:
+            messageTokens(line: line)
+
+        default:
+            generalTokens(line: line, language: language)
+        }
+    }
+
+    // MARK: Internal
+
+    /// Strings, line comments, numbers and keywords, wherever they
+    /// fall on the line.
+    static func generalTokens(line: String, language: SyntaxLanguage) -> [SyntaxToken] {
         var tokens = [SyntaxToken]()
         var plain = ""
         let characters = Array(line)
@@ -253,6 +299,18 @@ public enum SyntaxHighlighter {
         }
         flushPlain()
         return merge(tokens)
+    }
+
+    /// Joins neighbouring tokens of one kind, so a line's colours
+    /// come back as runs; the git tokenizers share it.
+    static func merge(_ tokens: [SyntaxToken]) -> [SyntaxToken] {
+        tokens.reduce(into: [SyntaxToken]()) { merged, token in
+            if let last = merged.last, last.kind == token.kind {
+                merged[merged.count - 1] = SyntaxToken(kind: last.kind, text: last.text + token.text)
+            } else {
+                merged.append(token)
+            }
+        }
     }
 
     // MARK: Private
@@ -335,15 +393,5 @@ public enum SyntaxHighlighter {
 
     private static func isWordBoundary(_ characters: [Character], before index: Int) -> Bool {
         index == 0 || isWordCharacter(characters[index - 1]) == false
-    }
-
-    private static func merge(_ tokens: [SyntaxToken]) -> [SyntaxToken] {
-        tokens.reduce(into: [SyntaxToken]()) { merged, token in
-            if let last = merged.last, last.kind == token.kind {
-                merged[merged.count - 1] = SyntaxToken(kind: last.kind, text: last.text + token.text)
-            } else {
-                merged.append(token)
-            }
-        }
     }
 }

--- a/Sources/AgentIDEDomain/TmuxControl.swift
+++ b/Sources/AgentIDEDomain/TmuxControl.swift
@@ -42,25 +42,42 @@ public enum TmuxControl {
             return ["send-keys -H " + raw.map { String($0, radix: hexRadix) }.joined(separator: " ")]
         }
 
+        return chunks(of: text).map(command(for:))
+    }
+
+    /// The commands that paste text into the attached session's
+    /// active pane.
+    ///
+    /// A paste is not typing: it goes into a tmux buffer and is
+    /// pasted from there, so tmux wraps it in bracketed paste
+    /// markers when the pane's own application asked for them.
+    /// Deciding that here instead was wrong, since the local
+    /// terminal only learns the mode from output it has seen, and a
+    /// pane attached mid-session never saw it being set: the markers
+    /// went missing and the agent took a multi-line paste as several
+    /// lines of typing, which is how the cursor ended up inside the
+    /// pasted text rather than after it.
+    ///
+    /// Long text is appended to the same buffer chunk by chunk, so
+    /// however many commands it takes, one paste arrives.
+    public static func pasteCommands(text: String) -> [String] {
+        // Whatever the local terminal wrapped it in comes off: tmux
+        // adds the markers, and only when the pane wants them.
+        let stripped = text
+            .replacing(bracketedPasteStart, with: "")
+            .replacing(bracketedPasteEnd, with: "")
+        guard stripped.isEmpty == false else {
+            return []
+        }
+
         var commands = [String]()
-        var chunk = ""
-        var escapedLength = 0
-        for character in text {
-            let piece = escaped(character)
-            // Measured on the escaped text, since that is what tmux
-            // reads: counting source characters split pastes that
-            // would have fitted in one command comfortably.
-            if escapedLength + piece.count > escapedBudget, chunk.isEmpty == false {
-                commands.append(command(for: chunk))
-                chunk = ""
-                escapedLength = 0
-            }
-            chunk.append(character)
-            escapedLength += piece.count
+        for (index, chunk) in chunks(of: stripped).enumerated() {
+            // The first command starts the buffer and the rest add
+            // to it, so one paste arrives however long it is.
+            let opening = index == 0 ? "set-buffer -b " : "set-buffer -a -b "
+            commands.append(opening + pasteBuffer + " -- " + quoted(chunk))
         }
-        if chunk.isEmpty == false {
-            commands.append(command(for: chunk))
-        }
+        commands.append("paste-buffer -d -p -b " + pasteBuffer)
         return commands
     }
 
@@ -128,6 +145,14 @@ public enum TmuxControl {
     /// `send-keys -H` reads bytes as hexadecimal.
     private static let hexRadix = 16
 
+    /// The buffer a paste is staged in; it is deleted as it pastes.
+    private static let pasteBuffer = "agentide-paste"
+
+    /// What a terminal wraps a paste in when the application asked
+    /// for bracketed paste.
+    private static let bracketedPasteStart = "\u{1B}[200~"
+    private static let bracketedPasteEnd = "\u{1B}[201~"
+
     /// Escaped characters per command. tmux carried 32,000 in one
     /// command in testing; half of that leaves room for the command
     /// itself and for whatever the untested ceiling really is, while
@@ -141,6 +166,28 @@ public enum TmuxControl {
     /// starting with a dash from reading as a flag.
     private static func command(for chunk: String) -> String {
         "send-keys -l -- " + quoted(chunk)
+    }
+
+    /// Splits text into pieces each of which fits one command,
+    /// measured on the escaped text, since that is what tmux reads.
+    private static func chunks(of text: String) -> [String] {
+        var chunks = [String]()
+        var chunk = ""
+        var escapedLength = 0
+        for character in text {
+            let piece = escaped(character)
+            if escapedLength + piece.count > escapedBudget, chunk.isEmpty == false {
+                chunks.append(chunk)
+                chunk = ""
+                escapedLength = 0
+            }
+            chunk.append(character)
+            escapedLength += piece.count
+        }
+        if chunk.isEmpty == false {
+            chunks.append(chunk)
+        }
+        return chunks
     }
 
     /// Any other control character as tmux's three-digit octal

--- a/Sources/AgentIDEDomain/Wrapping.swift
+++ b/Sources/AgentIDEDomain/Wrapping.swift
@@ -1,0 +1,83 @@
+// MARK: - Wrapping
+
+/// Turning hard-wrapped prose back into one line per point.
+public enum Wrapping {
+    // MARK: Public
+
+    /// Joins the lines a commit message wrapped by hand back into
+    /// whole bullets and paragraphs. Commit bodies are wrapped to a
+    /// narrow column, which reads as broken lines wherever the text
+    /// is reflowed for its width instead, a pull request body most
+    /// of all. Blank lines, headings, quotes, tables, list starts and
+    /// fenced code are left exactly as they are, so only the
+    /// continuations of a line move.
+    public static func unwrapped(_ text: String) -> String {
+        var lines = [String]()
+        var isFenced = false
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let current = String(line)
+            if current.trimmingLeadingSpaces().hasPrefix("```") {
+                isFenced.toggle()
+                lines.append(current)
+                continue
+            }
+            guard isFenced == false,
+                  let previous = lines.last,
+                  isContinuation(current),
+                  previous.isEmpty == false,
+                  starts(block: previous) == false || isListItem(previous)
+            else {
+                lines.append(current)
+                continue
+            }
+
+            lines[lines.count - 1] = previous + " " + current.trimmingLeadingSpaces()
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: Private
+
+    /// How far a line can be indented and still be prose rather than
+    /// the indented code block four spaces make it.
+    private static let codeIndent = 4
+
+    /// Whether a line continues the one above rather than starting
+    /// something of its own.
+    private static func isContinuation(_ line: String) -> Bool {
+        let body = line.trimmingLeadingSpaces()
+        return body.isEmpty == false
+            && line.prefix { $0 == " " }.count < codeIndent
+            && line.hasPrefix("\t") == false
+            && starts(block: line) == false
+    }
+
+    /// Whether a line opens a block of its own, which never joins
+    /// the line above it.
+    private static func starts(block line: String) -> Bool {
+        let body = line.trimmingLeadingSpaces()
+        return isListItem(line)
+            || body.hasPrefix("#")
+            || body.hasPrefix(">")
+            || body.hasPrefix("|")
+            || body.hasPrefix("---")
+    }
+
+    private static func isListItem(_ line: String) -> Bool {
+        let body = line.trimmingLeadingSpaces()
+        for marker in ["- ", "* ", "+ "] where body.hasPrefix(marker) {
+            return true
+        }
+        // An ordered item: digits, then a dot or bracket, then a space.
+        let digits = body.prefix(while: \.isNumber)
+        let after = body.dropFirst(digits.count)
+        return digits.isEmpty == false && (after.hasPrefix(". ") || after.hasPrefix(") "))
+    }
+}
+
+private extension String {
+    /// The line without its leading spaces and tabs.
+    func trimmingLeadingSpaces() -> String {
+        String(drop { $0 == " " || $0 == "\t" })
+    }
+}

--- a/Sources/DashboardFeature/DashboardModel+Retention.swift
+++ b/Sources/DashboardFeature/DashboardModel+Retention.swift
@@ -1,0 +1,49 @@
+import AgentIDEDomain
+import Foundation
+
+/// Keeping rows that a single reading of the system lost.
+public extension DashboardModel {
+    /// Every worktree the sidebar lists; a path leaving this set
+    /// is a worktree that has really gone, since a row survives a
+    /// reading that lost it while its directory is there.
+    var worktreePaths: Set<String> {
+        Set(groups.flatMap(\.items).map(\.worktree.path))
+    }
+
+    /// Puts back the rows the newest reading dropped whose worktree
+    /// is still on disk. A reading is never proof a worktree is
+    /// gone: its listing can fail, and git hides a worktree from its
+    /// own listing for the whole of a rebase. Losing a row closes
+    /// the pane it holds open, taking the shell running there with
+    /// it, so only a worktree that really went away loses its row.
+    static func retainingLostRows(
+        of previous: [RepositoryGroup],
+        in next: [RepositoryGroup],
+    ) -> [RepositoryGroup] {
+        var merged = next.map { fresh -> RepositoryGroup in
+            guard let old = previous.first(where: { $0.repository.path == fresh.repository.path }) else {
+                return fresh
+            }
+
+            var items = fresh.items
+            let paths = Set(items.map(\.worktree.path))
+            for (index, item) in old.items.enumerated()
+                where paths.contains(item.worktree.path) == false && stillExists(item.worktree.path) {
+                // Back where it was, so a row the reading lost does
+                // not jump down the list and back on the next tick.
+                items.insert(item, at: min(index, items.count))
+            }
+            return RepositoryGroup(repository: fresh.repository, items: items, defaultBranch: fresh.defaultBranch)
+        }
+        let listed = Set(next.map(\.repository.path))
+        merged += previous.filter { listed.contains($0.repository.path) == false && stillExists($0.repository.path) }
+        return merged
+    }
+
+    /// Whether a worktree or repository is still there; its
+    /// directory going away is the one proof of deletion, and both
+    /// removing a worktree and deleting a repository take it.
+    private static func stillExists(_ path: String) -> Bool {
+        FileManager.default.fileExists(atPath: path)
+    }
+}

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -178,17 +178,18 @@ public final class DashboardModel {
             return
         }
 
-        notifyChanges(from: groups, to: overview.groups)
-        groups = overview.groups
+        let listed = Self.retainingLostRows(of: groups, in: overview.groups)
+        notifyChanges(from: groups, to: listed)
+        groups = listed
         foreign = overview.foreign
         if let selected = selection {
-            selection = overview.groups.flatMap(\.items).first { $0.id == selected.id }
+            selection = listed.flatMap(\.items).first { $0.id == selected.id }
         } else if hasRestoredSelection == false {
             let stored = UserDefaults.standard.string(forKey: Self.selectedWorktreeKey)
-            selection = overview.groups.flatMap(\.items).first { $0.worktree.path == stored }
+            selection = listed.flatMap(\.items).first { $0.worktree.path == stored }
         }
         hasRestoredSelection = true
-        cacheSidebar(overview.groups)
+        cacheSidebar(listed)
         await refreshStalePullRequests()
     }
 

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -167,11 +167,14 @@ extension PullRequestsModel {
     }
 
     /// Splits one commit message into the form's title and body.
+    /// The body comes back unwrapped: commit messages are wrapped by
+    /// hand to a narrow column, and a pull request reflows its own
+    /// text, so the hand-wrapping reads as broken bullets there.
     static func description(splitFromMessage message: String) -> (title: String, body: String) {
         let lines = message.split(separator: "\n", omittingEmptySubsequences: false)
         let title = lines.first.map(String.init) ?? ""
         let body = lines.dropFirst().joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-        return (title, body)
+        return (title, Wrapping.unwrapped(body))
     }
 
     /// Opens the pull request from the form's title and body, with

--- a/Sources/ReviewFeature/DiffFileView.swift
+++ b/Sources/ReviewFeature/DiffFileView.swift
@@ -1,4 +1,3 @@
-import AgentIDEData
 import AgentIDEDomain
 import AppKit
 import SwiftUI
@@ -72,7 +71,10 @@ struct DiffFileView: View {
             headerRow
             if isCollapsed == false {
                 ForEach(Array(file.hunks.enumerated()), id: \.offset) { hunkIndex, hunk in
+                    // The find bar scrolls to a hunk, since a hunk's
+                    // lines are drawn as one block of text.
                     hunkView(hunkIndex: hunkIndex, hunk: hunk)
+                        .id(ReviewModel.FindTarget(file: file.path, hunk: hunkIndex).id)
                 }
             }
         }
@@ -86,6 +88,9 @@ struct DiffFileView: View {
     private static let lineSpacing: CGFloat = 2
     private static let gutterSpacing: CGFloat = 6
     private static let selectionBarWidth: CGFloat = 3
+
+    /// Enough to find a match at a glance without hiding the code.
+    private static let foundOpacity = 0.45
     private static let changeOpacity = 0.15
     private static let selectedOpacity = 0.35
     private static let filePadding: CGFloat = 8
@@ -233,6 +238,27 @@ struct DiffFileView: View {
         return runs
     }
 
+    /// Tints what the find bar is looking for, over whatever the
+    /// syntax and whitespace colouring already put there.
+    private static func markFound(
+        _ ranges: [Range<String.Index>],
+        of line: String,
+        in content: inout AttributedString,
+    ) {
+        let characters = content.characters
+        for range in ranges {
+            let start = line.distance(from: line.startIndex, to: range.lowerBound)
+            let length = line.distance(from: range.lowerBound, to: range.upperBound)
+            guard let from = characters.index(characters.startIndex, offsetBy: start, limitedBy: characters.endIndex),
+                  let upTo = characters.index(from, offsetBy: length, limitedBy: characters.endIndex)
+            else {
+                return
+            }
+
+            content[from ..< upTo].backgroundColor = .yellow.opacity(Self.foundOpacity)
+        }
+    }
+
     /// The hunk's code as one attributed string: syntax colours per
     /// token and change backgrounds per line, markers excluded so
     /// copies paste cleanly.
@@ -276,6 +302,7 @@ struct DiffFileView: View {
             }
             offset += token.text.count
         }
+        Self.markFound(model.findRanges(in: line.content), of: line.content, in: &content)
         if content.characters.isEmpty {
             var blank = AttributedString(" ")
             blank.backgroundColor = base
@@ -312,87 +339,5 @@ struct DiffFileView: View {
     private func isSelected(hunkIndex: Int, lineIndex: Int) -> Bool {
         model.selections[file.path]?
             .contains(DiffSelection(hunkIndex: hunkIndex, lineIndex: lineIndex)) ?? false
-    }
-}
-
-// MARK: - ReviewFileListView
-
-/// The review pane's file list: collapsible diffs, or inline
-/// editors in the uncommitted scope so fixes are typed directly.
-struct ReviewFileListView: View {
-    // MARK: Internal
-
-    let model: ReviewModel
-    let worktreePath: String
-    let service: SessionService
-
-    /// Whether files start collapsed (the Hide All display mode);
-    /// the per-file carets override it.
-    let hideAllByDefault: Bool
-
-    @Binding var collapseOverrides: [String: Bool]
-
-    var body: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: Self.spacing) {
-                ForEach(model.files) { file in
-                    fileSection(file)
-                }
-            }
-            .padding(Self.spacing)
-        }
-    }
-
-    // MARK: Private
-
-    private static let spacing: CGFloat = 8
-    private static let editorMinimumHeight: CGFloat = 240
-    private static let editorMaximumHeight: CGFloat = 420
-
-    @ViewBuilder
-    private func fileSection(_ file: DiffFile) -> some View {
-        // Every scope leads with the diff, uncommitted included: it
-        // once showed the whole file in an editor instead, which read
-        // as a broken diff. Uncommitted files keep that editor for
-        // fixing in place, below their diff.
-        DiffFileView(
-            file: file,
-            model: model,
-            isCollapsed: isCollapsed(file),
-            onToggleCollapse: { toggleCollapse(file) },
-            onEdit: {
-                FileOpener.open(relativePath: file.path, line: nil, worktreePath: worktreePath)
-            },
-        )
-        if model.showsUncommitted, isCollapsed(file) == false, file.isNew == false {
-            FileEditorView(
-                worktreePath: worktreePath,
-                relativePath: file.path,
-                service: service,
-                showsClose: false,
-            )
-            .frame(minHeight: Self.editorMinimumHeight, maxHeight: Self.editorMaximumHeight)
-        }
-        if isCollapsed(file) == false {
-            ForEach(model.threads(for: file.path)) { thread in
-                ReviewThreadRow(
-                    thread: thread,
-                    onEdit: {
-                        FileOpener.open(relativePath: thread.path, line: thread.line, worktreePath: worktreePath)
-                    },
-                    onToggleResolved: { await model.toggleResolved(thread) },
-                )
-            }
-        }
-    }
-
-    private func isCollapsed(_ file: DiffFile) -> Bool {
-        // Generated files always start collapsed, whatever the
-        // expand-all state says; only their own caret opens them.
-        collapseOverrides[file.path] ?? (hideAllByDefault || model.isGenerated(file.path) || file.isNew)
-    }
-
-    private func toggleCollapse(_ file: DiffFile) {
-        collapseOverrides[file.path] = isCollapsed(file) == false
     }
 }

--- a/Sources/ReviewFeature/EditorPane.swift
+++ b/Sources/ReviewFeature/EditorPane.swift
@@ -9,10 +9,13 @@ import TerminalUI
 public struct EditorPane: View {
     // MARK: Lifecycle
 
-    /// Creates the pane for a worktree.
-    public init(worktreePath: String, service: SessionService) {
+    /// Creates the pane for a worktree. `waitingEdit` is a file some
+    /// command outside the app is blocked on, which takes the pane
+    /// over until it is dealt with.
+    public init(worktreePath: String, service: SessionService, waitingEdit: ExternalEdit? = nil) {
         self.worktreePath = worktreePath
         self.service = service
+        self.waitingEdit = waitingEdit
     }
 
     // MARK: Public
@@ -21,19 +24,13 @@ public struct EditorPane: View {
     /// editor. Arrow keys move the highlight and return opens it.
     public var body: some View {
         VStack(spacing: 0) {
-            finderField
-            if query.isEmpty == false, results.isEmpty == false {
-                resultsList
-                Divider()
-            }
-            if let target {
-                editor(for: target)
+            if let edit = blockingEdit {
+                // The finder is beside the point while a command is
+                // stopped waiting on one particular file.
+                FileEditorView(waitingOn: edit) { saved in finish(edit, saved: saved) }
+                    .id(edit.id)
             } else {
-                ContentUnavailableView(
-                    "No file open",
-                    systemImage: "doc.text",
-                    description: Text("Cmd-T finds a file to edit."),
-                )
+                finder
             }
         }
         .task(id: worktreePath) {
@@ -81,6 +78,10 @@ public struct EditorPane: View {
     @State private var highlighted = 0
     @State private var handledFocusRequest = 0
 
+    /// The waiting file already dealt with, so the pane returns to
+    /// the finder as soon as the buttons are pressed.
+    @State private var finishedEdit: String?
+
     /// The query, mode and open file persist across restarts.
     @AppStorage("finderQuery")
     private var query = ""
@@ -101,6 +102,33 @@ public struct EditorPane: View {
 
     private let worktreePath: String
     private let service: SessionService
+    private let waitingEdit: ExternalEdit?
+
+    /// The file this pane is blocked on, until it is finished with:
+    /// the answer takes a moment to reach the spool and come back,
+    /// and the pane must not flash the file again in between.
+    private var blockingEdit: ExternalEdit? {
+        waitingEdit?.id == finishedEdit ? nil : waitingEdit
+    }
+
+    /// The finder over its results over the file being edited. Arrow
+    /// keys move the highlight and return opens it.
+    @ViewBuilder private var finder: some View {
+        finderField
+        if query.isEmpty == false, results.isEmpty == false {
+            resultsList
+            Divider()
+        }
+        if let target {
+            editor(for: target)
+        } else {
+            ContentUnavailableView(
+                "No file open",
+                systemImage: "doc.text",
+                description: Text("Cmd-T finds a file to edit."),
+            )
+        }
+    }
 
     /// A search-field look: magnifier, plain field and a clear
     /// button, pinned above everything else.
@@ -211,6 +239,13 @@ public struct EditorPane: View {
         }
 
         target = Result(file: editorFilePath, line: editorFileLine > 0 ? editorFileLine : nil)
+    }
+
+    /// Releases the command waiting on the file and returns the
+    /// pane to its finder.
+    private func finish(_ edit: ExternalEdit, saved: Bool) {
+        finishedEdit = edit.id
+        Task { await service.finishEdit(edit, saved: saved) }
     }
 
     private func consumeFocusRequest() {

--- a/Sources/ReviewFeature/FileEditorView.swift
+++ b/Sources/ReviewFeature/FileEditorView.swift
@@ -3,9 +3,9 @@ import AgentIDEDomain
 import SwiftUI
 import TerminalUI
 
-/// A syntax-highlighted editor for one file in the worktree, with
-/// line numbers, visible invisibles and uncommitted-line markers,
-/// for review-time fixes.
+/// A syntax-highlighted editor for one file, with line numbers,
+/// visible invisibles and uncommitted-line markers, for review-time
+/// fixes and for the files commands outside the app wait on.
 struct FileEditorView: View {
     // MARK: Lifecycle
 
@@ -21,46 +21,52 @@ struct FileEditorView: View {
         showsClose: Bool = true,
         onClose: (() -> Void)? = nil,
     ) {
-        self.worktreePath = worktreePath
-        self.relativePath = relativePath
-        self.service = service
+        // A hostile repository could put `../` in a diff path, so a
+        // file that resolves outside the worktree gets no path at
+        // all and the editor refuses to read or write it.
+        let base = URL(fileURLWithPath: worktreePath).standardizedFileURL.path
+        let target = URL(fileURLWithPath: worktreePath + "/" + relativePath).standardizedFileURL.path
+        path = target == base || target.hasPrefix(base + "/") ? target : nil
+        title = relativePath
+        language = SyntaxLanguage.language(forPath: relativePath)
+        changedLines = { await service.changedLineNumbers(worktreePath: worktreePath, file: relativePath) }
         self.jumpToLine = jumpToLine
         self.showsClose = showsClose
         self.onClose = onClose
+        onFinish = nil
+    }
+
+    /// Creates an editor for a file a command is waiting on, which
+    /// is regularly outside every worktree: git keeps a linked
+    /// worktree's rebase todo list in the repository's own `.git`
+    /// directory. Finishing releases the command, and cancelling
+    /// fails it, which is how a rebase is aborted.
+    init(waitingOn edit: ExternalEdit, onFinish: @escaping (Bool) -> Void) {
+        path = edit.path
+        title = edit.name
+        language = SyntaxLanguage.language(forPath: edit.path)
+        changedLines = nil
+        jumpToLine = nil
+        showsClose = false
+        onClose = nil
+        self.onFinish = onFinish
     }
 
     // MARK: Internal
 
-    /// The editor with icon save and close actions. Save enables
-    /// only with unsaved changes and reports Saved after writing.
+    /// The editor under its header. Save enables only with unsaved
+    /// changes and reports Saved after writing; a file some command
+    /// waits on says so and finishes it instead of closing.
     var body: some View {
         VStack(spacing: 0) {
-            HStack {
-                Text(relativePath).font(.headline.monospaced())
-                Spacer()
-                if let status {
-                    Text(status).font(.callout).foregroundStyle(.secondary)
-                }
-                Button("Save", systemImage: "square.and.arrow.down") { save() }
-                    .labelStyle(.iconOnly)
-                    .buttonStyle(.borderless)
-                    .disabled(hasChanges == false)
-                    .keyboardShortcut("s", modifiers: .command)
-                    .hoverHelp("Write the buffer back to the file (Cmd-S); dims until there are changes")
-                if showsClose {
-                    Button("Close", systemImage: "xmark") { close() }
-                        .labelStyle(.iconOnly)
-                        .buttonStyle(.borderless)
-                        .hoverHelp("Close the editor without saving")
-                }
-            }
-            .padding(Self.padding)
+            header
+                .padding(Self.padding)
             Divider()
             HighlightingTextEditor(
                 text: $content,
-                language: SyntaxLanguage.language(forPath: relativePath),
+                language: language,
                 jumpToLine: jumpToLine,
-                changedLines: changedLines,
+                changedLines: markedLines,
             )
         }
         .onAppear { load() }
@@ -80,51 +86,89 @@ struct FileEditorView: View {
 
     @State private var content = ""
     @State private var saved = ""
-    @State private var changedLines: Set<Int> = []
+    @State private var markedLines: Set<Int> = []
     @State private var status: String?
 
     @Environment(\.dismiss)
     private var dismiss
 
-    private let worktreePath: String
-    private let relativePath: String
-    private let service: SessionService
+    /// The file, absolute and already checked; nil when the path
+    /// resolved outside the worktree it claimed to be in.
+    private let path: String?
+    private let title: String
+    private let language: SyntaxLanguage?
+
+    /// Which lines the gutter marks as uncommitted, absent for a
+    /// file that belongs to no worktree.
+    private let changedLines: (() async -> Set<Int>)?
     private let jumpToLine: Int?
     private let showsClose: Bool
     private let onClose: (() -> Void)?
+
+    /// Releases the command waiting on this file, saved or not.
+    private let onFinish: ((Bool) -> Void)?
 
     private var hasChanges: Bool {
         content != saved
     }
 
-    /// The resolved path, but only when it stays inside the worktree:
-    /// a hostile repository could put `../` in a diff path.
-    private var safePath: String? {
-        let base = URL(fileURLWithPath: worktreePath).standardizedFileURL.path
-        let target = URL(fileURLWithPath: worktreePath + "/" + relativePath).standardizedFileURL.path
-        return target == base || target.hasPrefix(base + "/") ? target : nil
+    /// The file's name beside what can be done to it. The primary
+    /// action exists only while a command waits, since that is the
+    /// only time closing the editor decides anything.
+    private var header: some View {
+        HStack {
+            Text(title).font(.headline.monospaced())
+            if onFinish != nil {
+                Text("A command is waiting").font(.callout).foregroundStyle(.secondary)
+            }
+            Spacer()
+            if let status {
+                Text(status).font(.callout).foregroundStyle(.secondary)
+            }
+            Button("Save", systemImage: "square.and.arrow.down") { save() }
+                .labelStyle(.iconOnly)
+                .buttonStyle(.borderless)
+                .disabled(hasChanges == false)
+                .keyboardShortcut("s", modifiers: .command)
+                .hoverHelp("Write the buffer back to the file (Cmd-S); dims until there are changes")
+            if showsClose {
+                Button("Close", systemImage: "xmark") { close() }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.borderless)
+                    .hoverHelp("Close the editor without saving")
+            }
+            if let onFinish {
+                Button("Cancel") { onFinish(false) }
+                    .buttonStyle(.glass)
+                    .hoverHelp("Leave the file as it was and fail the waiting command, which aborts a rebase")
+                Button("Save and close") { save(); onFinish(true) }
+                    .buttonStyle(.glassProminent)
+                    .keyboardShortcut(.return, modifiers: .command)
+                    .hoverHelp("Write the file and let the waiting command carry on (Cmd-Return)")
+            }
+        }
     }
 
     private func load() {
-        guard let safePath else {
+        guard let path else {
             ErrorLog.shared.report("Refusing to open a path outside the worktree.")
             return
         }
 
-        content = (try? String(contentsOfFile: safePath, encoding: .utf8)) ?? ""
+        content = (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
         saved = content
         reloadChangedLines()
     }
 
     private func save() {
-        guard let safePath else {
+        guard let path else {
             ErrorLog.shared.report("Refusing to write a path outside the worktree.")
             return
         }
 
         do {
             content = Whitespace.strippingTrailingWhitespace(content)
-            try content.write(toFile: safePath, atomically: true, encoding: .utf8)
+            try content.write(toFile: path, atomically: true, encoding: .utf8)
             saved = content
             status = Self.savedStatus
             reloadChangedLines()
@@ -144,8 +188,10 @@ struct FileEditorView: View {
     /// Marks lines uncommitted against HEAD in the gutter; buffer
     /// edits count only once saved to disk.
     private func reloadChangedLines() {
-        Task {
-            changedLines = await service.changedLineNumbers(worktreePath: worktreePath, file: relativePath)
+        guard let changedLines else {
+            return
         }
+
+        Task { markedLines = await changedLines() }
     }
 }

--- a/Sources/ReviewFeature/HighlightingTextEditor.swift
+++ b/Sources/ReviewFeature/HighlightingTextEditor.swift
@@ -112,6 +112,20 @@ struct HighlightingTextEditor: NSViewRepresentable {
         view.font = CodeStyle.nsFont
         view.isRichText = false
         view.allowsUndo = true
+        // Code is not prose: smart quotes, dashes, replacements and
+        // corrections all silently break what is typed here.
+        view.isAutomaticQuoteSubstitutionEnabled = false
+        view.isAutomaticDashSubstitutionEnabled = false
+        view.isAutomaticTextReplacementEnabled = false
+        view.isAutomaticSpellingCorrectionEnabled = false
+        view.isAutomaticDataDetectionEnabled = false
+        view.isAutomaticLinkDetectionEnabled = false
+        view.isContinuousSpellCheckingEnabled = false
+        view.isGrammarCheckingEnabled = false
+        // The find bar is AppKit's own, so Cmd-F, Cmd-G and
+        // Cmd-Shift-G work here exactly as they do everywhere else.
+        view.usesFindBar = true
+        view.isIncrementalSearchingEnabled = true
         view.string = text
         let scroll = NSScrollView()
         scroll.hasVerticalScroller = true

--- a/Sources/ReviewFeature/ReviewFileListView.swift
+++ b/Sources/ReviewFeature/ReviewFileListView.swift
@@ -1,0 +1,97 @@
+import AgentIDEData
+import AgentIDEDomain
+import SwiftUI
+import TerminalUI
+
+// MARK: - ReviewFileListView
+
+/// The review pane's file list: collapsible diffs, or inline
+/// editors in the uncommitted scope so fixes are typed directly.
+struct ReviewFileListView: View {
+    // MARK: Internal
+
+    let model: ReviewModel
+    let worktreePath: String
+    let service: SessionService
+
+    /// Whether files start collapsed (the Hide All display mode);
+    /// the per-file carets override it.
+    let hideAllByDefault: Bool
+
+    @Binding var collapseOverrides: [String: Bool]
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: Self.spacing) {
+                    ForEach(model.files) { file in
+                        fileSection(file)
+                    }
+                }
+                .padding(Self.spacing)
+            }
+            // A match in a collapsed file has nothing on screen to
+            // scroll to, which SwiftUI treats as no request at all.
+            .onChange(of: model.currentFindTarget) { _, target in
+                guard let target else {
+                    return
+                }
+
+                withAnimation { proxy.scrollTo(target, anchor: .center) }
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private static let spacing: CGFloat = 8
+    private static let editorMinimumHeight: CGFloat = 240
+    private static let editorMaximumHeight: CGFloat = 420
+
+    @ViewBuilder
+    private func fileSection(_ file: DiffFile) -> some View {
+        // Every scope leads with the diff, uncommitted included: it
+        // once showed the whole file in an editor instead, which read
+        // as a broken diff. Uncommitted files keep that editor for
+        // fixing in place, below their diff.
+        DiffFileView(
+            file: file,
+            model: model,
+            isCollapsed: isCollapsed(file),
+            onToggleCollapse: { toggleCollapse(file) },
+            onEdit: {
+                FileOpener.open(relativePath: file.path, line: nil, worktreePath: worktreePath)
+            },
+        )
+        if model.showsUncommitted, isCollapsed(file) == false, file.isNew == false {
+            FileEditorView(
+                worktreePath: worktreePath,
+                relativePath: file.path,
+                service: service,
+                showsClose: false,
+            )
+            .frame(minHeight: Self.editorMinimumHeight, maxHeight: Self.editorMaximumHeight)
+        }
+        if isCollapsed(file) == false {
+            ForEach(model.threads(for: file.path)) { thread in
+                ReviewThreadRow(
+                    thread: thread,
+                    onEdit: {
+                        FileOpener.open(relativePath: thread.path, line: thread.line, worktreePath: worktreePath)
+                    },
+                    onToggleResolved: { await model.toggleResolved(thread) },
+                )
+            }
+        }
+    }
+
+    private func isCollapsed(_ file: DiffFile) -> Bool {
+        // Generated files always start collapsed, whatever the
+        // expand-all state says; only their own caret opens them.
+        collapseOverrides[file.path] ?? (hideAllByDefault || model.isGenerated(file.path) || file.isNew)
+    }
+
+    private func toggleCollapse(_ file: DiffFile) {
+        collapseOverrides[file.path] = isCollapsed(file) == false
+    }
+}

--- a/Sources/ReviewFeature/ReviewFindBar.swift
+++ b/Sources/ReviewFeature/ReviewFindBar.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import TerminalUI
+
+/// The review pane's find bar. Return and the arrows walk the
+/// matches, Escape closes it, and the count says how many there are.
+struct ReviewFindBar: View {
+    // MARK: Internal
+
+    @Bindable var model: ReviewModel
+
+    /// Raised whenever Cmd-F is pressed, so the field takes focus
+    /// again even when the bar is already open.
+    let focusRequest: Int
+    let onClose: () -> Void
+
+    var body: some View {
+        HStack(spacing: Self.spacing) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            TextField("Find in the diff", text: $model.findQuery)
+                .textFieldStyle(.plain)
+                .focused($focused)
+                .onSubmit { model.moveFind(by: 1) }
+                .onKeyPress(.downArrow) { model.moveFind(by: 1); return .handled }
+                .onKeyPress(.upArrow) { model.moveFind(by: -1); return .handled }
+            Text(model.findSummary)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+            Button("Previous match", systemImage: "chevron.up") { model.moveFind(by: -1) }
+                .labelStyle(.iconOnly)
+                .buttonStyle(.borderless)
+                .disabled(model.findTargets.isEmpty)
+                .hoverHelp("The match before this one (up arrow)")
+            Button("Next match", systemImage: "chevron.down") { model.moveFind(by: 1) }
+                .labelStyle(.iconOnly)
+                .buttonStyle(.borderless)
+                .disabled(model.findTargets.isEmpty)
+                .hoverHelp("The match after this one (return or down arrow)")
+            Button("Close find", systemImage: "xmark") { onClose() }
+                .labelStyle(.iconOnly)
+                .buttonStyle(.borderless)
+                .hoverHelp("Close the find bar and clear its highlights (Escape)")
+        }
+        .padding(.horizontal, Self.padding)
+        .padding(.vertical, Self.verticalPadding)
+        .onExitCommand { onClose() }
+        .task(id: focusRequest) { focused = true }
+    }
+
+    // MARK: Private
+
+    private static let spacing: CGFloat = 6
+    private static let padding: CGFloat = 8
+    private static let verticalPadding: CGFloat = 4
+
+    @FocusState private var focused: Bool
+}

--- a/Sources/ReviewFeature/ReviewModel+Find.swift
+++ b/Sources/ReviewFeature/ReviewModel+Find.swift
@@ -1,0 +1,79 @@
+import AgentIDEDomain
+
+/// Finding text in the diff. The editor and the terminals answer
+/// AppKit's own find bar, but a diff is a list of views rather than
+/// one text view, so the review pane searches its files itself.
+extension ReviewModel {
+    /// Where a match is: the hunk holding it, which is what the list
+    /// can scroll to.
+    struct FindTarget: Hashable {
+        let file: String
+        let hunk: Int
+
+        /// The identity the diff gives that hunk's view.
+        var id: String {
+            file + "#" + String(hunk)
+        }
+    }
+
+    /// What the find bar reports beside its field.
+    var findSummary: String {
+        guard findQuery.isEmpty == false else {
+            return ""
+        }
+        guard findTargets.isEmpty == false else {
+            return "No matches"
+        }
+
+        return String(currentFind + 1) + " of " + String(findTargets.count)
+    }
+
+    /// The hunk the diff should be showing, nil when nothing matches.
+    var currentFindTarget: String? {
+        findTargets.indices.contains(currentFind) ? findTargets[currentFind].id : nil
+    }
+
+    /// Whether a line has anything to highlight, so the renderer
+    /// only searches lines while a query is live.
+    func findRanges(in line: String) -> [Range<String.Index>] {
+        guard findQuery.isEmpty == false else {
+            return []
+        }
+
+        var ranges = [Range<String.Index>]()
+        var start = line.startIndex
+        while let range = line.range(of: findQuery, options: .caseInsensitive, range: start ..< line.endIndex) {
+            ranges.append(range)
+            start = range.upperBound > range.lowerBound ? range.upperBound : line.index(after: range.lowerBound)
+            guard start < line.endIndex else {
+                break
+            }
+        }
+        return ranges
+    }
+
+    /// Recounts the hunks holding a match, keeping the current one
+    /// where it can: the query grows a character at a time, and the
+    /// diff should not jump back to the top for each of them.
+    func updateFindTargets() {
+        let previous = currentFindTarget
+        findTargets = findQuery.isEmpty ? [] : files.flatMap { file in
+            file.hunks
+                .indices
+                .filter { index in
+                    file.hunks[index].lines.contains { findRanges(in: $0.content).isEmpty == false }
+                }
+                .map { FindTarget(file: file.path, hunk: $0) }
+        }
+        currentFind = findTargets.firstIndex { $0.id == previous } ?? 0
+    }
+
+    /// Moves to the next or previous match, wrapping at both ends.
+    func moveFind(by offset: Int) {
+        guard findTargets.isEmpty == false else {
+            return
+        }
+
+        currentFind = (currentFind + offset + findTargets.count) % findTargets.count
+    }
+}

--- a/Sources/ReviewFeature/ReviewModel.swift
+++ b/Sources/ReviewFeature/ReviewModel.swift
@@ -68,6 +68,10 @@ final class ReviewModel {
     /// commit (false); rejection amends only in the latter mode.
     private(set) var showsUncommitted = false
 
+    /// Set only by the find extension, which recounts them.
+    var findTargets: [FindTarget] = []
+    var currentFind = 0
+
     /// The commit message being edited.
     var commitMessage = ""
 
@@ -91,6 +95,12 @@ final class ReviewModel {
     /// the upstream scope has something to diff against; refreshed
     /// on every reload.
     private(set) var hasUpstream = false
+
+    /// The find bar's query; the hunks holding a match and which of
+    /// them is showing are derived from it.
+    var findQuery = "" {
+        didSet { updateFindTargets() }
+    }
 
     /// Whether the commit message differs from the commit's actual
     /// message, so Amend only lights up with something to amend.

--- a/Sources/ReviewFeature/ReviewView.swift
+++ b/Sources/ReviewFeature/ReviewView.swift
@@ -62,6 +62,10 @@ public struct ReviewView: View {
         VStack(spacing: 0) {
             toolbar
             Divider()
+            if showsFind {
+                ReviewFindBar(model: model, focusRequest: findRequest) { closeFind() }
+                Divider()
+            }
             diffList
             ReviewFooterView(
                 model: model,
@@ -76,6 +80,12 @@ public struct ReviewView: View {
             model = makeModel()
             await model.reload()
         }
+        // Cmd-F reaches the pane through the storage bus: a diff is
+        // not a text view, so AppKit's own find bar, which the
+        // editor and the terminals answer, has nothing to attach to.
+        .onChange(of: findRequest) { showsFind = true }
+        .onChange(of: findNextRequest) { model.moveFind(by: 1) }
+        .onChange(of: findPreviousRequest) { model.moveFind(by: -1) }
         // The menu bar's Commit Outstanding lands here through the
         // storage bus.
         .onChange(of: commitRequest) { Task { await commitOutstanding() } }
@@ -97,6 +107,18 @@ public struct ReviewView: View {
     @AppStorage("commitRequest")
     private var commitRequest = 0
     @State private var collapseOverrides: [String: Bool] = [:]
+
+    /// Whether the find bar is showing; the menu's Find opens it
+    /// and Escape or its own button closes it.
+    @State private var showsFind = false
+
+    /// The find menu items' counters on the storage bus.
+    @AppStorage("reviewFindRequest")
+    private var findRequest = 0
+    @AppStorage("reviewFindNextRequest")
+    private var findNextRequest = 0
+    @AppStorage("reviewFindPreviousRequest")
+    private var findPreviousRequest = 0
 
     private let worktreePath: String
     private let service: SessionService
@@ -174,8 +196,6 @@ public struct ReviewView: View {
         )
     }
 
-    /// The collapsible file list; the uncommitted scope embeds the
-    /// shared editor per file so fixes are typed directly.
     @ViewBuilder private var diffList: some View {
         if model.files.isEmpty {
             ContentUnavailableView("No changes", systemImage: "checkmark.circle")
@@ -236,6 +256,15 @@ public struct ReviewView: View {
         // The colour fill alone is invisible to VoiceOver.
         .accessibilityAddTraits(isOn ? .isSelected : [])
         .hoverHelp(help)
+    }
+
+    /// The collapsible file list; the uncommitted scope embeds the
+    /// shared editor per file so fixes are typed directly.
+    /// Closing clears the query too, so the highlights go with the
+    /// bar rather than being left behind on the diff.
+    private func closeFind() {
+        showsFind = false
+        model.findQuery = ""
     }
 
     private func commitOutstanding() async {

--- a/Sources/SessionFeature/BrowserPanes.swift
+++ b/Sources/SessionFeature/BrowserPanes.swift
@@ -1,0 +1,95 @@
+import Observation
+import WebKit
+
+// MARK: - BrowserPane
+
+/// One embedded browser page that is loaded right now: what it shows
+/// and the web process rendering it, so pages can be watched and
+/// closed beside the sessions in the manager.
+public struct BrowserPane: Identifiable, Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a pane record.
+    public init(worktreePath: String, address: String, processIdentifier: Int32) {
+        self.worktreePath = worktreePath
+        self.address = address
+        self.processIdentifier = processIdentifier
+    }
+
+    // MARK: Public
+
+    /// The worktree whose pane this is, and its identity: each
+    /// worktree has at most one browser.
+    public let worktreePath: String
+
+    /// What it has loaded, empty for a blank page.
+    public let address: String
+
+    /// The web content process, zero when WebKit has not started one
+    /// or no longer says which it is.
+    public let processIdentifier: Int32
+
+    public var id: String {
+        worktreePath
+    }
+}
+
+// MARK: - BrowserPanes
+
+/// Every browser page loaded right now. Pages stay mounted while
+/// other worktrees are worked in, so something has to say what they
+/// are costing and let them be closed.
+@preconcurrency
+@Observable
+@MainActor
+public final class BrowserPanes {
+    // MARK: Lifecycle
+
+    deinit {
+        // Lives for the app's whole lifetime.
+    }
+
+    // MARK: Public
+
+    /// The one register of loaded pages, which the manager lists.
+    public static let shared: BrowserPanes = .init()
+
+    /// The loaded pages, by worktree.
+    public private(set) var all: [BrowserPane] = []
+
+    /// The web content process of a view, nil when WebKit does not
+    /// answer for it: the answer is not part of the framework's
+    /// public surface, so it is asked for only when the view says it
+    /// understands the question, and its absence costs the row its
+    /// figures rather than the app anything.
+    public static func processIdentifier(of view: WKWebView) -> Int32? {
+        // The runtime answers with a bridged number, which is what
+        // asking a framework a question it does not publish costs.
+        // swiftlint:disable:next legacy_objc_type
+        let identifier = (view.value(forKey: Self.processKey) as? NSNumber)?.int32Value
+        guard view.responds(to: Selector((Self.processKey))), let identifier, identifier > 0 else {
+            return nil
+        }
+
+        return identifier
+    }
+
+    /// Records what a worktree's browser is showing.
+    public func record(_ pane: BrowserPane) {
+        if let index = all.firstIndex(where: { $0.worktreePath == pane.worktreePath }) {
+            all[index] = pane
+        } else {
+            all.append(pane)
+        }
+    }
+
+    /// Forgets a browser whose pane has gone.
+    public func remove(worktreePath: String) {
+        all.removeAll { $0.worktreePath == worktreePath }
+    }
+
+    // MARK: Private
+
+    /// WebKit's own name for the process behind a view.
+    private static let processKey = "_webProcessIdentifier"
+}

--- a/Sources/SessionFeature/BrowserView.swift
+++ b/Sources/SessionFeature/BrowserView.swift
@@ -4,15 +4,20 @@ import WebKit
 
 // MARK: - BrowserView
 
-/// An embedded browser for dev servers and pull request pages. The
-/// data store persists and is shared, so a GitHub login survives
-/// tab switches and restarts.
+/// An embedded browser for dev servers and pull request pages, one
+/// per worktree. The data store persists and is shared, so a GitHub
+/// login survives tab switches and restarts, and each worktree's
+/// address is remembered so a page closed or lost to a restart comes
+/// back where it was.
 public struct BrowserView: View {
     // MARK: Lifecycle
 
-    /// Creates the browser.
-    public init() {
-        // State holds the address.
+    /// Creates the browser for a worktree. `isActive` says whether
+    /// this is the pane on screen: the others stay loaded, but only
+    /// this one takes an address asked for from elsewhere.
+    public init(worktreePath: String, isActive: Bool) {
+        self.worktreePath = worktreePath
+        self.isActive = isActive
     }
 
     // MARK: Public
@@ -37,7 +42,7 @@ public struct BrowserView: View {
             .padding(Self.padding)
             Divider()
             ZStack {
-                WebPane(request: $request)
+                WebPane(request: $request, onProcess: record(processIdentifier:))
                 if request == nil || (address.isEmpty && editingAddress == false) {
                     ContentUnavailableView(
                         "Nothing loaded",
@@ -51,23 +56,81 @@ public struct BrowserView: View {
                 }
             }
         }
-        .onAppear { load() }
+        .task(id: worktreePath) {
+            // A worktree with no address of its own takes the one
+            // last asked for, which is how a pull request page opens
+            // in a worktree that has never had a browser.
+            address = Self.addresses(in: storedAddresses)[worktreePath] ?? (isActive ? requestedAddress : "")
+            load()
+        }
         .onChange(of: address) {
+            remember()
             if editingAddress == false {
                 load()
             }
         }
+        // An address asked for from elsewhere goes to the pane on
+        // screen, never to the ones loaded behind it.
+        .onChange(of: requestedAddress) {
+            if isActive, requestedAddress.isEmpty == false {
+                address = requestedAddress
+            }
+        }
+        .onDisappear { BrowserPanes.shared.remove(worktreePath: worktreePath) }
     }
 
     // MARK: Private
 
     private static let padding: CGFloat = 8
 
+    /// The address bus other panes write to, and every worktree's
+    /// own address, stored as path-address lines.
     @AppStorage("browserAddress")
-    private var address = ""
+    private var requestedAddress = ""
+    @AppStorage("browserAddresses")
+    private var storedAddresses = ""
+
+    @State private var address = ""
     @State private var request: URLRequest?
 
     @FocusState private var editingAddress: Bool
+
+    private let worktreePath: String
+    private let isActive: Bool
+
+    /// Parses the stored path-address lines.
+    private static func addresses(in lines: String) -> [String: String] {
+        var addresses = [String: String]()
+        for line in lines.split(separator: "\n") {
+            let parts = line.split(separator: "\t", maxSplits: 1)
+            if let path = parts.first, parts.count > 1, let page = parts.last {
+                addresses[String(path)] = String(page)
+            }
+        }
+        return addresses
+    }
+
+    /// Tells the register what this page is and what is rendering
+    /// it, so the session manager can list and close it.
+    private func record(processIdentifier: Int32) {
+        BrowserPanes.shared.record(BrowserPane(
+            worktreePath: worktreePath,
+            address: address,
+            processIdentifier: processIdentifier,
+        ))
+    }
+
+    /// Keeps this worktree's address for the next time its browser
+    /// opens, including after a restart.
+    private func remember() {
+        var addresses = Self.addresses(in: storedAddresses)
+        addresses[worktreePath] = address
+        storedAddresses = addresses
+            .filter { $0.value.isEmpty == false }
+            .map { $0.key + "\t" + $0.value }
+            .sorted()
+            .joined(separator: "\n")
+    }
 
     private func load() {
         guard let url = URL(string: address) else {
@@ -88,14 +151,50 @@ public struct BrowserView: View {
 // MARK: - WebPane
 
 private struct WebPane: NSViewRepresentable {
+    /// Reports the web content process behind the page whenever a
+    /// navigation commits, since that is when WebKit has one and
+    /// when it may have swapped for another.
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        // MARK: Lifecycle
+
+        init(onProcess: @escaping (Int32) -> Void) {
+            self.onProcess = onProcess
+        }
+
+        deinit {
+            // The delegate dies with its view.
+        }
+
+        // MARK: Internal
+
+        // The delegate's own signature hands over an implicitly
+        // unwrapped navigation, which nothing here reads.
+        // swiftlint:disable:next implicitly_unwrapped_optional
+        func webView(_ webView: WKWebView, didCommit _: WKNavigation!) {
+            onProcess(BrowserPanes.processIdentifier(of: webView) ?? 0)
+        }
+
+        // MARK: Private
+
+        private let onProcess: (Int32) -> Void
+    }
+
     @Binding var request: URLRequest?
 
-    func makeNSView(context _: Context) -> WKWebView {
+    let onProcess: (Int32) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onProcess: onProcess)
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
         let configuration = WKWebViewConfiguration()
         // The shared persistent store keeps logins across tabs and
         // restarts.
         configuration.websiteDataStore = .default()
-        return WKWebView(frame: .zero, configuration: configuration)
+        let view = WKWebView(frame: .zero, configuration: configuration)
+        view.navigationDelegate = context.coordinator
+        return view
     }
 
     func updateNSView(_ view: WKWebView, context _: Context) {

--- a/Sources/SessionFeature/SessionManagerSheet.swift
+++ b/Sources/SessionFeature/SessionManagerSheet.swift
@@ -2,17 +2,25 @@ import AgentIDEData
 import SwiftUI
 import TerminalUI
 
-/// Lists every AgentIDE tmux session, sandboxed agents and host
-/// shells alike, with where each lives, what it costs and a kill
-/// per row: the escape hatch when something is running that should
-/// not be.
+/// Lists everything this app has running: every AgentIDE tmux
+/// session, sandboxed agents and host shells alike, and the browser
+/// pages it renders itself, with where each lives, what it costs and
+/// a way to stop it. The escape hatch when something is running that
+/// should not be.
 public struct SessionManagerSheet: View {
     // MARK: Lifecycle
 
-    /// Creates the manager; `onDismiss` closes the sheet.
+    /// Creates the manager; `onCloseBrowser` closes a browser page,
+    /// which only the window can do, and `onDismiss` closes the
+    /// sheet.
     @preconcurrency
-    public init(service: SessionService, onDismiss: @escaping @MainActor () -> Void) {
+    public init(
+        service: SessionService,
+        onCloseBrowser: @escaping @MainActor (String) -> Void,
+        onDismiss: @escaping @MainActor () -> Void,
+    ) {
         self.service = service
+        self.onCloseBrowser = onCloseBrowser
         self.onDismiss = onDismiss
     }
 
@@ -29,11 +37,11 @@ public struct SessionManagerSheet: View {
                 Button("Done") { onDismiss() }
                     .keyboardShortcut(.cancelAction)
             }
-            if sessions.isEmpty {
+            if sessions.isEmpty, browsers.all.isEmpty {
                 ContentUnavailableView(
-                    "No sessions running",
+                    "Nothing running",
                     systemImage: "terminal",
-                    description: Text("Agent sessions and host shells appear here."),
+                    description: Text("Agent sessions, host shells and browser pages appear here."),
                 )
                 .frame(minHeight: Self.listHeight)
             } else {
@@ -48,31 +56,47 @@ public struct SessionManagerSheet: View {
     // MARK: Internal
 
     var list: some View {
-        List(sessions, id: \.name) { session in
-            HStack(spacing: Self.spacing) {
-                Image(systemName: session.isHostShell ? "terminal" : "cpu")
-                    .foregroundStyle(.secondary)
-                    .accessibilityLabel(session.isHostShell ? "Host shell" : "Agent session")
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(session.name).font(CodeStyle.font).lineLimit(1)
-                    Text(location(of: session))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .hoverHelp(session.workingDirectory)
+        List {
+            ForEach(sessions, id: \.name) { session in
+                row(
+                    Entry(
+                        icon: session.isHostShell ? "terminal" : "cpu",
+                        label: session.isHostShell ? "Host shell" : "Agent session",
+                        title: session.name,
+                        directory: session.workingDirectory,
+                        usage: usage(of: session),
+                    ),
+                ) {
+                    killButton(for: session)
                 }
-                Spacer()
-                Text(usage(of: session))
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
-                    .hoverHelp("CPU and memory summed over the session's process tree")
-                killButton(for: session)
+            }
+            ForEach(browsers.all) { pane in
+                row(
+                    Entry(
+                        icon: "safari",
+                        label: "Browser page",
+                        title: pane.address.isEmpty ? "Blank page" : pane.address,
+                        directory: pane.worktreePath,
+                        usage: usage(of: pane),
+                    ),
+                ) {
+                    closeButton(for: pane)
+                }
             }
         }
         .frame(minHeight: Self.listHeight)
     }
 
     // MARK: Private
+
+    /// What one row says, whatever it is a row of.
+    private struct Entry {
+        let icon: String
+        let label: String
+        let title: String
+        let directory: String
+        let usage: String
+    }
 
     private static let spacing: CGFloat = 10
     private static let listHeight: CGFloat = 260
@@ -83,9 +107,43 @@ public struct SessionManagerSheet: View {
 
     @State private var sessions: [SessionOverview] = []
     @State private var killed: Set<String> = []
+    @State private var browserUsage: [Int32: (cpuPercent: Double, memoryMegabytes: Int)] = [:]
 
+    private let browsers: BrowserPanes = .shared
     private let service: SessionService
+    private let onCloseBrowser: @MainActor (String) -> Void
     private let onDismiss: @MainActor () -> Void
+
+    /// One row: what it is, where it lives, what it costs and how to
+    /// stop it.
+    private func row(_ entry: Entry, @ViewBuilder action: () -> some View) -> some View {
+        HStack(spacing: Self.spacing) {
+            Image(systemName: entry.icon)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(entry.label)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(entry.title).font(CodeStyle.font).lineLimit(1)
+                Text(location(of: entry.directory))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .hoverHelp(entry.directory)
+            }
+            Spacer()
+            Text(entry.usage)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .hoverHelp("CPU and memory summed over its process tree")
+            action()
+        }
+    }
+
+    /// Closing a page ends the web process rendering it; its address
+    /// is remembered, so the tab opens it again.
+    private func closeButton(for pane: BrowserPane) -> some View {
+        Button("Close") { onCloseBrowser(pane.worktreePath) }
+            .hoverHelp("Close this page and end the web process rendering it; its address is kept")
+    }
 
     /// Kill greys to Killing while it runs and Killed once the
     /// session is gone; the service escalates a stuck kill itself.
@@ -111,6 +169,7 @@ public struct SessionManagerSheet: View {
 
     private func reload() async {
         sessions = await service.sessionOverviews()
+        browserUsage = await service.usage(ofProcesses: browsers.all.map(\.processIdentifier))
         killed = killed.filter { name in sessions.contains { $0.name == name } }
         // A row killed and gone needs no marker; one killed and
         // still listed shows Killed until a refresh proves it away.
@@ -118,14 +177,28 @@ public struct SessionManagerSheet: View {
 
     /// The owning worktree, its repository and container: the
     /// path's tail places it.
-    private func location(of session: SessionOverview) -> String {
-        session.workingDirectory
+    private func location(of directory: String) -> String {
+        directory
             .split(separator: "/")
             .suffix(Self.locationComponents)
             .joined(separator: "/")
     }
 
     private func usage(of session: SessionOverview) -> String {
-        String(format: "%.0f%% · %d MB", session.cpuPercent, session.memoryMegabytes)
+        usage(cpuPercent: session.cpuPercent, memoryMegabytes: session.memoryMegabytes)
+    }
+
+    /// A page WebKit has not told us its process for shows no
+    /// figures rather than zeroes it cannot stand behind.
+    private func usage(of pane: BrowserPane) -> String {
+        guard let measured = browserUsage[pane.processIdentifier] else {
+            return ""
+        }
+
+        return usage(cpuPercent: measured.cpuPercent, memoryMegabytes: measured.memoryMegabytes)
+    }
+
+    private func usage(cpuPercent: Double, memoryMegabytes: Int) -> String {
+        String(format: "%.0f%% · %d MB", cpuPercent, memoryMegabytes)
     }
 }

--- a/Sources/TerminalUI/LinkOpener.swift
+++ b/Sources/TerminalUI/LinkOpener.swift
@@ -11,6 +11,10 @@ public enum UtilityTabTarget {
     /// The cross-module storage key that switches the utility tab.
     public static let key = "utilityTab"
 
+    /// The key that shows the utility pane, for the panes that must
+    /// be seen whether or not it was open.
+    public static let visibilityKey = "showsUtilityPane"
+
     /// The embedded browser tab.
     public static let browser = "browser"
 

--- a/Sources/TerminalUI/PaneTerminalView.swift
+++ b/Sources/TerminalUI/PaneTerminalView.swift
@@ -20,6 +20,24 @@ final class PaneTerminalView: LocalProcessTerminalView {
     /// Reflows multi-line copies for pasting into prose tools.
     var reflowsCopies = false
 
+    /// Takes a paste whole, before the local terminal turns it into
+    /// keystrokes; true means it was delivered, false leaves it to
+    /// the terminal's own handling. An agent pane pastes through
+    /// tmux, which knows whether the pane's application wants
+    /// bracketed paste; a shell pane is its own terminal and
+    /// already knows.
+    var onPaste: ((String) -> Bool)?
+
+    /// Pastes the clipboard, offering it to the owner first.
+    override func paste(_ sender: Any) {
+        guard let text = NSPasteboard.general.string(forType: .string),
+              onPaste?(text) == true
+        else {
+            super.paste(sender)
+            return
+        }
+    }
+
     /// The right-click menu: Copy and Paste, which terminals
     /// otherwise lack entirely.
     override func menu(for _: NSEvent) -> NSMenu? {

--- a/Sources/TerminalUI/TerminalPaneView.swift
+++ b/Sources/TerminalUI/TerminalPaneView.swift
@@ -35,14 +35,17 @@ public struct TerminalPaneView: View {
     }
 
     /// Creates a terminal running the user's login shell in a
-    /// directory on a local PTY.
+    /// directory on a local PTY. `environment` adds to what a shell
+    /// normally inherits, for the editor variables that point back
+    /// at the app.
     @preconcurrency
     public init(
         shellIn directory: String,
+        environment: [String: String] = [:],
         isActive: Bool = true,
         onProcessTerminated: (@MainActor () -> Void)? = nil,
     ) {
-        transport = .shell(directory: directory)
+        transport = .shell(directory: directory, environment: environment)
         reflowsCopies = false
         self.isActive = isActive
         self.onProcessTerminated = onProcessTerminated
@@ -80,7 +83,7 @@ public struct TerminalPaneView: View {
 /// or a local shell's working directory.
 enum TerminalTransport: Equatable {
     case control(command: [String])
-    case shell(directory: String)
+    case shell(directory: String, environment: [String: String])
 }
 
 // MARK: - TerminalRepresentable

--- a/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
+++ b/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
@@ -280,14 +280,17 @@ extension TerminalRepresentable {
             case let .control(command):
                 startControl(command, in: view)
 
-            case let .shell(directory):
+            case let .shell(directory, environment):
                 // A login interactive shell so the user's own config
                 // applies; the PTY belongs to the view and dies with
-                // it, which is the whole design.
+                // it, which is the whole design. The extras join what
+                // a terminal always sets, so passing them cannot cost
+                // the shell its own variables.
                 view.startProcess(
                     executable: "/bin/zsh",
                     args: ["-il"],
-                    environment: nil,
+                    environment: Terminal.getEnvironmentVariables()
+                        + environment.sorted { $0.key < $1.key }.map { $0.key + "=" + $0.value },
                     execName: nil,
                     currentDirectory: directory,
                 )

--- a/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
+++ b/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
@@ -278,6 +278,9 @@ extension TerminalRepresentable {
             self.view = view
             switch transport {
             case let .control(command):
+                view.onPaste = { [weak self] text in
+                    self?.paste(text) ?? false
+                }
                 startControl(command, in: view)
 
             case let .shell(directory, environment):
@@ -295,6 +298,21 @@ extension TerminalRepresentable {
                     currentDirectory: directory,
                 )
             }
+        }
+
+        /// Pastes through tmux's own buffer, which brackets the text
+        /// when the pane's application asked for it. Only a control
+        /// pane takes this path: a local shell is its own terminal
+        /// and pastes into itself.
+        private func paste(_ text: String) -> Bool {
+            guard channel != nil else {
+                return false
+            }
+
+            for command in TmuxControl.pasteCommands(text: text) {
+                sendCommand(command, expecting: .acknowledgement)
+            }
+            return true
         }
 
         private func startControl(_ command: [String], in view: PaneTerminalView) {

--- a/Tests/AgentIDEDataTests/EditorShimIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/EditorShimIntegrationTests.swift
@@ -1,0 +1,150 @@
+@testable import AgentIDEData
+import AgentIDEDomain
+import Foundation
+import Testing
+
+/// Exercises the real shim script against a real spool, since what
+/// matters is that a command run outside the app blocks on it and
+/// takes its answer.
+struct EditorShimIntegrationTests {
+    // MARK: Internal
+
+    @Test
+    func `a waiting command blocks until the file is saved and closed`() async throws {
+        let root = try TestSupport.temporaryDirectory("shim")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let shim = shim(root: root)
+        let file = root + "/git-rebase-todo"
+        try "pick a1b2c3d Work\n".write(toFile: file, atomically: true, encoding: .utf8)
+
+        let edits = paths(root: root).editsDirectory
+        let spool = ExternalEditSpool(directory: edits)
+        let process = try run(shim, arguments: ["--wait", "git-rebase-todo"], in: root)
+        let edit = try #require(await firstEdit(in: spool))
+        #expect(edit.path == file)
+        #expect(edit.workingDirectory == root)
+        spool.claim(edit)
+
+        // Still waiting: the file is on screen, not dealt with.
+        try await Task.sleep(for: .milliseconds(Self.settleMilliseconds))
+        #expect(process.isRunning)
+
+        spool.finish(edit, saved: true)
+        try await exit(of: process)
+        #expect(process.terminationStatus == 0)
+        // The shim tidies up after itself, so the app never shows a
+        // finished request again.
+        #expect(try FileManager.default.contentsOfDirectory(atPath: edits).isEmpty)
+    }
+
+    @Test
+    func `a cancelled edit fails the command, which aborts a rebase`() async throws {
+        let root = try TestSupport.temporaryDirectory("shim-cancel")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let shim = shim(root: root)
+        let spool = ExternalEditSpool(directory: paths(root: root).editsDirectory)
+
+        let process = try run(shim, arguments: ["-w", root + "/COMMIT_EDITMSG"], in: root)
+        let edit = try #require(await firstEdit(in: spool))
+        spool.claim(edit)
+        spool.finish(edit, saved: false)
+        try await exit(of: process)
+        #expect(process.terminationStatus != 0)
+    }
+
+    @Test
+    func `a request whose command has gone is swept rather than shown`() async throws {
+        let root = try TestSupport.temporaryDirectory("shim-sweep")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let shim = shim(root: root)
+        let edits = paths(root: root).editsDirectory
+        let spool = ExternalEditSpool(directory: edits)
+
+        let process = try run(shim, arguments: ["--wait", root + "/file.txt"], in: root)
+        _ = try #require(await firstEdit(in: spool))
+        process.terminate()
+        try await exit(of: process)
+
+        #expect(spool.pending().isEmpty)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: edits).isEmpty)
+    }
+
+    @Test
+    func `a shell pane is told where the shim is and that it is one`() throws {
+        let root = try TestSupport.temporaryDirectory("shim-env")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let environment = shim(root: root).environment
+
+        // Every tool splits these on whitespace, so a path with a
+        // space in it would break all of them.
+        #expect(shim(root: root).path.contains(" ") == false)
+        for variable in ["EDITOR", "VISUAL", "GIT_EDITOR"] {
+            #expect(environment[variable] == shim(root: root).path + " --wait")
+        }
+        // A shell that sets its own EDITOR can still find the shim
+        // and tell it is running here.
+        #expect(environment["PATH"]?.hasPrefix(Self.shimDirectory + ":") == true)
+        #expect(environment["AGENTIDE"] == "1")
+        #expect(environment["AGENTIDE_EDITS"] == paths(root: root).editsDirectory)
+        // The sequence editor is left alone deliberately.
+        #expect(environment["GIT_SEQUENCE_EDITOR"] == nil)
+    }
+
+    // MARK: Private
+
+    private static let settleMilliseconds = 600
+    private static let pollMilliseconds = 50
+    private static let waitAttempts = 100
+
+    /// The shim as shipped, run straight from the repository: under
+    /// test there is no app bundle to find it in.
+    private static let shimDirectory = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("bin")
+        .path
+
+    private func shim(root: String) -> EditorShim {
+        EditorShim(paths: paths(root: root), directory: Self.shimDirectory)
+    }
+
+    private func paths(root: String) -> WorkspacePaths {
+        WorkspacePaths(
+            hostUser: "test",
+            sharedWorkspace: root + "/shared",
+            sandboxHome: root + "/home",
+            metadataFile: root + "/state.json",
+            appDirectory: root + "/app",
+        )
+    }
+
+    private func run(_ shim: EditorShim, arguments: [String], in directory: String) throws -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: shim.path)
+        process.arguments = arguments
+        process.currentDirectoryURL = URL(fileURLWithPath: directory)
+        process.environment = ProcessInfo.processInfo.environment.merging(shim.environment) { _, new in new }
+        try process.run()
+        return process
+    }
+
+    /// The first spooled request, waiting for the shim to write it.
+    private func firstEdit(in spool: ExternalEditSpool) async -> ExternalEdit? {
+        for _ in 0 ..< Self.waitAttempts {
+            if let edit = spool.pending().first {
+                return edit
+            }
+
+            try? await Task.sleep(for: .milliseconds(Self.pollMilliseconds))
+        }
+        return nil
+    }
+
+    private func exit(of process: Process) async throws {
+        for _ in 0 ..< Self.waitAttempts where process.isRunning {
+            try await Task.sleep(for: .milliseconds(Self.pollMilliseconds))
+        }
+        #expect(process.isRunning == false)
+    }
+}

--- a/Tests/AgentIDEDataTests/GitClientIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/GitClientIntegrationTests.swift
@@ -33,6 +33,30 @@ struct GitClientIntegrationTests {
     }
 
     @Test
+    func `a worktree keeps its row while detached mid-rebase`() async throws {
+        let root = try TestSupport.temporaryDirectory("detached")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let repoPath = root + "/repo"
+        try await TestSupport.makeRepository(at: repoPath)
+        let repository = Repository(name: "repo", path: repoPath)
+        let worktreePath = root + "/worktrees/uuid/sentry_errors"
+        try await git.createWorktree(repository: repository, branch: "sentry_errors", at: worktreePath)
+
+        // git detaches HEAD for the whole of a rebase, and reporting
+        // no worktree took its sidebar row away, which killed the
+        // shell running in it.
+        try await TestSupport.runGit(["checkout", "--detach"], in: worktreePath)
+        let detached = try await git.worktrees(of: repository)
+        #expect(detached.map(\.path) == [worktreePath])
+        // Its directory is named for the branch it will return to.
+        #expect(detached.map(\.branch) == ["sentry_errors"])
+
+        try await TestSupport.runGit(["checkout", "sentry_errors"], in: worktreePath)
+        let reattached = try await git.worktrees(of: repository)
+        #expect(reattached.map(\.branch) == ["sentry_errors"])
+    }
+
+    @Test
     func `per-line rejection reverses only the selected change and amends`() async throws {
         let root = try TestSupport.temporaryDirectory("reject")
         defer { try? FileManager.default.removeItem(atPath: root) }

--- a/Tests/AgentIDEDomainTests/SyntaxHighlighterTests.swift
+++ b/Tests/AgentIDEDomainTests/SyntaxHighlighterTests.swift
@@ -13,6 +13,47 @@ struct SyntaxHighlighterTests {
         #expect(SyntaxLanguage.language(forPath: "config.yaml") == .yaml)
         #expect(SyntaxLanguage.language(forPath: "README.md") == .markdown)
         #expect(SyntaxLanguage.language(forPath: "binary.png") == nil)
+        // The files commands hand to an editor have no extension.
+        let rebase = ".git/worktrees/agent/rebase-merge/git-rebase-todo"
+        #expect(SyntaxLanguage.language(forPath: rebase) == .gitRebaseTodo)
+        #expect(SyntaxLanguage.language(forPath: ".git/COMMIT_EDITMSG") == .gitMessage)
+    }
+
+    @Test
+    func `highlights a rebase todo's commands, commits and instructions`() {
+        let line = "pick a1b2c3d Keep a worktree listed"
+        let tokens = SyntaxHighlighter.highlight(line: line, language: .gitRebaseTodo)
+        #expect(tokens.map(\.text).joined() == line)
+        #expect(tokens.first == SyntaxToken(kind: .keyword, text: "pick"))
+        #expect(tokens.contains(SyntaxToken(kind: .number, text: "a1b2c3d")))
+        #expect(tokens.contains { $0.kind == .plain && $0.text.contains("Keep a worktree listed") })
+
+        let instruction = "# Commands:"
+        #expect(SyntaxHighlighter.highlight(line: instruction, language: .gitRebaseTodo)
+            == [SyntaxToken(kind: .comment, text: instruction)])
+
+        // A label is not a commit, and an unknown first word is not a
+        // command, so neither is coloured as one.
+        let label = SyntaxHighlighter.highlight(line: "label onto", language: .gitRebaseTodo)
+        #expect(label.first == SyntaxToken(kind: .keyword, text: "label"))
+        #expect(label.contains { $0.kind == .number } == false)
+        let broken = SyntaxHighlighter.highlight(line: "picky a1b2c3d Work", language: .gitRebaseTodo)
+        #expect(broken.contains { $0.kind == .keyword } == false)
+    }
+
+    @Test
+    func `highlights only the block git strips from a commit message`() {
+        let subject = "Keep a worktree listed while it is detached"
+        #expect(SyntaxHighlighter.highlight(line: subject, language: .gitMessage)
+            == [SyntaxToken(kind: .plain, text: subject)])
+        // An apostrophe must not open a string that swallows the rest
+        // of the line, as the general tokenizer would have it.
+        let body = "- git's own listing hides it"
+        #expect(SyntaxHighlighter.highlight(line: body, language: .gitMessage)
+            == [SyntaxToken(kind: .plain, text: body)])
+        let comment = "# Please enter the commit message for your changes."
+        #expect(SyntaxHighlighter.highlight(line: comment, language: .gitMessage)
+            == [SyntaxToken(kind: .comment, text: comment)])
     }
 
     @Test

--- a/Tests/AgentIDEDomainTests/TmuxPasteTests.swift
+++ b/Tests/AgentIDEDomainTests/TmuxPasteTests.swift
@@ -50,6 +50,38 @@ struct TmuxPasteTests {
     }
 
     @Test
+    func `a paste is staged in a buffer and pasted from it`() {
+        let commands = TmuxControl.pasteCommands(text: "a multi-line\npaste with 🙂")
+        #expect(commands == [
+            "set-buffer -b agentide-paste -- \"a multi-line\\npaste with 🙂\"",
+            "paste-buffer -d -p -b agentide-paste",
+        ])
+        #expect(TmuxControl.pasteCommands(text: "").isEmpty)
+    }
+
+    @Test
+    func `tmux decides the bracketing, so the markers come off first`() {
+        // The local terminal only knows the mode from output it has
+        // seen; a pane attached mid-session never saw it being set,
+        // and its missing markers stranded the cursor mid-paste.
+        let bracketed = "\u{1B}[200~pasted\u{1B}[201~"
+        #expect(TmuxControl.pasteCommands(text: bracketed).first == "set-buffer -b agentide-paste -- \"pasted\"")
+        #expect(TmuxControl.pasteCommands(text: bracketed).last?.contains("-p") == true)
+    }
+
+    @Test
+    func `a long paste is appended into one buffer and pasted once`() {
+        let commands = TmuxControl.pasteCommands(text: String(repeating: "x", count: 40_000))
+        #expect(commands.count > 2)
+        #expect(commands.first?.hasPrefix("set-buffer -b ") == true)
+        #expect(commands.dropFirst().dropLast().allSatisfy { $0.hasPrefix("set-buffer -a -b ") })
+        // However many commands stage it, one paste arrives.
+        let pastes = commands.count { $0.hasPrefix("paste-buffer") }
+        #expect(pastes == 1)
+        #expect(commands.last?.hasPrefix("paste-buffer") == true)
+    }
+
+    @Test
     func `a paste splits only when the command itself would not fit`() {
         // Chunking once counted source characters, so a paste this
         // size split into several commands despite fitting easily.

--- a/Tests/AgentIDEDomainTests/WrappingTests.swift
+++ b/Tests/AgentIDEDomainTests/WrappingTests.swift
@@ -1,0 +1,51 @@
+import AgentIDEDomain
+import Testing
+
+/// Exercises putting hand-wrapped commit prose back onto one line
+/// per point, which is what a pull request body wants.
+struct WrappingTests {
+    @Test
+    func `joins wrapped bullets and paragraphs into whole lines`() {
+        let message = """
+        - Run lint without concurrency on standard runners before
+          a candidate enters the expensive stage.
+        - Let one candidate finish while the newest waiting candidate
+          replaces older pending work through the default queue.
+
+        A paragraph that was wrapped by hand at a narrow column
+        also becomes one line again.
+        """
+        #expect(Wrapping.unwrapped(message) == """
+        - Run lint without concurrency on standard runners before a candidate enters the expensive stage.
+        - Let one candidate finish while the newest waiting candidate replaces older pending work through \
+        the default queue.
+
+        A paragraph that was wrapped by hand at a narrow column also becomes one line again.
+        """)
+    }
+
+    @Test
+    func `leaves blocks that mean something by their lines alone`() {
+        let message = """
+        # Heading
+        Its paragraph.
+
+        ```sh
+        script/style --fix
+        script/test
+        ```
+
+            indented code stays put
+
+        > A quote
+        > with two lines.
+        """
+        #expect(Wrapping.unwrapped(message) == message)
+    }
+
+    @Test
+    func `an unwrapped body is left exactly as it is`() {
+        let message = "One line.\n\n- One bullet.\n- Another bullet."
+        #expect(Wrapping.unwrapped(message) == message)
+    }
+}

--- a/Tests/DashboardFeatureTests/RowRetentionTests.swift
+++ b/Tests/DashboardFeatureTests/RowRetentionTests.swift
@@ -1,0 +1,72 @@
+import AgentIDEDomain
+import DashboardFeature
+import Foundation
+import Testing
+
+/// The sidebar keeps rows one reading lost, so the panes they hold
+/// open, and the shells running in those panes, only close when the
+/// worktree really goes away.
+@MainActor
+struct RowRetentionTests {
+    // MARK: Internal
+
+    @Test
+    func `keeps a row git stopped listing and drops a deleted one`() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let repositoryPath = try makeDirectory(in: root, named: "repo")
+        let rebasing = try makeDirectory(in: root, named: "rebasing")
+        let deleted = root + "/deleted"
+
+        let previous = [group(repositoryPath: repositoryPath, paths: [repositoryPath, rebasing, deleted])]
+        // A rebase detaches the worktree, which git omits from its
+        // own listing, and the deleted one is genuinely gone.
+        let next = [group(repositoryPath: repositoryPath, paths: [repositoryPath])]
+
+        let merged = DashboardModel.retainingLostRows(of: previous, in: next)
+        #expect(merged.flatMap(\.items).map(\.worktree.path) == [repositoryPath, rebasing])
+    }
+
+    @Test
+    func `keeps a repository the listing lost and drops a removed one`() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let kept = try makeDirectory(in: root, named: "kept")
+        let removed = root + "/removed"
+
+        let previous = [
+            group(repositoryPath: kept, paths: [kept]),
+            group(repositoryPath: removed, paths: [removed]),
+        ]
+        let merged = DashboardModel.retainingLostRows(of: previous, in: [])
+        #expect(merged.map(\.repository.path) == [kept])
+    }
+
+    // MARK: Private
+
+    private func makeDirectory(in parent: String? = nil, named name: String = "retention") throws -> String {
+        let path = (parent ?? NSTemporaryDirectory()) + "/" + name + (parent == nil ? UUID().uuidString : "")
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        return path
+    }
+
+    private func group(repositoryPath: String, paths: [String]) -> RepositoryGroup {
+        RepositoryGroup(
+            repository: Repository(name: "repo", path: repositoryPath),
+            items: paths.map { path in
+                WorktreeItem(
+                    worktree: Worktree(
+                        repositoryName: "repo",
+                        repositoryPath: repositoryPath,
+                        branch: URL(fileURLWithPath: path).lastPathComponent,
+                        path: path,
+                    ),
+                    session: nil,
+                    isDirty: false,
+                    aheadOfUpstream: nil,
+                    hasUnread: false,
+                )
+            },
+        )
+    }
+}

--- a/Tests/ReviewFeatureTests/ReviewModelTests.swift
+++ b/Tests/ReviewFeatureTests/ReviewModelTests.swift
@@ -95,6 +95,49 @@ struct ReviewModelTests {
         #expect(model.branchCommits.last?.contains("origin/main") == true)
     }
 
+    @Test
+    func `finding walks the hunks that hold a match and highlights them`() async throws {
+        let path = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("agentide-find-" + UUID().uuidString, isDirectory: true)
+            .path
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        try await makeRepository(at: path)
+        try "needle here\n".write(toFile: path + "/one.txt", atomically: true, encoding: .utf8)
+        try "nothing\n".write(toFile: path + "/two.txt", atomically: true, encoding: .utf8)
+        try "a NEEDLE too\n".write(toFile: path + "/three.txt", atomically: true, encoding: .utf8)
+        try await runGit(["add", "-A"], in: path)
+
+        let model = ReviewModel(worktreePath: path, git: GitClient(runner: FoundationProcessRunner()))
+        model.scope = .uncommitted
+        await model.reload()
+        #expect(model.findTargets.isEmpty)
+        #expect(model.findSummary.isEmpty)
+
+        // Matching ignores case, and only the hunks holding a match
+        // are walked.
+        model.findQuery = "needle"
+        #expect(model.findTargets.map(\.file) == ["one.txt", "three.txt"])
+        #expect(model.findSummary == "1 of 2")
+        #expect(model.currentFindTarget == "one.txt#0")
+
+        model.moveFind(by: 1)
+        #expect(model.currentFindTarget == "three.txt#0")
+        // Walking wraps rather than stopping at the last match.
+        model.moveFind(by: 1)
+        #expect(model.currentFindTarget == "one.txt#0")
+        model.moveFind(by: -1)
+        #expect(model.currentFindTarget == "three.txt#0")
+
+        // The renderer asks for what to tint on each line.
+        #expect(model.findRanges(in: "a needle and a needle").count == 2)
+        #expect(model.findRanges(in: "nothing").isEmpty)
+
+        model.findQuery = ""
+        #expect(model.findTargets.isEmpty)
+        #expect(model.findRanges(in: "needle").isEmpty)
+    }
+
     // MARK: Private
 
     private func makeRepository(at path: String) async throws {

--- a/bin/agentide
+++ b/bin/agentide
@@ -1,0 +1,81 @@
+#!/bin/sh
+# AgentIDE's editor shim, shipped inside the app bundle and put on a
+# shell pane's PATH. It hands a file to the app's own editor and
+# waits there until the file is saved and closed, so it can serve as
+# EDITOR, VISUAL or GIT_EDITOR. A cancelled edit exits non-zero,
+# which is how git is told to abort.
+set -eu
+
+# The app names its own spool, so a development build never answers
+# the installed app's shells; anything else means the installed one.
+spool="${AGENTIDE_EDITS:-${HOME}/.agentide/edits}"
+
+# How long to wait for the app to take a request, as a count of
+# polls: long enough to cover a busy app, short enough that a shell
+# without one says so rather than hanging.
+claim_tries=50
+poll_seconds=0.2
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    # Waiting is the only behaviour, but editors are configured with
+    # the flag, so it is accepted.
+    -w | --wait) shift ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      printf 'agentide: unknown option: %s\n' "$1" >&2
+      exit 64
+      ;;
+    *) break ;;
+  esac
+done
+
+if [ "$#" -eq 0 ]; then
+  printf 'usage: agentide [--wait] file...\n' >&2
+  exit 64
+fi
+
+mkdir -p "${spool}"
+
+# The physical directory, since that is how git names a worktree and
+# how the app matches one.
+cwd="$(pwd -P)"
+
+for file in "$@"; do
+  case "${file}" in
+    /*) path="${file}" ;;
+    *) path="${cwd}/${file}" ;;
+  esac
+  id="$(/usr/bin/uuidgen)"
+  request="${spool}/${id}.request"
+  trap 'rm -f "${request}" "${spool}/${id}.open" "${spool}/${id}.done"; exit 130' HUP INT TERM
+  printf '{"path":"%s","workingDirectory":"%s","processIdentifier":%s}\n' \
+    "$(printf '%s' "${path}" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
+    "$(printf '%s' "${cwd}" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
+    "$$" >"${request}.partial"
+  mv "${request}.partial" "${request}"
+
+  # The app claims a request as soon as it shows the file, so an
+  # unclaimed one means it is not running.
+  tries=0
+  while [ ! -e "${spool}/${id}.open" ] && [ ! -e "${spool}/${id}.done" ]; do
+    if [ "${tries}" -ge "${claim_tries}" ]; then
+      rm -f "${request}"
+      printf 'agentide: AgentIDE did not answer; is it running?\n' >&2
+      exit 69
+    fi
+    tries=$((tries + 1))
+    sleep "${poll_seconds}"
+  done
+  while [ ! -e "${spool}/${id}.done" ]; do
+    sleep "${poll_seconds}"
+  done
+
+  status="$(cat "${spool}/${id}.done")"
+  rm -f "${request}" "${spool}/${id}.open" "${spool}/${id}.done"
+  trap - HUP INT TERM
+  [ "${status}" = 0 ] || exit "${status}"
+done

--- a/bin/agentide
+++ b/bin/agentide
@@ -18,8 +18,8 @@ poll_seconds=0.2
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    # Waiting is the only behaviour, but editors are configured with
-    # the flag, so it is accepted.
+    # Waiting is the only behaviour, but editors are configured
+    # with the flag either way, so both spellings are accepted.
     -w | --wait) shift ;;
     --)
       shift
@@ -34,7 +34,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ "$#" -eq 0 ]; then
-  printf 'usage: agentide [--wait] file...\n' >&2
+  printf 'usage: agentide [-w|--wait] file...\n' >&2
   exit 64
 fi
 

--- a/project.yml
+++ b/project.yml
@@ -13,6 +13,12 @@ targets:
     platform: macOS
     sources:
       - App
+      # A folder reference, so the shim keeps its name, its place and
+      # its executable bit inside Resources; a shell pane puts this
+      # directory on its PATH.
+      - path: bin
+        type: folder
+        buildPhase: resources
     dependencies:
       - package: AgentIDEPackage
         product: DashboardFeature

--- a/script/style
+++ b/script/style
@@ -8,11 +8,12 @@ STYLE_FIX=""
 [[ "${1-}" == "--fix" ]] && STYLE_FIX="1"
 
 shell_style() {
-  shellcheck script/*
+  # The shipped shim in bin is a shell script like the rest.
+  shellcheck script/* bin/*
   if [[ -n "${STYLE_FIX}" ]]; then
-    shfmt -i 2 -ci -w script/*
+    shfmt -i 2 -ci -w script/* bin/*
   else
-    shfmt -i 2 -ci -d script/*
+    shfmt -i 2 -ci -d script/* bin/*
   fi
 }
 


### PR DESCRIPTION
- Preserve worktree presence during rebase and pane closure
- Maintain sidebar rows only when directory and worktree persist
- Reintegrate commit message continuations into pull request body
- Route shell command waits through agentide shim with dual flag naming
- Direct tmux paste to buffer for consistent operation across panes
- Enable Cmd-F with system find bar and diff view integration
- Standardize shim flag usage across configuration and documentation