### PR TITLE
Answer a waiting command only once it is saved

### DIFF
--- a/Sources/ReviewFeature/FileEditorView.swift
+++ b/Sources/ReviewFeature/FileEditorView.swift
@@ -83,6 +83,7 @@ struct FileEditorView: View {
 
     private static let padding: CGFloat = 8
     private static let savedStatus = "Saved."
+    private static let failedStatus = "Not saved."
 
     @State private var content = ""
     @State private var saved = ""
@@ -137,15 +138,29 @@ struct FileEditorView: View {
                     .buttonStyle(.borderless)
                     .hoverHelp("Close the editor without saving")
             }
-            if let onFinish {
-                Button("Cancel") { onFinish(false) }
-                    .buttonStyle(.glass)
-                    .hoverHelp("Leave the file as it was and fail the waiting command, which aborts a rebase")
-                Button("Save and close") { save(); onFinish(true) }
-                    .buttonStyle(.glassProminent)
-                    .keyboardShortcut(.return, modifiers: .command)
-                    .hoverHelp("Write the file and let the waiting command carry on (Cmd-Return)")
+            waitingActions
+        }
+    }
+
+    /// What a file some command is waiting on offers instead of a
+    /// close: finish it, or fail it and let the command deal with
+    /// that, which is how a rebase is aborted.
+    @ViewBuilder private var waitingActions: some View {
+        if let onFinish {
+            Button("Cancel") { onFinish(false) }
+                .buttonStyle(.glass)
+                .hoverHelp("Leave the file as it was and fail the waiting command, which aborts a rebase")
+            // Only a file that actually reached the disk lets the
+            // command carry on: a failed write would otherwise leave
+            // git rebasing with the edit it never got.
+            Button("Save and close") {
+                if save() {
+                    onFinish(true)
+                }
             }
+            .buttonStyle(.glassProminent)
+            .keyboardShortcut(.return, modifiers: .command)
+            .hoverHelp("Write the file and let the waiting command carry on (Cmd-Return)")
         }
     }
 
@@ -160,10 +175,12 @@ struct FileEditorView: View {
         reloadChangedLines()
     }
 
-    private func save() {
+    /// Writes the buffer back, reporting whether it landed.
+    @discardableResult
+    private func save() -> Bool {
         guard let path else {
             ErrorLog.shared.report("Refusing to write a path outside the worktree.")
-            return
+            return false
         }
 
         do {
@@ -172,8 +189,11 @@ struct FileEditorView: View {
             saved = content
             status = Self.savedStatus
             reloadChangedLines()
+            return true
         } catch {
             ErrorLog.shared.report(error.localizedDescription)
+            status = Self.failedStatus
+            return false
         }
     }
 

--- a/Sources/ReviewFeature/FileEditorView.swift
+++ b/Sources/ReviewFeature/FileEditorView.swift
@@ -179,6 +179,9 @@ struct FileEditorView: View {
     @discardableResult
     private func save() -> Bool {
         guard let path else {
+            // The header says so too: a button that only writes to
+            // the errors tab reads as a button that does nothing.
+            status = Self.failedStatus
             ErrorLog.shared.report("Refusing to write a path outside the worktree.")
             return false
         }

--- a/Sources/SessionFeature/BrowserPanes.swift
+++ b/Sources/SessionFeature/BrowserPanes.swift
@@ -10,7 +10,7 @@ public struct BrowserPane: Identifiable, Hashable, Sendable {
     // MARK: Lifecycle
 
     /// Creates a pane record.
-    public init(worktreePath: String, address: String, processIdentifier: Int32) {
+    public init(worktreePath: String, address: String, processIdentifier: Int32?) {
         self.worktreePath = worktreePath
         self.address = address
         self.processIdentifier = processIdentifier
@@ -25,9 +25,11 @@ public struct BrowserPane: Identifiable, Hashable, Sendable {
     /// What it has loaded, empty for a blank page.
     public let address: String
 
-    /// The web content process, zero when WebKit has not started one
-    /// or no longer says which it is.
-    public let processIdentifier: Int32
+    /// The web content process rendering it, nil when WebKit has
+    /// not started one or will not say which it is. Nothing may
+    /// stand in for it: sampling process zero would sum the usage of
+    /// everything the kernel owns.
+    public let processIdentifier: Int32?
 
     public var id: String {
         worktreePath

--- a/Sources/SessionFeature/BrowserView.swift
+++ b/Sources/SessionFeature/BrowserView.swift
@@ -112,7 +112,7 @@ public struct BrowserView: View {
 
     /// Tells the register what this page is and what is rendering
     /// it, so the session manager can list and close it.
-    private func record(processIdentifier: Int32) {
+    private func record(processIdentifier: Int32?) {
         BrowserPanes.shared.record(BrowserPane(
             worktreePath: worktreePath,
             address: address,
@@ -157,7 +157,7 @@ private struct WebPane: NSViewRepresentable {
     final class Coordinator: NSObject, WKNavigationDelegate {
         // MARK: Lifecycle
 
-        init(onProcess: @escaping (Int32) -> Void) {
+        init(onProcess: @escaping (Int32?) -> Void) {
             self.onProcess = onProcess
         }
 
@@ -171,17 +171,17 @@ private struct WebPane: NSViewRepresentable {
         // unwrapped navigation, which nothing here reads.
         // swiftlint:disable:next implicitly_unwrapped_optional
         func webView(_ webView: WKWebView, didCommit _: WKNavigation!) {
-            onProcess(BrowserPanes.processIdentifier(of: webView) ?? 0)
+            onProcess(BrowserPanes.processIdentifier(of: webView))
         }
 
         // MARK: Private
 
-        private let onProcess: (Int32) -> Void
+        private let onProcess: (Int32?) -> Void
     }
 
     @Binding var request: URLRequest?
 
-    let onProcess: (Int32) -> Void
+    let onProcess: (Int32?) -> Void
 
     func makeCoordinator() -> Coordinator {
         Coordinator(onProcess: onProcess)

--- a/Sources/SessionFeature/SessionManagerSheet.swift
+++ b/Sources/SessionFeature/SessionManagerSheet.swift
@@ -169,7 +169,7 @@ public struct SessionManagerSheet: View {
 
     private func reload() async {
         sessions = await service.sessionOverviews()
-        browserUsage = await service.usage(ofProcesses: browsers.all.map(\.processIdentifier))
+        browserUsage = await service.usage(ofProcesses: browsers.all.compactMap(\.processIdentifier))
         killed = killed.filter { name in sessions.contains { $0.name == name } }
         // A row killed and gone needs no marker; one killed and
         // still listed shows Killed until a refresh proves it away.
@@ -189,9 +189,9 @@ public struct SessionManagerSheet: View {
     }
 
     /// A page WebKit has not told us its process for shows no
-    /// figures rather than zeroes it cannot stand behind.
+    /// figures rather than numbers it cannot stand behind.
     private func usage(of pane: BrowserPane) -> String {
-        guard let measured = browserUsage[pane.processIdentifier] else {
+        guard let identifier = pane.processIdentifier, let measured = browserUsage[identifier] else {
             return ""
         }
 


### PR DESCRIPTION
- Save and close released the waiting command whether or not the write landed, so a failed write let git carry on rebasing with the edit it never got; a failure now keeps the editor open and says so, leaving Cancel as the way out
- A browser page WebKit will not name has no process at all rather than process zero, which the session manager was sampling: its tree is everything the kernel owns, so the row showed enormous figures for a page it knew nothing about