### PR TITLE
Fix session and conversation management across worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,27 @@ Hard-won on macOS 27 beta; check before assuming they expired.
   name, never index, so reordering cannot repoint them.
 - Octicon SVG imagesets in `App/Assets.xcassets` render as template
   images; `ChecksStyle` maps GitHub states to them.
+- `cannot execute tool 'metal' due to missing Metal Toolchain` breaks
+  every build of SwiftTerm-dependent targets, which is the app and
+  most tests. The toolchain is a downloadable asset each user mounts
+  under its own home, but mounts are visible to everyone: when the
+  host user has it mounted, Xcode finds that mount, cannot read it
+  across the sandbox boundary and refuses rather than making its own.
+  Eject the host user's mount, as the host user, then ask for the
+  component again inside the sandbox, which mounts its own copy at
+  `<hash>_1`:
+
+  ```bash
+  cd ~/Library/Developer/DVTDownloads/MetalToolchain/mounts
+  diskutil eject <hash>
+  xcodebuild -downloadComponent MetalToolchain  # in the sandbox
+  ```
+
+  The coordinator writes its failures to stderr, not `os_log`, so
+  `log show` finds nothing however good the predicate is. Until it is
+  fixed, `swift build --target AgentIDEDomain`, `--target
+  AgentIDEData` and `--target AgentIDEDataTests` still typecheck,
+  since none of them reach SwiftTerm.
 - tmux servers and sessions outlive the app and only read config at
   start, so changes to launch commands, configs or session shapes
   often need existing tmux sessions or servers restarted (or leaked

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -613,7 +613,11 @@ shim rather than a protocol:
 7. Each pull request row offers the last mile as small actions: copy the
    unresolved review conversations, or the failing checks with their
    failed steps' actual log output, to the clipboard for pasting into
-   an agent, and open the page in the Browser tab. Conversations
+   an agent, and open the page in the Browser tab. A failing check names
+   its own job, and that job is what is read (`gh run view --job`),
+   since a run of fifty jobs where one failed would otherwise paste the
+   other forty-nine; while the run is still going `gh` refuses its logs,
+   so the job's log comes from the API instead. Conversations
    resolve individually through the GraphQL API, on the conversation
    page and inline on the review tab under the files they anchor to,
    each entry naming its file and line; resolving refreshes the pull

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -657,15 +657,25 @@ shim rather than a protocol:
 
 ### Close and reopen a session
 
-Closing a session kills only the tmux session. The worktree, transcripts and
-metadata (including the resume id) remain, and the deliberate close is
-recorded so the automatic resumes below leave that worktree alone until a
-session starts there again. Reopening builds the agent's
-resume command (`claude --resume <id>`, or the Codex equivalent) through the
-normal launch shape in the same canonical cwd, restoring the full prior
-conversation. A worktree whose session never recorded a resume id falls
-back to a fresh session there, never a relaunch of the original prompt,
-which would re-run the whole task against the already modified worktree.
+Closing a session ends the tmux session and everything in it, escalating
+past the polite kill when that does not take, so the button ends the agent
+rather than asking it to stop. The worktree, transcripts and metadata
+(including the resume id) remain, and the deliberate close is recorded so
+the automatic resumes below leave that worktree alone until a session
+starts there again.
+
+Reopening builds the agent's resume command (`claude --resume <id>`, or the
+Codex equivalent) through the normal launch shape in the same canonical cwd,
+restoring the full prior conversation. Resuming fails in ways that look like
+success, though: an agent handed a conversation it has rolled away, or one a
+newer version will not read, exits at once, and `remain-on-exit` keeps the
+dead pane, so the name is taken and the terminal attaches to a corpse.
+Reopening therefore works through the ways in until one is still running a
+moment later: the recorded conversation, then the newest conversations the
+worktree's own transcripts name, then a fresh session there. Each attempt
+kills whatever holds the session name first. Relaunching with the original
+prompt is never among them, since it would re-run the whole task against the
+already modified worktree.
 
 While agents or shells run, the app holds a system activity that defers
 idle sleep (`SleepInhibitor`; closing the lid still sleeps), and sessions

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -718,6 +718,26 @@ encoded name extends one of the repository's `worktrees/<uuid>`
 containers is scanned too, so conversations from worktrees created and
 deleted by other tooling still appear.
 
+### Conversations outside the sandbox
+
+Everything the app derives from can be rebuilt except one thing: the
+conversations. Worktrees and git objects live in the shared workspace and on
+GitHub, tmux is ephemeral by design, agent credentials can be obtained again
+and configuration comes from the `user/` template. Transcripts live only in
+the sandbox user's home, which is disposable by design and was emptied by
+accident once, taking finished conversations with it.
+
+Each worktree's newest conversation is therefore copied out of the sandbox at
+the moments it is about to matter: when a session is closed, and when one is
+resumed. The copy goes to iCloud Drive when it is set up, and to the app's
+own directory when it is not, one file per worktree with a small index beside
+it naming the worktree, branch, agent and resume id, since a transcript alone
+says none of that. Deleting a worktree, or cleaning it up after a merge,
+takes its copy with it: the conversation is being thrown away deliberately
+and a backup nobody asked to keep is clutter. Only the conversation is
+copied, never the code or anything the agent read, because git and GitHub
+already hold the first and the second is not ours to put in anyone's cloud.
+
 ## State and persistence
 
 | Fact | Source of truth | The app's role |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -728,8 +728,11 @@ the sandbox user's home, which is disposable by design and was emptied by
 accident once, taking finished conversations with it.
 
 Each worktree's newest conversation is therefore copied out of the sandbox at
-the moments it is about to matter: when a session is closed, and when one is
-resumed. The copy goes to iCloud Drive when it is set up, and to the app's
+the moments it is about to matter: when a session is closed, when one is
+resumed, and hourly while one runs. The hourly copy rides the poll that
+already reads the world, skips a transcript that has not moved on and records
+when it last ran in the metadata store, so a session running for a day is
+never more than an hour stale. The copy goes to iCloud Drive when it is set up, and to the app's
 own directory when it is not, one file per worktree with a small index beside
 it naming the worktree, branch, agent and resume id, since a transcript alone
 says none of that. Deleting a worktree, or cleaning it up after a merge,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -581,6 +581,14 @@ shim rather than a protocol:
 4. Native versus shell: polling, dashboards and review threads are native
    URLSession; `gh pr create`, `gh pr merge --auto` and other one-shots
    shell out as the host user.
+5. Pushing asks GitHub what the viewer may do here (`viewerPermission`)
+   before choosing a remote. Write access pushes to the repository; anything
+   less pushes to the viewer's own fork, created with its remote on first
+   use by `gh repo fork`, which picks whatever protocol the checkout already
+   uses. The pull request then names its branch `owner:branch`, since it
+   belongs to the repository it is opened against rather than the one
+   holding the branch. An unanswerable permission question keeps the
+   repository, which is what every push did before asking was possible.
 5. When the branch has no open pull request, the worktree scope shows a
    creation form instead of the list: title, body and the repository's
    `.github/PULL_REQUEST_TEMPLATE.md` as three editable fields. Open PR

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -511,6 +511,17 @@ long as the thing inside them should live, not for as long as it is visible:
    when the view answers to the question, and a page it will not name shows
    no figures rather than wrong ones.
 
+4. Displays are not fixed either. Unplugging the display a fullscreen
+   window is on leaves the window black on a space with nothing behind it,
+   and coming out of fullscreen restores the frame it had on the display
+   that has gone, which the remaining screen can neither show nor let the
+   user drag smaller. The window leaves fullscreen when its screen goes and
+   fits its frame back inside whichever screen it lands on, and the panes
+   fit the width it ends up with: the utility pane narrows first, then the
+   sidebar, and a window too narrow for all three hides the utility pane
+   for the layout only, so it comes back with the room rather than being
+   forgotten.
+
 ### Editing what a command is waiting on (Review)
 
 Commands run in a shell pane regularly want an editor: `git rebase -i` for

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -628,9 +628,13 @@ shim rather than a protocol:
    dims until the tip commit verifies and the service refuses regardless.
    The signed rebase (`--force-rebase --gpg-sign` after a fetch) picks its
    base to sign the minimum: the branch's own origin ref when it exists,
-   every commit unique to it verifies and only new local commits need
-   signatures, keeping pushed history's hashes; otherwise origin/HEAD,
-   re-signing the whole branch.
+   is still an ancestor of the branch, every commit unique to it verifies
+   and only new local commits need signatures, keeping pushed history's
+   hashes; otherwise origin/HEAD, re-signing the whole branch. The
+   ancestor test is what keeps an amended branch out of that path:
+   amending a pushed commit leaves the pushed one behind as a stale twin
+   rather than a parent, and rebasing on it replays the amended work on
+   top of what it replaced.
 
 ### Cleanup (Tidy up)
 

--- a/App/RootView+Panes.swift
+++ b/App/RootView+Panes.swift
@@ -1,4 +1,5 @@
 import AgentIDEDomain
+import DashboardFeature
 import SessionFeature
 import SwiftUI
 
@@ -6,6 +7,43 @@ import SwiftUI
 
 /// The shell tab's layers, split from the view for length.
 extension RootView {
+    /// One conversations UI everywhere: a live session shows its
+    /// terminal; anything else shows the conversation list, scoped
+    /// to the worktree or covering the whole repository on its page;
+    /// a worktree with nothing to list offers the new session form.
+    @ViewBuilder
+    func primary(for item: WorktreeItem) -> some View {
+        if item.isPlaceholder {
+            // The row exists before the worktree does.
+            ProgressView("Creating worktree and starting the agent…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if isResuming, item.session == nil {
+            ProgressView("Resuming conversation…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let session = item.session {
+            agentTerminal(for: session, isActive: isCovered == false)
+                .id(session.name)
+                // Dropped files stage into the shared workspace (the
+                // sandbox cannot read host paths) and their staged
+                // paths type into the agent.
+                .dropDestination(for: URL.self) { urls, _ in
+                    dropFiles(urls, into: session.name)
+                }
+        } else if item.worktree.path == item.worktree.repositoryPath {
+            repositoryConversations(for: item)
+        } else if item.pastSessions.isEmpty == false {
+            worktreeConversations(for: item)
+        } else {
+            CreateSessionPane(
+                worktree: item.worktree,
+                model: dependencies.dashboard,
+                canResume: dependencies.service.hasRecordedSession(worktreePath: item.worktree.path),
+                onResume: { await resumeLatest(in: item) },
+                onStarted: { await sessionStarted() },
+            )
+        }
+    }
+
     /// A running shell stays mounted whichever tab, worktree or page
     /// shows, so its terminal survives everything short of destroying
     /// the worktree it runs in. Both layers always fill the pane, so

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -313,6 +313,10 @@ extension RootView {
             EditorPane(
                 worktreePath: item.worktree.path,
                 service: dependencies.service,
+                // The closure stays a non-final argument: the
+                // formatter rewrites a trailing one after a
+                // multiline call.
+                onFinishedWaiting: { finishedWaitingEdit() },
                 waitingEdit: waitingEdit(in: item.worktree.path),
             )
 

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -238,10 +238,7 @@ extension RootView {
     private func close(_ session: AgentSession, in item: WorktreeItem) async {
         // The pane goes now, not when tmux has been asked again.
         dependencies.dashboard.forgetSession(at: item.worktree.path)
-        await dependencies.service.closeSession(
-            sessionName: session.name,
-            worktreePath: item.worktree.path,
-        )
+        await dependencies.service.closeSession(sessionName: session.name, worktree: item.worktree)
         await dependencies.dashboard.refresh()
     }
 }

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -236,6 +236,8 @@ extension RootView {
     }
 
     private func close(_ session: AgentSession, in item: WorktreeItem) async {
+        // The pane goes now, not when tmux has been asked again.
+        dependencies.dashboard.forgetSession(at: item.worktree.path)
         await dependencies.service.closeSession(
             sessionName: session.name,
             worktreePath: item.worktree.path,

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -232,11 +232,11 @@ extension RootView {
                 .accessibilityLabel("Close session")
         }
         .buttonStyle(.plain)
-        .hoverHelp("Kill the tmux session; the worktree and conversation survive for resuming")
+        .hoverHelp("End the session and its tmux session now; the worktree and conversation survive for resuming")
     }
 
     private func close(_ session: AgentSession, in item: WorktreeItem) async {
-        try? await dependencies.service.closeSession(
+        await dependencies.service.closeSession(
             sessionName: session.name,
             worktreePath: item.worktree.path,
         )

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -22,6 +22,25 @@ struct RootView: View {
     @AppStorage("showsUtilityPane")
     var showsUtilityPane = true
 
+    /// Whether the launch's one automatic resume is running, so the
+    /// pane it fills can say so; internal because the extension
+    /// files cannot see the view's own state.
+    var isResuming: Bool {
+        isAutoResuming
+    }
+
+    /// Whether the utility pane is both wanted and able to fit: a
+    /// window too narrow for three panes shows the two the work
+    /// happens in, without forgetting the pane was asked for.
+    var showsUtility: Bool {
+        PaneLayout(
+            width: windowWidth,
+            sidebar: sidebarWidth,
+            utility: utilityPaneWidth,
+            showsUtility: showsUtilityPane,
+        ).showsUtility
+    }
+
     /// Whether a middle page covers the split: its panes stay
     /// mounted underneath and must not take clicks or keystrokes.
     var isCovered: Bool {
@@ -52,13 +71,17 @@ struct RootView: View {
         // views neither persisted divider positions nor honoured
         // ideal widths on this OS. The sidebar never hides; it
         // resizes down to a slim strip instead.
+        // The window's width decides what the panes may be: widths
+        // dragged on a large display do not fit a small one, and a
+        // window whose display was unplugged lands on whatever is
+        // left.
         HStack(spacing: 0) {
             DashboardView(model: dependencies.dashboard)
                 .frame(width: sidebarWidth)
                 .frame(maxHeight: .infinity)
                 .background(SidebarMaterial())
                 .ignoresSafeArea(.container, edges: .top)
-            PaneDivider(width: $sidebarWidth, range: Self.sidebarRange, controlsLeadingPane: true)
+            PaneDivider(width: $sidebarWidth, range: PaneLayout.sidebarRange, controlsLeadingPane: true)
                 .ignoresSafeArea(.container, edges: .top)
             detail
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -66,6 +89,7 @@ struct RootView: View {
         }
         .ignoresSafeArea(.container, edges: .top)
         .background(WindowConfigurator())
+        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { fitPanes(to: $0) }
         .sheet(isPresented: sessionManagerBinding) { sessionManager }
         .task {
             FlavourIcon.apply()
@@ -179,9 +203,6 @@ struct RootView: View {
 
     /// Slim enough for icon-and-truncated-text rows while staying
     /// wider than the traffic lights band.
-    private static let sidebarRange = 150.0 ... 440.0
-    private static let utilityRange = 340.0 ... 1_200.0
-    private static let primaryMinimum: CGFloat = 420
     private static let stripSpacing: CGFloat = 4
 
     /// The utility header row's height: the tab capsules plus the
@@ -246,6 +267,9 @@ struct RootView: View {
     @AppStorage("utilityPaneWidth")
     private var utilityPaneWidth = 480.0
 
+    /// What the window is now, which the panes are fitted to.
+    @State private var windowWidth: CGFloat = 0
+
     /// Whether anything is running that idle sleep would interrupt.
     private var hasLiveWork: Bool {
         runningShells.isEmpty == false || runningWorktreePaths.isEmpty == false
@@ -286,21 +310,21 @@ struct RootView: View {
             // session strip's empty right end, in exactly the spot
             // the pane header shows it, so it never moves on toggle.
             .overlay(alignment: .topTrailing) {
-                if showsUtilityPane == false {
+                if showsUtility == false {
                     utilityToggleButton
                         .frame(height: Self.toggleRowHeight)
                         .padding(.trailing, Self.stripSpacing)
                 }
             }
             .frame(
-                minWidth: Self.primaryMinimum,
+                minWidth: PaneLayout.primaryMinimum,
                 maxWidth: .infinity,
                 maxHeight: .infinity,
                 alignment: .top,
             )
             .ignoresSafeArea(.container, edges: .top)
-            if showsUtilityPane {
-                PaneDivider(width: $utilityPaneWidth, range: Self.utilityRange, controlsLeadingPane: false)
+            if showsUtility {
+                PaneDivider(width: $utilityPaneWidth, range: PaneLayout.utilityRange, controlsLeadingPane: false)
                     .ignoresSafeArea(.container, edges: .top)
                 utilityPane(for: item)
                     .frame(width: utilityPaneWidth)
@@ -336,40 +360,22 @@ struct RootView: View {
         }
     }
 
-    /// One conversations UI everywhere: a live session shows its
-    /// terminal; anything else shows the conversation list, scoped
-    /// to the worktree or covering the whole repository on its page;
-    /// a worktree with nothing to list offers the new session form.
-    @ViewBuilder
-    private func primary(for item: WorktreeItem) -> some View {
-        if item.isPlaceholder {
-            // The row exists before the worktree does.
-            ProgressView("Creating worktree and starting the agent…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if isAutoResuming, item.session == nil {
-            ProgressView("Resuming conversation…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if let session = item.session {
-            agentTerminal(for: session, isActive: isCovered == false)
-                .id(session.name)
-                // Dropped files stage into the shared workspace (the
-                // sandbox cannot read host paths) and their staged
-                // paths type into the agent.
-                .dropDestination(for: URL.self) { urls, _ in
-                    dropFiles(urls, into: session.name)
-                }
-        } else if item.worktree.path == item.worktree.repositoryPath {
-            repositoryConversations(for: item)
-        } else if item.pastSessions.isEmpty == false {
-            worktreeConversations(for: item)
-        } else {
-            CreateSessionPane(
-                worktree: item.worktree,
-                model: dependencies.dashboard,
-                canResume: dependencies.service.hasRecordedSession(worktreePath: item.worktree.path),
-                onResume: { await resumeLatest(in: item) },
-                onStarted: { await sessionStarted() },
-            )
+    /// Narrows the panes to what the window can hold. The widths
+    /// are written back, so the dividers keep dragging from where
+    /// the panes actually are.
+    private func fitPanes(to width: CGFloat) {
+        windowWidth = width
+        let layout = PaneLayout(
+            width: width,
+            sidebar: sidebarWidth,
+            utility: utilityPaneWidth,
+            showsUtility: showsUtilityPane,
+        )
+        if layout.sidebar != sidebarWidth {
+            sidebarWidth = layout.sidebar
+        }
+        if layout.utility != utilityPaneWidth {
+            utilityPaneWidth = layout.utility
         }
     }
 }

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -166,6 +166,12 @@ struct RootView: View {
         waiting.edit(in: worktreePath)
     }
 
+    /// Dealing with a waiting file puts the pane back where it was,
+    /// which is nearly always the shell the command was typed in.
+    func finishedWaitingEdit() {
+        waiting.restorePreviousPane()
+    }
+
     func visitBrowser(at path: String) {
         visitedBrowsers.insert(path)
     }

--- a/App/WaitingEdits.swift
+++ b/App/WaitingEdits.swift
@@ -37,7 +37,7 @@ final class WaitingEdits {
         for await edits in service.pendingEdits() {
             all = edits
             if edits.isEmpty {
-                restorePane()
+                restorePreviousPane()
             }
             guard let edit = edits.first, edit.id != shown else {
                 continue
@@ -47,6 +47,20 @@ final class WaitingEdits {
             takeOverPane(for: edit, dashboard: dashboard)
             await service.claimEdit(edit)
         }
+    }
+
+    /// Puts back whatever the utility pane was showing before a
+    /// waiting file took it over. Called when the editor's own
+    /// buttons finish one, so the pane comes back immediately rather
+    /// than when the spool next answers, and again when nothing is
+    /// waiting, which covers a command that went away by itself.
+    func restorePreviousPane() {
+        guard let previousTab else {
+            return
+        }
+
+        self.previousTab = nil
+        UserDefaults.standard.set(previousTab, forKey: UtilityTabTarget.key)
     }
 
     // MARK: Private
@@ -62,17 +76,11 @@ final class WaitingEdits {
             dashboard.select(item)
         }
         let defaults = UserDefaults.standard
-        previousTab = previousTab ?? defaults.string(forKey: UtilityTabTarget.key)
+        // A tab the user has never switched by hand is not in the
+        // defaults at all, and without a name to go back to the pane
+        // used to stay on the editor once the command was answered.
+        previousTab = previousTab ?? defaults.string(forKey: UtilityTabTarget.key) ?? UtilityTab.review.rawValue
         defaults.set(true, forKey: UtilityTabTarget.visibilityKey)
         defaults.set(UtilityTabTarget.editor, forKey: UtilityTabTarget.key)
-    }
-
-    private func restorePane() {
-        guard let previousTab else {
-            return
-        }
-
-        self.previousTab = nil
-        UserDefaults.standard.set(previousTab, forKey: UtilityTabTarget.key)
     }
 }

--- a/App/WindowConfigurator.swift
+++ b/App/WindowConfigurator.swift
@@ -12,7 +12,7 @@ struct WindowConfigurator: NSViewRepresentable {
         // MARK: Lifecycle
 
         deinit {
-            // Nothing to clean up.
+            // The observers are removed with the view.
         }
 
         // MARK: Internal
@@ -20,6 +20,7 @@ struct WindowConfigurator: NSViewRepresentable {
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
             configureWindow()
+            observeDisplays()
         }
 
         func configureWindow() {
@@ -45,6 +46,83 @@ struct WindowConfigurator: NSViewRepresentable {
         // MARK: Private
 
         private static let autosaveName = "AgentIDEMainWindow"
+
+        /// Long enough for the fullscreen animation to finish before
+        /// the frame is measured; the notification arrives while the
+        /// window is still leaving its space.
+        private static let settleSeconds = 0.6
+
+        private var observers: [any NSObjectProtocol] = []
+
+        /// Displays come and go. Unplugging the one a fullscreen
+        /// window is on leaves the window black on a space with no
+        /// screen behind it, and coming out of fullscreen restores
+        /// the frame it had on the display that has gone: wider than
+        /// the remaining screen, so its edges cannot be dragged and
+        /// its green button cannot fill a screen it does not fit.
+        /// Both are handled here rather than left to the user.
+        private func observeDisplays() {
+            guard observers.isEmpty, let window else {
+                return
+            }
+
+            let centre = NotificationCenter.default
+            observers.append(centre.addObserver(
+                forName: NSApplication.didChangeScreenParametersNotification,
+                object: nil,
+                queue: .main,
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.displaysChanged() }
+            })
+            observers.append(centre.addObserver(
+                forName: NSWindow.didExitFullScreenNotification,
+                object: window,
+                queue: .main,
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.fitToScreen() }
+            })
+        }
+
+        private func displaysChanged() {
+            guard let window else {
+                return
+            }
+
+            // A fullscreen window whose screen has gone cannot be
+            // recovered in place: leaving fullscreen puts it back on
+            // a screen that exists.
+            if window.styleMask.contains(.fullScreen), window.screen == nil {
+                window.toggleFullScreen(nil)
+            }
+            fitToScreen()
+            // Leaving fullscreen is animated, so the frame that
+            // needs fitting is not there yet.
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.settleSeconds) { [weak self] in
+                self?.fitToScreen()
+            }
+        }
+
+        /// Brings the frame back inside the screen it is on, keeping
+        /// its size where it fits and its corner where it can.
+        private func fitToScreen() {
+            guard let window,
+                  window.styleMask.contains(.fullScreen) == false,
+                  let visible = (window.screen ?? NSScreen.main)?.visibleFrame
+            else {
+                return
+            }
+
+            var frame = window.frame
+            frame.size.width = min(frame.width, visible.width)
+            frame.size.height = min(frame.height, visible.height)
+            frame.origin.x = min(max(frame.minX, visible.minX), visible.maxX - frame.width)
+            frame.origin.y = min(max(frame.minY, visible.minY), visible.maxY - frame.height)
+            guard frame != window.frame else {
+                return
+            }
+
+            window.setFrame(frame, display: true, animate: false)
+        }
 
         /// The frame autosave restores position and size. Fullscreen
         /// deliberately does not restore: macOS reopens fullscreen

--- a/App/WindowConfigurator.swift
+++ b/App/WindowConfigurator.swift
@@ -12,13 +12,26 @@ struct WindowConfigurator: NSViewRepresentable {
         // MARK: Lifecycle
 
         deinit {
-            // The observers are removed with the view.
+            // The observers go when the view leaves its window,
+            // which AppKit always tells it about; a deinit cannot
+            // touch them, since Swift will not let one reach
+            // non-Sendable state.
         }
 
         // MARK: Internal
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
+            guard window != nil else {
+                // Block-based observers outlive their view: the
+                // centre holds the token, so one left behind keeps
+                // being delivered for the life of the process.
+                let centre = NotificationCenter.default
+                observers.forEach(centre.removeObserver)
+                observers = []
+                return
+            }
+
             configureWindow()
             observeDisplays()
         }

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ before shipping.
   than the app (so agents survive AgentIDE quitting, crashing or
   updating, expectedly or not; the host shell tab deliberately does not,
   living and dying with the app)
+- **Fits** itself to whatever display it is on: unplugging the monitor a
+  fullscreen window is on drops it back onto the screen that is left, at a
+  size that screen can show, with the panes narrowed to match (so a window
+  is never stranded larger than the display under it)
 - **Keeps** every running shell alive while you move around the app and
   keeps a worktree listed until it is really gone, rebases and failed
   listings included (so only closing a shell or destroying its worktree

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ before shipping.
   than the app (so agents survive AgentIDE quitting, crashing or
   updating, expectedly or not; the host shell tab deliberately does not,
   living and dying with the app)
+- **Keeps** a copy of each worktree's newest conversation in iCloud Drive,
+  the conversation only, and drops it when the worktree is deleted (so the
+  sandbox user is disposable: its transcripts are the one thing git and
+  GitHub do not already hold)
 - **Fits** itself to whatever display it is on: unplugging the monitor a
   fullscreen window is on drops it back onto the screen that is left, at a
   size that screen can show, with the panes narrowed to match (so a window

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ before shipping.
   updating, expectedly or not; the host shell tab deliberately does not,
   living and dying with the app)
 - **Keeps** a copy of each worktree's newest conversation in iCloud Drive,
-  the conversation only, and drops it when the worktree is deleted (so the
-  sandbox user is disposable: its transcripts are the one thing git and
-  GitHub do not already hold)
+  hourly while it runs and whenever it is closed or resumed, the conversation
+  only, and drops it when the worktree is deleted (so the sandbox user is
+  disposable: its transcripts are the one thing git and GitHub do not hold)
 - **Fits** itself to whatever display it is on: unplugging the monitor a
   fullscreen window is on drops it back onto the screen that is left, at a
   size that screen can show, with the panes narrowed to match (so a window

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ before shipping.
   commit, unwrapped from the narrow column commit messages are written
   to, or drafting them from many with the on-device model (so shipping
   needs no retyping)
+- **Pushes** to your own fork when the repository is not yours to write to,
+  creating it and its remote the first time and opening the pull request from
+  it (so working in someone else's repository needs no setup and no thinking
+  about where the branch goes)
 - **Copies** unresolved review comments, or failing CI steps with their
   actual log output, straight into a prompt, resolves conversations one
   by one, resolves merge conflicts and enables automerge or merges,

--- a/Sources/AgentIDEData/ConversationBackup.swift
+++ b/Sources/AgentIDEData/ConversationBackup.swift
@@ -11,27 +11,26 @@ import Foundation
 /// Drive carries it off the machine, and a copy is dropped when its
 /// worktree is deleted, so the backups track the work rather than
 /// accumulating behind it.
-public struct ConversationBackup: Sendable {
+struct ConversationBackup {
     // MARK: Lifecycle
 
     /// Creates a backup store. `directory` overrides where copies go,
     /// for tests; the default is iCloud Drive when it is set up on
     /// this Mac and the app's own support directory when it is not.
-    public init(paths: WorkspacePaths, directory: String? = nil) {
-        self.paths = paths
+    init(paths: WorkspacePaths, directory: String? = nil) {
         self.directory = directory ?? Self.cloudDirectory ?? paths.appDirectory + "/conversations"
     }
 
-    // MARK: Public
+    // MARK: Internal
 
     /// Where copies are kept, so the app can say so.
-    public let directory: String
+    let directory: String
 
     /// Copies a worktree's newest conversation, replacing the copy
     /// already there: one file per worktree, the one a resume would
     /// continue. Cheap enough to call on every poll, since an
     /// unchanged transcript is not copied again.
-    public func store(_ past: TranscriptSession, worktree: Worktree) {
+    func store(_ past: TranscriptSession, worktree: Worktree) {
         let destination = path(worktree: worktree, extension: URL(fileURLWithPath: past.path).pathExtension)
         let manager = FileManager.default
         guard let source = try? manager.attributesOfItem(atPath: past.path) else {
@@ -57,21 +56,10 @@ public struct ConversationBackup: Sendable {
     /// Drops a worktree's copy, which deleting the worktree does:
     /// the conversation is being thrown away deliberately, and a
     /// backup nobody asked to keep is clutter in iCloud.
-    public func forget(worktree: Worktree) {
+    func forget(worktree: Worktree) {
         let manager = FileManager.default
         let folder = directory + "/" + slug(worktree)
         try? manager.removeItem(atPath: folder)
-    }
-
-    /// The copy kept for a worktree, nil when there is none: what a
-    /// restore reads back into the sandbox.
-    public func stored(worktree: Worktree) -> String? {
-        let folder = directory + "/" + slug(worktree)
-        let names = (try? FileManager.default.contentsOfDirectory(atPath: folder)) ?? []
-        return names
-            .filter { $0.hasPrefix(Self.transcriptName + ".") }
-            .min()
-            .map { folder + "/" + $0 }
     }
 
     // MARK: Private
@@ -94,8 +82,6 @@ public struct ConversationBackup: Sendable {
         try? FileManager.default.createDirectory(at: container, withIntermediateDirectories: true)
         return container.path
     }
-
-    private let paths: WorkspacePaths
 
     /// One folder per worktree, named for what it is rather than the
     /// uuid its path carries.

--- a/Sources/AgentIDEData/ConversationBackup.swift
+++ b/Sources/AgentIDEData/ConversationBackup.swift
@@ -1,0 +1,132 @@
+import AgentIDEDomain
+import Foundation
+
+/// Keeps a copy of each worktree's newest conversation where the
+/// sandbox cannot reach it.
+///
+/// Transcripts live in the sandbox user's home, which is disposable
+/// by design and was emptied by accident once: the conversations went
+/// with it while the code, which git and GitHub hold, was never at
+/// risk. Only the conversation is copied for that reason. iCloud
+/// Drive carries it off the machine, and a copy is dropped when its
+/// worktree is deleted, so the backups track the work rather than
+/// accumulating behind it.
+public struct ConversationBackup: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a backup store. `directory` overrides where copies go,
+    /// for tests; the default is iCloud Drive when it is set up on
+    /// this Mac and the app's own support directory when it is not.
+    public init(paths: WorkspacePaths, directory: String? = nil) {
+        self.paths = paths
+        self.directory = directory ?? Self.cloudDirectory ?? paths.appDirectory + "/conversations"
+    }
+
+    // MARK: Public
+
+    /// Where copies are kept, so the app can say so.
+    public let directory: String
+
+    /// Copies a worktree's newest conversation, replacing the copy
+    /// already there: one file per worktree, the one a resume would
+    /// continue. Cheap enough to call on every poll, since an
+    /// unchanged transcript is not copied again.
+    public func store(_ past: TranscriptSession, worktree: Worktree) {
+        let destination = path(worktree: worktree, extension: URL(fileURLWithPath: past.path).pathExtension)
+        let manager = FileManager.default
+        guard let source = try? manager.attributesOfItem(atPath: past.path) else {
+            return
+        }
+
+        let copied = try? manager.attributesOfItem(atPath: destination)
+        let sourceDate = source[.modificationDate] as? Date ?? .distantPast
+        let copiedDate = copied?[.modificationDate] as? Date ?? .distantPast
+        guard copied == nil || sourceDate > copiedDate else {
+            return
+        }
+
+        try? manager.createDirectory(
+            atPath: URL(fileURLWithPath: destination).deletingLastPathComponent().path,
+            withIntermediateDirectories: true,
+        )
+        try? manager.removeItem(atPath: destination)
+        try? manager.copyItem(atPath: past.path, toPath: destination)
+        writeIndex(past, worktree: worktree)
+    }
+
+    /// Drops a worktree's copy, which deleting the worktree does:
+    /// the conversation is being thrown away deliberately, and a
+    /// backup nobody asked to keep is clutter in iCloud.
+    public func forget(worktree: Worktree) {
+        let manager = FileManager.default
+        let folder = directory + "/" + slug(worktree)
+        try? manager.removeItem(atPath: folder)
+    }
+
+    /// The copy kept for a worktree, nil when there is none: what a
+    /// restore reads back into the sandbox.
+    public func stored(worktree: Worktree) -> String? {
+        let folder = directory + "/" + slug(worktree)
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: folder)) ?? []
+        return names
+            .filter { $0.hasPrefix(Self.transcriptName + ".") }
+            .min()
+            .map { folder + "/" + $0 }
+    }
+
+    // MARK: Private
+
+    /// What the copy is called, whatever the agent named it.
+    private static let transcriptName = "conversation"
+    private static let indexName = "conversation.json"
+
+    /// iCloud Drive's own folder for this app, nil when the user has
+    /// not set iCloud Drive up. No entitlement is involved: it is a
+    /// directory that syncs.
+    private static var cloudDirectory: String? {
+        let container = FileManager.default
+            .url(forUbiquityContainerIdentifier: nil)?
+            .appendingPathComponent("Documents/AgentIDE/conversations")
+        guard let container else {
+            return nil
+        }
+
+        try? FileManager.default.createDirectory(at: container, withIntermediateDirectories: true)
+        return container.path
+    }
+
+    private let paths: WorkspacePaths
+
+    /// One folder per worktree, named for what it is rather than the
+    /// uuid its path carries.
+    private func slug(_ worktree: Worktree) -> String {
+        (worktree.repositoryName + "-" + worktree.branch)
+            .replacing("/", with: "-")
+            .replacing(" ", with: "-")
+    }
+
+    private func path(worktree: Worktree, extension suffix: String) -> String {
+        directory + "/" + slug(worktree) + "/" + Self.transcriptName + "." + (suffix.isEmpty ? "jsonl" : suffix)
+    }
+
+    /// Beside the copy, what it belongs to: a conversation file alone
+    /// says nothing about which worktree, agent or session it came
+    /// from, and a restore needs all three.
+    private func writeIndex(_ past: TranscriptSession, worktree: Worktree) {
+        let index: [String: String] = [
+            "repository": worktree.repositoryName,
+            "repositoryPath": worktree.repositoryPath,
+            "branch": worktree.branch,
+            "worktreePath": worktree.path,
+            "agent": String(describing: past.agent),
+            "resumeID": past.resumeID,
+            "sourcePath": past.path,
+            "storedAt": ISO8601DateFormatter().string(from: Date()),
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: index, options: [.sortedKeys]) else {
+            return
+        }
+
+        try? data.write(to: URL(fileURLWithPath: directory + "/" + slug(worktree) + "/" + Self.indexName))
+    }
+}

--- a/Sources/AgentIDEData/GitClient+Branches.swift
+++ b/Sources/AgentIDEData/GitClient+Branches.swift
@@ -45,6 +45,17 @@ public extension GitClient {
         return output.split(separator: "\n").allSatisfy { Self.signedStates.contains(String($0)) }
     }
 
+    /// Whether one ref is an ancestor of another, which is how an
+    /// appended branch is told from a rewritten one.
+    func isAncestor(worktreePath: String, ref: String, of descendant: String) async -> Bool {
+        let result = try? await git(
+            ["merge-base", "--is-ancestor", ref, descendant],
+            in: worktreePath,
+            allowFailure: true,
+        )
+        return result?.succeeded ?? false
+    }
+
     /// Whether origin already carries the branch, after a fetch.
     func remoteBranchExists(worktreePath: String, branch: String) async -> Bool {
         let result = try? await git(

--- a/Sources/AgentIDEData/GitClient.swift
+++ b/Sources/AgentIDEData/GitClient.swift
@@ -300,8 +300,8 @@ public struct GitClient: Sendable {
     }
 
     /// Pushes the branch, creating its upstream.
-    public func push(worktreePath: String, branch: String) async throws {
-        try await git(["push", "--set-upstream", "origin", branch], in: worktreePath)
+    public func push(worktreePath: String, branch: String, remote: String = "origin") async throws {
+        try await git(["push", "--set-upstream", remote, branch], in: worktreePath)
     }
 
     /// Removes a worktree and deletes its branch; the archive bundle

--- a/Sources/AgentIDEData/GitHubClient+Checks.swift
+++ b/Sources/AgentIDEData/GitHubClient+Checks.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+/// What failed in CI, in the form an agent can be handed: the failing
+/// steps of the failing job, rather than a link to go and read.
+public extension GitHubClient {
+    /// The pull request's failing checks, one line each, followed by
+    /// each failing Actions run's failed step output; the links
+    /// alone were useless for pasting into an agent. Passing,
+    /// pending and skipped rows are noise for every caller.
+    func failingChecks(repositoryPath: String, number: Int) async -> String {
+        let checks = try? await gh(
+            ["pr", "checks", String(number)],
+            in: repositoryPath,
+            allowFailure: true,
+        )
+        let failing = (checks?.standardOutput ?? "")
+            .split(separator: "\n")
+            .filter { line in
+                let fields = line.split(separator: "\t")
+                return fields.count > 1 && fields[1].localizedCaseInsensitiveContains("fail")
+            }
+            .map(String.init)
+        var sections = failing.joined(separator: "\n")
+        for job in Self.jobIDs(fromCheckLines: failing) {
+            let excerpt = await failedSteps(ofJob: job, repositoryPath: repositoryPath)
+            guard excerpt.isEmpty == false else {
+                continue
+            }
+
+            sections += "\n\nFailed steps of job " + job + ":\n" + excerpt
+        }
+        return sections
+    }
+
+    /// One job's failed steps. `gh run view --job` narrows the log to
+    /// the job that actually failed rather than every job in the run,
+    /// which is what a failing check names; it refuses while the run
+    /// is still going, and the API serves that job's log regardless,
+    /// so the two are tried in turn.
+    func failedSteps(ofJob job: String, repositoryPath: String) async -> String {
+        let failed = try? await gh(
+            ["run", "view", "--job", job, "--log-failed"],
+            in: repositoryPath,
+            allowFailure: true,
+        )
+        let output = (failed?.standardOutput ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if output.isEmpty == false {
+            return Self.failureExcerpt(fromRunLog: output)
+        }
+
+        let live = try? await gh(
+            ["api", "repos/{owner}/{repo}/actions/jobs/" + job + "/logs"],
+            in: repositoryPath,
+            allowFailure: true,
+        )
+        let raw = (live?.standardOutput ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard raw.isEmpty == false else {
+            return ""
+        }
+
+        // The API serves the job's whole log without the step prefix
+        // `gh` adds, so there is nothing to group by: the tail from
+        // its first error is the failure.
+        return Self.tail(of: raw.split(separator: "\n", omittingEmptySubsequences: false).map(String.init))
+            .prefixWithinLimit(Self.runLogLimit)
+    }
+
+    // MARK: Internal
+
+    /// Enough log to diagnose without flooding the clipboard.
+    internal static var runLogLimit: Int {
+        // swiftlint:disable:next no_magic_numbers
+        20_000
+    }
+
+    /// `gh run view --log-failed` prefixes every line with its job
+    /// and step names, tab separated.
+    internal static var stepPrefixFields: Int {
+        // swiftlint:disable:next no_magic_numbers
+        2
+    }
+
+    /// How many lines of a failed step to keep, and how many before
+    /// its first error line for context.
+    internal static var stepTailLines: Int {
+        // swiftlint:disable:next no_magic_numbers
+        60
+    }
+
+    internal static var errorContextLines: Int {
+        // swiftlint:disable:next no_magic_numbers
+        5
+    }
+
+    /// The useful part of a `gh run view --log-failed` dump: its
+    /// lines carry a repeated `job\tstep\t` prefix, and the failure
+    /// is at the end, so the head of a long log was setup noise
+    /// rather than the error. Each failed step keeps its own tail,
+    /// from its first error line where one exists.
+    internal static func failureExcerpt(fromRunLog log: String) -> String {
+        var steps = [String]()
+        var lines = [String: [String]]()
+        for raw in log.split(separator: "\n", omittingEmptySubsequences: false) {
+            let fields = raw.split(separator: "\t", maxSplits: stepPrefixFields, omittingEmptySubsequences: false)
+            let step = fields.count > stepPrefixFields
+                ? fields[0 ..< stepPrefixFields].joined(separator: " / ")
+                : ""
+            let text = fields.count > stepPrefixFields ? String(fields[stepPrefixFields]) : String(raw)
+            if lines[step] == nil {
+                steps.append(step)
+                lines[step] = []
+            }
+            lines[step]?.append(text)
+        }
+        return steps
+            .map { step in
+                let body = Self.tail(of: lines[step] ?? [])
+                return step.isEmpty ? body : step + "\n" + body
+            }
+            .joined(separator: "\n\n")
+            .prefixWithinLimit(runLogLimit)
+    }
+
+    /// One step's last lines, starting at its first error line when
+    /// it has one: the message that explains the failure sits there,
+    /// with the lines after it as context.
+    internal static func tail(of lines: [String]) -> String {
+        let markers = ["error:", "##[error]", "error ", "failed", "fatal:", "assertion"]
+        let firstError = lines.firstIndex { line in
+            let lowered = line.lowercased()
+            return markers.contains { lowered.contains($0) }
+        }
+        let start = firstError.map { max($0 - errorContextLines, 0) }
+            ?? max(lines.count - stepTailLines, 0)
+        return lines[start...].suffix(stepTailLines).joined(separator: "\n")
+    }
+
+    /// Distinct Actions job ids from the failing check lines' links,
+    /// in order. A failing check links its own job, which is the one
+    /// worth reading: a run of fifty jobs where one failed otherwise
+    /// pastes the other forty-nine as well. External checks without
+    /// an Actions link contribute no logs.
+    internal static func jobIDs(fromCheckLines lines: [String]) -> [String] {
+        var ids = [String]()
+        for line in lines {
+            guard let range = line.range(of: "/job/") else {
+                continue
+            }
+
+            let id = String(line[range.upperBound...].prefix(while: \.isNumber))
+            if id.isEmpty == false, ids.contains(id) == false {
+                ids.append(id)
+            }
+        }
+        return ids
+    }
+}

--- a/Sources/AgentIDEData/GitHubClient+Fork.swift
+++ b/Sources/AgentIDEData/GitHubClient+Fork.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Pushing to a repository you cannot write to. Plenty of work
+/// happens in other people's repositories, where a branch belongs in
+/// your own fork and the pull request comes from there.
+public extension GitHubClient {
+    /// Whether the branch belongs in this repository or in a fork of
+    /// it, decided by what GitHub says the viewer may do here. An
+    /// unanswerable question keeps the repository itself, since that
+    /// is what every push did before asking was possible.
+    func canPush(worktreePath: String) async -> Bool {
+        let result = try? await gh(
+            ["repo", "view", "--json", "viewerPermission", "--jq", ".viewerPermission"],
+            in: worktreePath,
+            allowFailure: true,
+        )
+        let permission = (result?.standardOutput ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard permission.isEmpty == false, permission != "null" else {
+            return true
+        }
+
+        return Self.writingPermissions.contains(permission)
+    }
+
+    /// The account a fork would belong to, which is whoever `gh` is
+    /// authenticated as; nil when it will not say.
+    func viewer(worktreePath: String) async -> String? {
+        let result = try? await gh(["api", "user", "--jq", ".login"], in: worktreePath, allowFailure: true)
+        let login = (result?.standardOutput ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return login.isEmpty ? nil : login
+    }
+
+    /// Makes sure the viewer's fork exists and that a remote points
+    /// at it, leaving both alone when they already do. `gh` picks the
+    /// same protocol the repository already uses, so an SSH checkout
+    /// keeps pushing over SSH.
+    func ensureFork(worktreePath: String, remoteName: String) async throws {
+        _ = try await gh(
+            ["repo", "fork", "--clone=false", "--remote", "--remote-name", remoteName],
+            in: worktreePath,
+            // A fork and a remote that already exist are the wanted
+            // state, and `gh` calls both of them failures.
+            allowFailure: true,
+        )
+    }
+
+    // MARK: Internal
+
+    /// What GitHub calls being able to push.
+    internal static let writingPermissions: Set<String> = ["ADMIN", "MAINTAIN", "WRITE"]
+}

--- a/Sources/AgentIDEData/GitHubClient+Threads.swift
+++ b/Sources/AgentIDEData/GitHubClient+Threads.swift
@@ -14,31 +14,6 @@ public extension GitHubClient {
         return Self.threads(fromRESTJSON: result?.standardOutput ?? "")
     }
 
-    /// Enough log to diagnose without flooding the clipboard.
-    private static var runLogLimit: Int {
-        // swiftlint:disable:next no_magic_numbers
-        20_000
-    }
-
-    /// `gh run view --log-failed` prefixes every line with its job
-    /// and step names, tab separated.
-    private static var stepPrefixFields: Int {
-        // swiftlint:disable:next no_magic_numbers
-        2
-    }
-
-    /// How many lines of a failed step to keep, and how many before
-    /// its first error line for context.
-    private static var stepTailLines: Int {
-        // swiftlint:disable:next no_magic_numbers
-        60
-    }
-
-    private static var errorContextLines: Int {
-        // swiftlint:disable:next no_magic_numbers
-        5
-    }
-
     // MARK: Public
 
     /// The pull request's review conversation threads with a REST
@@ -107,84 +82,7 @@ public extension GitHubClient {
         )
     }
 
-    /// The pull request's failing checks, one line each, followed by
-    /// each failing Actions run's failed step output; the links
-    /// alone were useless for pasting into an agent. Passing,
-    /// pending and skipped rows are noise for every caller.
-    func failingChecks(repositoryPath: String, number: Int) async -> String {
-        let checks = try? await gh(
-            ["pr", "checks", String(number)],
-            in: repositoryPath,
-            allowFailure: true,
-        )
-        let failing = (checks?.standardOutput ?? "")
-            .split(separator: "\n")
-            .filter { line in
-                let fields = line.split(separator: "\t")
-                return fields.count > 1 && fields[1].localizedCaseInsensitiveContains("fail")
-            }
-            .map(String.init)
-        var sections = failing.joined(separator: "\n")
-        for runID in Self.runIDs(fromCheckLines: failing) {
-            let log = try? await gh(
-                ["run", "view", runID, "--log-failed"],
-                in: repositoryPath,
-                allowFailure: true,
-            )
-            let output = (log?.standardOutput ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-            guard output.isEmpty == false else {
-                continue
-            }
-
-            sections += "\n\nFailed steps of run " + runID + ":\n" + Self.failureExcerpt(fromRunLog: output)
-        }
-        return sections
-    }
-
     // MARK: Internal
-
-    /// The useful part of a `gh run view --log-failed` dump: its
-    /// lines carry a repeated `job\tstep\t` prefix, and the failure
-    /// is at the end, so the head of a long log was setup noise
-    /// rather than the error. Each failed step keeps its own tail,
-    /// from its first error line where one exists.
-    internal static func failureExcerpt(fromRunLog log: String) -> String {
-        var steps = [String]()
-        var lines = [String: [String]]()
-        for raw in log.split(separator: "\n", omittingEmptySubsequences: false) {
-            let fields = raw.split(separator: "\t", maxSplits: stepPrefixFields, omittingEmptySubsequences: false)
-            let step = fields.count > stepPrefixFields
-                ? fields[0 ..< stepPrefixFields].joined(separator: " / ")
-                : ""
-            let text = fields.count > stepPrefixFields ? String(fields[stepPrefixFields]) : String(raw)
-            if lines[step] == nil {
-                steps.append(step)
-                lines[step] = []
-            }
-            lines[step]?.append(text)
-        }
-        return steps
-            .map { step in
-                let body = Self.tail(of: lines[step] ?? [])
-                return step.isEmpty ? body : step + "\n" + body
-            }
-            .joined(separator: "\n\n")
-            .prefixWithinLimit(runLogLimit)
-    }
-
-    /// One step's last lines, starting at its first error line when
-    /// it has one: the message that explains the failure sits there,
-    /// with the lines after it as context.
-    internal static func tail(of lines: [String]) -> String {
-        let markers = ["error:", "##[error]", "error ", "failed", "fatal:", "assertion"]
-        let firstError = lines.firstIndex { line in
-            let lowered = line.lowercased()
-            return markers.contains { lowered.contains($0) }
-        }
-        let start = firstError.map { max($0 - errorContextLines, 0) }
-            ?? max(lines.count - stepTailLines, 0)
-        return lines[start...].suffix(stepTailLines).joined(separator: "\n")
-    }
 
     /// Groups the REST inline comments into anchored threads; the
     /// REST rows carry no resolvable thread id, so these render
@@ -214,24 +112,6 @@ public extension GitHubClient {
                 resolveID: "",
             )
         }
-    }
-
-    /// Distinct Actions run ids from the failing check lines'
-    /// links, in order; external checks without an Actions link
-    /// contribute no logs.
-    internal static func runIDs(fromCheckLines lines: [String]) -> [String] {
-        var ids = [String]()
-        for line in lines {
-            guard let range = line.range(of: "/actions/runs/") else {
-                continue
-            }
-
-            let id = String(line[range.upperBound...].prefix(while: \.isNumber))
-            if id.isEmpty == false, ids.contains(id) == false {
-                ids.append(id)
-            }
-        }
-        return ids
     }
 
     /// Decodes the reviewThreads GraphQL answer; a decode failure

--- a/Sources/AgentIDEData/GitHubClient.swift
+++ b/Sources/AgentIDEData/GitHubClient.swift
@@ -142,14 +142,24 @@ public struct GitHubClient: Sendable {
 
     /// Opens a pull request from the worktree's branch; returns its
     /// URL. The body travels by file: it can hold anything.
-    public func createPullRequest(worktreePath: String, title: String, body: String) async throws -> String {
+    public func createPullRequest(
+        worktreePath: String,
+        title: String,
+        body: String,
+        head: String? = nil,
+    ) async throws -> String {
         let bodyFile = FileManager.default
             .temporaryDirectory
             .appendingPathComponent("agentide-pr-body-" + UUID().uuidString + ".md")
             .path
         try body.write(toFile: bodyFile, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(atPath: bodyFile) }
-        return try await gh(["pr", "create", "--title", title, "--body-file", bodyFile], in: worktreePath)
+        // A branch in a fork has to name itself as `owner:branch`,
+        // since the pull request belongs to the repository it is
+        // opened against, not the one holding the branch.
+        let arguments = ["pr", "create", "--title", title, "--body-file", bodyFile]
+            + (head.map { ["--head", $0] } ?? [])
+        return try await gh(arguments, in: worktreePath)
             .standardOutput
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/AgentIDEData/MetadataStore.swift
+++ b/Sources/AgentIDEData/MetadataStore.swift
@@ -66,6 +66,8 @@ public struct AppMetadata: Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         lastSeen = try container.decodeIfPresent([String: Date].self, forKey: .lastSeen) ?? [:]
         seenAt = try container.decodeIfPresent([String: Date].self, forKey: .seenAt) ?? [:]
+        conversationBackupAt = try container
+            .decodeIfPresent([String: Date].self, forKey: .conversationBackupAt) ?? [:]
         unreadMarks = try container.decodeIfPresent([String].self, forKey: .unreadMarks) ?? []
         pullRequestCache = try container
             .decodeIfPresent([String: PullRequestSummary].self, forKey: .pullRequestCache) ?? [:]
@@ -104,6 +106,11 @@ public struct AppMetadata: Codable, Sendable {
 
     /// When each worktree path was last viewed, for unread state.
     public var seenAt: [String: Date] = [:]
+
+    /// When each worktree's conversation was last copied out of the
+    /// sandbox, so a long-running session is copied on a schedule
+    /// rather than on every poll.
+    public var conversationBackupAt: [String: Date] = [:]
 
     /// Worktree paths the user marked unread to revisit, cleared by
     /// viewing them.

--- a/Sources/AgentIDEData/SessionService+Lifecycle.swift
+++ b/Sources/AgentIDEData/SessionService+Lifecycle.swift
@@ -10,6 +10,9 @@ public extension SessionService {
     /// session mapping survives, which is how the conversation stays
     /// attributed to the repository.
     func deleteWorktree(item: WorktreeItem) async throws {
+        // The conversation is being thrown away deliberately, so its
+        // copy goes too rather than lingering in iCloud.
+        ConversationBackup(paths: paths).forget(worktree: item.worktree)
         let worktree = item.worktree
         guard worktree.path != worktree.repositoryPath else {
             throw CommandError(
@@ -68,6 +71,9 @@ public extension SessionService {
     /// force delete is a separate, confirmed action. Returns the
     /// refusal, nil when the worktree was removed.
     func cleanUpMergedWorktree(item: WorktreeItem, baseRef: String) async throws -> CleanupRefusal? {
+        // A merged worktree is about to go; its conversation copy is
+        // dropped only once the removal itself succeeds, below.
+        let backup = ConversationBackup(paths: paths)
         let worktree = item.worktree
         guard await git.isDirty(worktreePath: worktree.path) == false else {
             return .dirty
@@ -91,6 +97,7 @@ public extension SessionService {
             branch: worktree.branch,
         )
         removeFriendlySymlink(worktree: worktree)
+        backup.forget(worktree: worktree)
         return nil
     }
 

--- a/Sources/AgentIDEData/SessionService+PullRequests.swift
+++ b/Sources/AgentIDEData/SessionService+PullRequests.swift
@@ -1,5 +1,26 @@
 import AgentIDEDomain
 
+// MARK: - PushDestination
+
+/// Where a branch can be pushed: the repository it came from, or the
+/// viewer's own fork of it when they may not write there.
+public enum PushDestination: Hashable, Sendable {
+    case origin
+    case fork(owner: String)
+
+    // MARK: Public
+
+    /// What `gh pr create` needs to name the branch when it lives in
+    /// a fork, nil when the branch is where the pull request is.
+    public func head(branch: String) -> String? {
+        guard case let .fork(owner) = self else {
+            return nil
+        }
+
+        return owner + ":" + branch
+    }
+}
+
 // MARK: - MergeCleanupReport
 
 /// What a post-merge cleanup did and what it could not do, so the
@@ -31,14 +52,48 @@ public extension SessionService {
     /// unsigned tip refuses: every pushed commit must be GPG signed
     /// (a local hook enforces the same), and Rebase on origin is the
     /// signing path.
-    func push(worktree: Worktree) async throws {
+    func push(worktree: Worktree) async throws -> PushDestination {
         guard await git.isCommitSigned(worktreePath: worktree.path) else {
             throw SessionServiceError(
                 "The tip commit is not GPG signed; Rebase on origin signs the branch before pushing.",
             )
         }
 
-        try await git.push(worktreePath: worktree.path, branch: worktree.branch)
+        let destination = await pushDestination(worktree: worktree)
+        guard case let .fork(owner) = destination else {
+            try await git.push(worktreePath: worktree.path, branch: worktree.branch)
+            return destination
+        }
+
+        try await github.ensureFork(worktreePath: worktree.path, remoteName: owner)
+        try await git.push(worktreePath: worktree.path, branch: worktree.branch, remote: owner)
+        return destination
+    }
+
+    /// Opens the pull request for a worktree's branch, naming the
+    /// branch as `owner:branch` when it lives in a fork: the pull
+    /// request belongs to the repository it is opened against rather
+    /// than the one holding the branch.
+    func createPullRequest(worktree: Worktree, title: String, body: String) async throws -> String {
+        try await github.createPullRequest(
+            worktreePath: worktree.path,
+            title: title,
+            body: body,
+            head: pushDestination(worktree: worktree).head(branch: worktree.branch),
+        )
+    }
+
+    /// Where this branch belongs: the repository itself when GitHub
+    /// says the branch may be pushed there, and the viewer's own fork
+    /// of it otherwise.
+    func pushDestination(worktree: Worktree) async -> PushDestination {
+        guard await github.canPush(worktreePath: worktree.path) == false,
+              let owner = await github.viewer(worktreePath: worktree.path)
+        else {
+            return .origin
+        }
+
+        return .fork(owner: owner)
     }
 
     /// Whether the worktree's tip commit is GPG signed, gating Push.

--- a/Sources/AgentIDEData/SessionService+Resuming.swift
+++ b/Sources/AgentIDEData/SessionService+Resuming.swift
@@ -35,6 +35,18 @@ extension SessionService {
         )
     }
 
+    /// Copies a worktree's newest conversation somewhere the sandbox
+    /// cannot reach, and says where it went. Called wherever a
+    /// conversation is about to be relied on or left behind, since
+    /// those are the moments it is worth having a copy of.
+    func backUpConversation(of worktree: Worktree) {
+        guard let newest = sessionsInDirectories(of: worktree.path, liveSession: nil).first else {
+            return
+        }
+
+        ConversationBackup(paths: paths).store(newest, worktree: worktree)
+    }
+
     /// The ways to continue a worktree's own agent, best first: the
     /// conversation recorded for it, then the conversations its
     /// transcripts still name, then a fresh one. Relaunching with

--- a/Sources/AgentIDEData/SessionService+Resuming.swift
+++ b/Sources/AgentIDEData/SessionService+Resuming.swift
@@ -1,0 +1,88 @@
+import AgentIDEDomain
+import Foundation
+
+/// Getting an agent running again in a worktree. Resuming fails in
+/// ways that look like success: the agent starts, refuses the
+/// conversation it was handed and exits, and tmux keeps the dead
+/// pane, so the name is taken and the terminal attaches to a corpse.
+/// Every way in therefore replaces whatever holds the name and is
+/// checked for still being alive a moment later.
+extension SessionService {
+    /// Starts a session under a name, trying each command in turn
+    /// until one is still running, and killing whatever holds the
+    /// name before each attempt. Throws when none of them stayed up.
+    func start(sessionName: String, directory: String, trying commands: [String]) async throws {
+        var failure: (any Error)?
+        for command in commands {
+            await killTmuxSession(name: sessionName, isHostShell: false)
+            do {
+                try await tmux.newSession(name: sessionName, directory: directory, command: command)
+            } catch {
+                failure = error
+                continue
+            }
+            if await isRunning(sessionName: sessionName) {
+                return
+            }
+        }
+        throw failure ?? CommandError(
+            command: commands.last ?? sessionName,
+            result: ProcessResult(
+                status: 1,
+                standardOutput: "",
+                standardError: "The agent exited as soon as it started",
+            ),
+        )
+    }
+
+    /// The ways to continue a worktree's own agent, best first: the
+    /// conversation recorded for it, then the conversations its
+    /// transcripts still name, then a fresh one. Relaunching with
+    /// the original prompt is deliberately not among them: it would
+    /// re-run the whole task against an already changed worktree.
+    func resumeCommands(sessionName: String, agent: AgentKind, worktreePath: String) -> [String] {
+        let metadata = store.load()
+        let arguments = metadata.arguments[sessionName] ?? ""
+        let agentRunner = runner(for: agent)
+        var commands = [String]()
+        if let resumeID = metadata.resumeIDs[sessionName] {
+            commands.append(agentRunner.resumeCommand(resumeID: resumeID, extraArguments: arguments))
+        }
+        let past = sessionsInDirectories(of: worktreePath, liveSession: nil)
+            .filter { $0.agent == agent }
+            .prefix(Self.transcriptAttempts)
+            .map { agentRunner.resumeCommand(resumeID: $0.resumeID, extraArguments: arguments) }
+        commands += past.filter { commands.contains($0) == false }
+        commands.append(agentRunner.launchCommand(extraArguments: arguments, promptFile: nil))
+        return commands
+    }
+
+    // MARK: Private
+
+    /// How many recorded conversations to offer the agent before
+    /// giving up on continuing one: the newest few are the ones a
+    /// resume plausibly means.
+    private static let transcriptAttempts = 3
+
+    /// How long a session has to survive to count as started, as
+    /// polls: an agent that refuses its conversation exits at once,
+    /// well inside this.
+    private static let livenessPolls = 4
+    private static let livenessPollMilliseconds = 350
+
+    /// Whether the session is still there with a live pane shortly
+    /// after starting.
+    private func isRunning(sessionName: String) async -> Bool {
+        for _ in 0 ..< Self.livenessPolls {
+            try? await Task.sleep(for: .milliseconds(Self.livenessPollMilliseconds))
+            let panes = await (try? tmux.panes()) ?? []
+            guard let pane = panes.first(where: { $0.sessionName == sessionName }) else {
+                return false
+            }
+            guard pane.isDead == false else {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/Sources/AgentIDEData/SessionService+Resuming.swift
+++ b/Sources/AgentIDEData/SessionService+Resuming.swift
@@ -47,6 +47,35 @@ extension SessionService {
         ConversationBackup(paths: paths).store(newest, worktree: worktree)
     }
 
+    /// Copies the conversation of every worktree with a running
+    /// session, at most once an hour each and only when the
+    /// transcript has moved on. A session can run for a day between
+    /// being started and being closed, and a copy taken only at
+    /// those two moments would be a day stale when the sandbox went
+    /// away. Off the caller's actor: this reads and copies files
+    /// while the window is being used.
+    @concurrent
+    func backUpRunningConversations(_ groups: [RepositoryGroup]) async {
+        var metadata = store.load()
+        var copied = false
+        let now = Date()
+        for item in groups.flatMap(\.items) where item.session?.status == .running {
+            let last = metadata.conversationBackupAt[item.worktree.path] ?? .distantPast
+            guard now.timeIntervalSince(last) >= Self.backupIntervalSeconds else {
+                continue
+            }
+
+            backUpConversation(of: item.worktree)
+            metadata.conversationBackupAt[item.worktree.path] = now
+            copied = true
+        }
+        guard copied else {
+            return
+        }
+
+        store.save(metadata)
+    }
+
     /// The ways to continue a worktree's own agent, best first: the
     /// conversation recorded for it, then the conversations its
     /// transcripts still name, then a fresh one. Relaunching with
@@ -70,6 +99,11 @@ extension SessionService {
     }
 
     // MARK: Private
+
+    /// How often a running session's conversation is copied: often
+    /// enough that little is lost, rarely enough that copying a long
+    /// transcript is never in anyone's way.
+    private static let backupIntervalSeconds = 3_600.0
 
     /// How many recorded conversations to offer the agent before
     /// giving up on continuing one: the newest few are the ones a

--- a/Sources/AgentIDEData/SessionService+Sessions.swift
+++ b/Sources/AgentIDEData/SessionService+Sessions.swift
@@ -104,7 +104,10 @@ public extension SessionService {
     /// the polite kill does not take; worktree, transcript and
     /// metadata survive so it stays resumable. The deliberate close
     /// is recorded so automatic resumes leave this worktree alone.
-    func closeSession(sessionName: String, worktreePath: String) async {
+    func closeSession(sessionName: String, worktreePath: String, worktree: Worktree? = nil) async {
+        if let worktree {
+            backUpConversation(of: worktree)
+        }
         rememberResumeID(sessionName: sessionName, worktreePath: worktreePath)
         var metadata = store.load()
         if metadata.intentionallyClosed.contains(worktreePath) == false {
@@ -191,6 +194,7 @@ public extension SessionService {
             )
         }
 
+        backUpConversation(of: worktree)
         try await start(
             sessionName: sessionName,
             directory: worktree.path,
@@ -221,6 +225,7 @@ public extension SessionService {
         ).filter { commands.contains($0) == false }
         try await start(sessionName: sessionName, directory: worktree.path, trying: commands)
         remember(sessionName: sessionName, worktreePath: worktree.path, resumeID: past.resumeID)
+        ConversationBackup(paths: paths).store(past, worktree: worktree)
         return sessionName
     }
 

--- a/Sources/AgentIDEData/SessionService+Sessions.swift
+++ b/Sources/AgentIDEData/SessionService+Sessions.swift
@@ -100,17 +100,18 @@ public extension SessionService {
         try await git.commitAll(worktreePath: worktreePath, message: "Commit outstanding agent work")
     }
 
-    /// Kills the tmux session; worktree, transcript and metadata
-    /// survive so it stays resumable. The deliberate close is
-    /// recorded so automatic resumes leave this worktree alone.
-    func closeSession(sessionName: String, worktreePath: String) async throws {
+    /// Ends the tmux session and everything in it, escalating when
+    /// the polite kill does not take; worktree, transcript and
+    /// metadata survive so it stays resumable. The deliberate close
+    /// is recorded so automatic resumes leave this worktree alone.
+    func closeSession(sessionName: String, worktreePath: String) async {
         rememberResumeID(sessionName: sessionName, worktreePath: worktreePath)
         var metadata = store.load()
         if metadata.intentionallyClosed.contains(worktreePath) == false {
             metadata.intentionallyClosed.append(worktreePath)
         }
         store.save(metadata)
-        try await tmux.killSession(name: sessionName)
+        await killTmuxSession(name: sessionName, isHostShell: false)
     }
 
     /// Whether the worktree's last session ended by explicit close,
@@ -172,7 +173,10 @@ public extension SessionService {
     }
 
     /// Resumes the session last recorded in a worktree, whether or
-    /// not a live tmux session still names it.
+    /// not a live tmux session still names it, and whether or not
+    /// the one that does is still alive: a refused conversation
+    /// leaves a dead pane holding the name, so every way in is tried
+    /// until one is still running.
     func resumeWorktree(_ worktree: Worktree) async throws {
         guard let sessionName = store.load().sessionsByWorktree[worktree.path] else {
             throw CommandError(
@@ -187,41 +191,35 @@ public extension SessionService {
             )
         }
 
-        let metadata = store.load()
-        let arguments = metadata.arguments[sessionName] ?? ""
-        if let resumeID = metadata.resumeIDs[sessionName] {
-            let command = runner(for: agent).resumeCommand(resumeID: resumeID, extraArguments: arguments)
-            try await tmux.newSession(name: sessionName, directory: worktree.path, command: command)
-        } else if let past = sessionsInDirectories(of: worktree.path, liveSession: nil).first {
-            // Externally killed sessions never record a resume id,
-            // but their transcripts still name the conversation; the
-            // newest one is what resuming should continue.
-            _ = try await resumePast(past, worktree: worktree)
-        } else {
-            // Without any conversation to continue, relaunching with
-            // the original prompt would re-run the whole task against
-            // the already modified worktree; a fresh session there is
-            // the safe fallback.
-            let command = runner(for: agent).launchCommand(extraArguments: arguments, promptFile: nil)
-            try await tmux.newSession(name: sessionName, directory: worktree.path, command: command)
-        }
+        try await start(
+            sessionName: sessionName,
+            directory: worktree.path,
+            trying: resumeCommands(sessionName: sessionName, agent: agent, worktreePath: worktree.path),
+        )
         clearIntentionalClose(worktreePath: worktree.path)
     }
 
     /// Relaunches a past conversation in its own worktree, replacing
-    /// any session already there.
+    /// whatever session is already there. An agent that will not
+    /// take the conversation back (one it has rolled away, or a
+    /// version that no longer reads that transcript) exits at once,
+    /// so the worktree's other conversations and then a fresh
+    /// session are tried rather than leaving a dead pane behind.
+    @discardableResult
     func resumePast(_ past: TranscriptSession, worktree: Worktree) async throws -> String {
         let sessionName = SessionName.make(
             repository: worktree.repositoryName,
             branch: worktree.branch,
             agent: past.agent,
         )
-        try? await tmux.killSession(name: sessionName)
-        try await tmux.newSession(
-            name: sessionName,
-            directory: worktree.path,
-            command: runner(for: past.agent).resumeCommand(resumeID: past.resumeID, extraArguments: ""),
-        )
+        let agentRunner = runner(for: past.agent)
+        var commands = [agentRunner.resumeCommand(resumeID: past.resumeID, extraArguments: "")]
+        commands += resumeCommands(
+            sessionName: sessionName,
+            agent: past.agent,
+            worktreePath: worktree.path,
+        ).filter { commands.contains($0) == false }
+        try await start(sessionName: sessionName, directory: worktree.path, trying: commands)
         remember(sessionName: sessionName, worktreePath: worktree.path, resumeID: past.resumeID)
         return sessionName
     }

--- a/Sources/AgentIDEData/SessionService+Sessions.swift
+++ b/Sources/AgentIDEData/SessionService+Sessions.swift
@@ -104,10 +104,11 @@ public extension SessionService {
     /// the polite kill does not take; worktree, transcript and
     /// metadata survive so it stays resumable. The deliberate close
     /// is recorded so automatic resumes leave this worktree alone.
-    func closeSession(sessionName: String, worktreePath: String, worktree: Worktree? = nil) async {
-        if let worktree {
-            backUpConversation(of: worktree)
-        }
+    func closeSession(sessionName: String, worktree: Worktree) async {
+        // The conversation is copied before the session goes, since
+        // a close is one of the two moments it is worth keeping.
+        backUpConversation(of: worktree)
+        let worktreePath = worktree.path
         rememberResumeID(sessionName: sessionName, worktreePath: worktreePath)
         var metadata = store.load()
         if metadata.intentionallyClosed.contains(worktreePath) == false {

--- a/Sources/AgentIDEData/SessionService+Sources.swift
+++ b/Sources/AgentIDEData/SessionService+Sources.swift
@@ -214,14 +214,21 @@ public extension SessionService {
     }
 
     /// The ref a signed rebase lands on. The branch's own origin ref
-    /// wins when it exists, every commit unique to it verifies and
-    /// local commits sit on top needing signatures: rebasing there
-    /// signs only the new commits, so pushed history keeps its
-    /// hashes. Anything else falls back to origin/HEAD, re-signing
-    /// the whole branch.
+    /// wins when it exists, is still an ancestor of the branch,
+    /// every commit unique to it verifies and local commits sit on
+    /// top needing signatures: rebasing there signs only the new
+    /// commits, so pushed history keeps its hashes. Anything else
+    /// falls back to origin/HEAD, re-signing the whole branch.
+    ///
+    /// The ancestor test is what keeps an amended branch out of
+    /// that path. Amending a pushed commit leaves the pushed one
+    /// behind as a stale twin rather than a parent, and rebasing on
+    /// it replays the amended work on top of what it replaced,
+    /// which is a conflict at best and a duplicated commit at worst.
     func signedRebaseTarget(worktreePath: String, branch: String) async -> String {
         let remote = "origin/" + branch
         guard await git.remoteBranchExists(worktreePath: worktreePath, branch: branch),
+              await git.isAncestor(worktreePath: worktreePath, ref: remote, of: "HEAD"),
               await git.allCommitsSigned(worktreePath: worktreePath, range: "origin/HEAD.." + remote),
               await (git.commitCount(worktreePath: worktreePath, range: remote + "..HEAD") ?? 0) > 0
         else {

--- a/Sources/AgentIDEData/SessionService.swift
+++ b/Sources/AgentIDEData/SessionService.swift
@@ -124,6 +124,11 @@ public struct SessionService: Sendable {
                     workingDirectory: pane.currentPath,
                 )
             }
+        // The poll is the only thing running while a session is, so
+        // it is what keeps the conversation copies current; the
+        // schedule inside means this costs a dictionary lookup on
+        // almost every tick.
+        await backUpRunningConversations(groups)
         return (groups, foreign)
     }
 

--- a/Sources/AgentIDEDomain/PaneLayout.swift
+++ b/Sources/AgentIDEDomain/PaneLayout.swift
@@ -1,0 +1,69 @@
+// MARK: - PaneLayout
+
+/// How wide the window's panes may be. The stored widths were
+/// dragged on whatever display the window was on last, so a window
+/// that ends up on a smaller one, by being dragged or by having its
+/// display unplugged, has to be told what still fits.
+public struct PaneLayout: Hashable, Sendable {
+    // MARK: Lifecycle
+
+    /// Fits the stored widths to a window: the utility pane gives
+    /// way first, then the sidebar, and a window too narrow for all
+    /// three drops the utility pane rather than growing past the
+    /// screen. Dropping it is for the layout only: what the user
+    /// asked for stays stored, so the pane returns with the room.
+    /// The parameters are named apart from the properties so that
+    /// assigning them needs no `self`, which the formatter strips.
+    public init(width: Double, sidebar stored: Double, utility storedUtility: Double, showsUtility wanted: Bool) {
+        guard width > 0 else {
+            sidebar = stored
+            utility = storedUtility
+            showsUtility = wanted
+            return
+        }
+
+        var fittedSidebar = stored.clamped(to: Self.sidebarRange)
+        var fittedUtility = storedUtility.clamped(to: Self.utilityRange)
+        var fits = wanted
+        if fits {
+            let overflow = fittedSidebar + fittedUtility + Self.primaryMinimum - width
+            if overflow > 0 {
+                fittedUtility = max(fittedUtility - overflow, Self.utilityRange.lowerBound)
+            }
+            // Not even with the sidebar at its narrowest: the
+            // utility pane goes rather than the window overflowing.
+            fits = Self.sidebarRange.lowerBound + fittedUtility + Self.primaryMinimum <= width
+        }
+        // The sidebar takes what is left, which is all of it once
+        // the utility pane has gone.
+        let occupied = (fits ? fittedUtility : 0) + Self.primaryMinimum
+        if fittedSidebar + occupied > width {
+            fittedSidebar = max(width - occupied, Self.sidebarRange.lowerBound)
+        }
+        sidebar = fittedSidebar
+        utility = fittedUtility
+        showsUtility = fits
+    }
+
+    // MARK: Public
+
+    /// Slim enough for icon-and-truncated-text rows while staying
+    /// wider than the traffic lights band.
+    public static let sidebarRange = 150.0 ... 440.0
+    public static let utilityRange = 340.0 ... 1_200.0
+
+    /// What the conversation pane needs to stay readable.
+    public static let primaryMinimum = 420.0
+
+    public let sidebar: Double
+    public let utility: Double
+
+    /// Whether the utility pane fits beside the others right now.
+    public let showsUtility: Bool
+}
+
+private extension Double {
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/Sources/AgentIDEDomain/RepositoryGroup.swift
+++ b/Sources/AgentIDEDomain/RepositoryGroup.swift
@@ -62,6 +62,22 @@ public struct WorktreeItem: Identifiable, Hashable, Sendable {
     public var id: String {
         worktree.id
     }
+
+    /// The same row with no session running in it, for a close that
+    /// should show on screen before tmux has been asked again.
+    public func withoutSession() -> Self {
+        Self(
+            worktree: worktree,
+            session: nil,
+            isDirty: isDirty,
+            aheadOfUpstream: aheadOfUpstream,
+            hasUnread: hasUnread,
+            pastSessions: pastSessions,
+            aheadOfDefault: aheadOfDefault,
+            behindDefault: behindDefault,
+            lastActivityAt: lastActivityAt,
+        )
+    }
 }
 
 // MARK: - RepositoryGroup

--- a/Sources/DashboardFeature/DashboardModel+Sessions.swift
+++ b/Sources/DashboardFeature/DashboardModel+Sessions.swift
@@ -5,6 +5,23 @@ import TerminalUI
 /// Session creation: every entry point funnels through one runner
 /// that closes the form, refreshes and selects the new worktree.
 public extension DashboardModel {
+    /// Forgets a worktree's session without waiting to be told: a
+    /// dead pane is still a session, so closing one only cleared the
+    /// pane once the next reading of tmux landed, and a kill tmux
+    /// was slow to finish left the agent pane on screen as though
+    /// the button had done nothing.
+    func forgetSession(at worktreePath: String) {
+        for groupIndex in groups.indices {
+            for itemIndex in groups[groupIndex].items.indices
+                where groups[groupIndex].items[itemIndex].worktree.path == worktreePath {
+                groups[groupIndex].items[itemIndex] = groups[groupIndex].items[itemIndex].withoutSession()
+            }
+        }
+        if selection?.worktree.path == worktreePath {
+            selection = groups.flatMap(\.items).first { $0.worktree.path == worktreePath }
+        }
+    }
+
     /// Creates a session from a typed prompt.
     func createSession(
         repository: Repository,

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -166,6 +166,17 @@ extension PullRequestsModel {
         }
     }
 
+    /// What a push is reported as, which depends on where it went:
+    /// a branch that went to a fork is worth saying so about, since
+    /// it is not in the repository being looked at.
+    static func describe(push destination: PushDestination, branch: String) -> String {
+        guard case let .fork(owner) = destination else {
+            return "Pushed " + branch + "."
+        }
+
+        return "Pushed " + branch + " to " + owner + "'s fork, since this repository is not yours to push to."
+    }
+
     /// Splits one commit message into the form's title and body.
     /// The body comes back unwrapped: commit messages are wrapped by
     /// hand to a narrow column, and a pull request reflows its own
@@ -217,9 +228,9 @@ extension PullRequestsModel {
         }
 
         do {
-            try await performPush(worktree)
+            let destination = try await performPush(worktree)
             isPushed = true
-            setStatus("Pushed.", detail: "Pushed " + worktree.branch + ".")
+            setStatus("Pushed.", detail: Self.describe(push: destination, branch: worktree.branch))
             Self.requestSidebarRefresh()
             await reload(keepingSelection: true)
             return true

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -50,7 +50,7 @@ final class PullRequestsModel {
             await github.failingChecks(repositoryPath: repository.path, number: number)
         }
         performCreate = { worktree, title, body in
-            try await github.createPullRequest(worktreePath: worktree.path, title: title, body: body)
+            try await service.createPullRequest(worktree: worktree, title: title, body: body)
         }
         fetchTemplate = { path in
             GitHubClient.pullRequestTemplate(in: path)
@@ -185,7 +185,7 @@ final class PullRequestsModel {
     var performPostMergeCleanup: (Worktree, String) async -> Void
     var fetchCurrentBranch: (String) async -> String?
     var fetchRebaseNeed: (Worktree) async -> SessionService.RebaseNeed
-    var performPush: (Worktree) async throws -> Void
+    var performPush: (Worktree) async throws -> PushDestination
     var performRebase: (Worktree) async throws -> Void
     var checkTipSigned: (String) async -> Bool
 

--- a/Sources/ReviewFeature/EditorPane.swift
+++ b/Sources/ReviewFeature/EditorPane.swift
@@ -12,10 +12,16 @@ public struct EditorPane: View {
     /// Creates the pane for a worktree. `waitingEdit` is a file some
     /// command outside the app is blocked on, which takes the pane
     /// over until it is dealt with.
-    public init(worktreePath: String, service: SessionService, waitingEdit: ExternalEdit? = nil) {
+    public init(
+        worktreePath: String,
+        service: SessionService,
+        onFinishedWaiting: (() -> Void)? = nil,
+        waitingEdit: ExternalEdit? = nil,
+    ) {
         self.worktreePath = worktreePath
         self.service = service
         self.waitingEdit = waitingEdit
+        self.onFinishedWaiting = onFinishedWaiting
     }
 
     // MARK: Public
@@ -103,6 +109,10 @@ public struct EditorPane: View {
     private let worktreePath: String
     private let service: SessionService
     private let waitingEdit: ExternalEdit?
+
+    /// Told when a waiting file is dealt with, so the pane the
+    /// command interrupted can come straight back.
+    private let onFinishedWaiting: (() -> Void)?
 
     /// The file this pane is blocked on, until it is finished with:
     /// the answer takes a moment to reach the spool and come back,
@@ -245,6 +255,7 @@ public struct EditorPane: View {
     /// pane to its finder.
     private func finish(_ edit: ExternalEdit, saved: Bool) {
         finishedEdit = edit.id
+        onFinishedWaiting?()
         Task { await service.finishEdit(edit, saved: saved) }
     }
 

--- a/Tests/AgentIDEDataTests/ConversationBackupTests.swift
+++ b/Tests/AgentIDEDataTests/ConversationBackupTests.swift
@@ -32,7 +32,7 @@ struct ConversationBackupTests {
         )
 
         backup.store(past, worktree: worktree)
-        let copied = try #require(backup.stored(worktree: worktree))
+        let copied = root + "/cloud/platform-zendesk-sla-alignment/conversation.jsonl"
         #expect(try String(contentsOfFile: copied, encoding: .utf8) == "first\n")
 
         // A conversation that has moved on replaces its copy, so what
@@ -54,7 +54,7 @@ struct ConversationBackupTests {
 
         // Deleting the worktree is deliberate, so the copy goes too.
         backup.forget(worktree: worktree)
-        #expect(backup.stored(worktree: worktree) == nil)
+        #expect(FileManager.default.fileExists(atPath: copied) == false)
     }
 
     // MARK: Private

--- a/Tests/AgentIDEDataTests/ConversationBackupTests.swift
+++ b/Tests/AgentIDEDataTests/ConversationBackupTests.swift
@@ -1,0 +1,74 @@
+@testable import AgentIDEData
+import AgentIDEDomain
+import Foundation
+import Testing
+
+/// The one thing the sandbox holds that git and GitHub do not: the
+/// conversation. These pin that a copy is kept, refreshed and thrown
+/// away with the worktree it belongs to.
+struct ConversationBackupTests {
+    // MARK: Internal
+
+    @Test
+    func `the newest conversation is copied, refreshed and forgotten`() throws {
+        let root = try TestSupport.temporaryDirectory("backup")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let backup = ConversationBackup(paths: paths(root: root), directory: root + "/cloud")
+        let worktree = Worktree(
+            repositoryName: "platform",
+            repositoryPath: root + "/platform",
+            branch: "zendesk-sla-alignment",
+            path: root + "/worktrees/uuid/polite-index",
+        )
+        let transcript = root + "/rollout.jsonl"
+        try "first\n".write(toFile: transcript, atomically: true, encoding: .utf8)
+        let past = TranscriptSession(
+            id: "019ff168",
+            path: transcript,
+            agent: .codexCLI,
+            modifiedAt: 0,
+            title: "Align Zendesk SLA",
+            resumeID: "019ff168",
+        )
+
+        backup.store(past, worktree: worktree)
+        let copied = try #require(backup.stored(worktree: worktree))
+        #expect(try String(contentsOfFile: copied, encoding: .utf8) == "first\n")
+
+        // A conversation that has moved on replaces its copy, so what
+        // is kept is what a resume would continue.
+        try "first\nsecond\n".write(toFile: transcript, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(Self.laterSeconds)],
+            ofItemAtPath: transcript,
+        )
+        backup.store(past, worktree: worktree)
+        #expect(try String(contentsOfFile: copied, encoding: .utf8) == "first\nsecond\n")
+
+        // What it belongs to travels with it, since a conversation
+        // file alone cannot say which worktree or agent it came from.
+        let index = root + "/cloud/platform-zendesk-sla-alignment/conversation.json"
+        let described = try #require(try? String(contentsOfFile: index, encoding: .utf8))
+        #expect(described.contains("zendesk-sla-alignment"))
+        #expect(described.contains("019ff168"))
+
+        // Deleting the worktree is deliberate, so the copy goes too.
+        backup.forget(worktree: worktree)
+        #expect(backup.stored(worktree: worktree) == nil)
+    }
+
+    // MARK: Private
+
+    /// Far enough ahead that the copy is unambiguously older.
+    private static let laterSeconds = 60.0
+
+    private func paths(root: String) -> WorkspacePaths {
+        WorkspacePaths(
+            hostUser: "test",
+            sharedWorkspace: root + "/shared",
+            sandboxHome: root + "/home",
+            metadataFile: root + "/state.json",
+            appDirectory: root + "/app",
+        )
+    }
+}

--- a/Tests/AgentIDEDataTests/GitHubClientTests.swift
+++ b/Tests/AgentIDEDataTests/GitHubClientTests.swift
@@ -28,15 +28,17 @@ struct GitHubClientTests {
     }
 
     @Test
-    func `run ids come deduplicated from failing check links`() {
+    func `job ids come deduplicated from failing check links`() {
         let lines = [
             "build\tfail\t1m2s\thttps://github.com/o/r/actions/runs/123/job/456",
             "test\tfail\t2m\thttps://github.com/o/r/actions/runs/123/job/789",
             "style\tfail\t3s\thttps://github.com/o/r/actions/runs/987/job/1",
             "external-ci\tfail\t5s\thttps://ci.example.invalid/build/9",
         ]
-        #expect(GitHubClient.runIDs(fromCheckLines: lines) == ["123", "987"])
-        #expect(GitHubClient.runIDs(fromCheckLines: []).isEmpty)
+        // Each failing check names its own job: two failures in one
+        // run are two jobs to read, not one run to paste whole.
+        #expect(GitHubClient.jobIDs(fromCheckLines: lines) == ["456", "789", "1"])
+        #expect(GitHubClient.jobIDs(fromCheckLines: []).isEmpty)
     }
 
     @Test

--- a/Tests/AgentIDEDataTests/PullRequestIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/PullRequestIntegrationTests.swift
@@ -45,5 +45,12 @@ struct PullRequestIntegrationTests {
         try await TestSupport.runGit(["push", "-q", "-u", "origin", "feature"], in: path)
         #expect(await git.remoteBranchExists(worktreePath: path, branch: "feature"))
         #expect(await world.service.signedRebaseTarget(worktreePath: path, branch: "feature") == "origin/HEAD")
+
+        // Amending a pushed commit leaves what was pushed behind as
+        // a stale twin rather than a parent, so rebasing there would
+        // replay the amended work on top of what it replaced.
+        try await TestSupport.runGit(["commit", "-q", "--amend", "-m", "Add more, again"], in: path)
+        #expect(await git.isAncestor(worktreePath: path, ref: "origin/feature", of: "HEAD") == false)
+        #expect(await world.service.signedRebaseTarget(worktreePath: path, branch: "feature") == "origin/HEAD")
     }
 }

--- a/Tests/AgentIDEDataTests/SessionServiceIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/SessionServiceIntegrationTests.swift
@@ -105,7 +105,7 @@ struct SessionServiceIntegrationTests {
         let overview = await world.service.overview()
         let item = try #require(overview.groups.first?.items.first { $0.worktree.branch.hasPrefix("doomed_work") })
         let worktreePath = item.worktree.path
-        try await world.service.closeSession(sessionName: sessionName, worktreePath: worktreePath)
+        await world.service.closeSession(sessionName: sessionName, worktree: item.worktree)
 
         // A conversation the deleted worktree leaves behind.
         let runner = PromptCaptureRunner()
@@ -140,7 +140,7 @@ struct SessionServiceIntegrationTests {
         )
         var overview = await world.service.overview()
         var item = try #require(overview.groups.first?.items.first { $0.worktree.branch.hasPrefix("anchor_work") })
-        try await world.service.closeSession(sessionName: sessionName, worktreePath: item.worktree.path)
+        await world.service.closeSession(sessionName: sessionName, worktree: item.worktree)
         let git = GitClient(runner: FoundationProcessRunner())
         let base = "main"
 
@@ -178,7 +178,7 @@ struct SessionServiceIntegrationTests {
         let worktree = try #require(
             overview.groups.first?.items.first { $0.worktree.branch.hasPrefix("original_work") }?.worktree,
         )
-        try await world.service.closeSession(sessionName: sessionName, worktreePath: worktree.path)
+        await world.service.closeSession(sessionName: sessionName, worktree: worktree)
 
         // A finished conversation left behind by any tool.
         let runner = PromptCaptureRunner()
@@ -228,7 +228,7 @@ struct SessionServiceIntegrationTests {
                 .first { $0.worktree.branch.hasPrefix("doomed_worktree") }?
                 .worktree,
         )
-        try await world.service.closeSession(sessionName: sessionName, worktreePath: worktree.path)
+        await world.service.closeSession(sessionName: sessionName, worktree: worktree)
 
         let runner = PromptCaptureRunner()
         let directory = try #require(runner.transcriptDirectory(

--- a/Tests/AgentIDEDomainTests/PaneLayoutTests.swift
+++ b/Tests/AgentIDEDomainTests/PaneLayoutTests.swift
@@ -1,0 +1,57 @@
+import AgentIDEDomain
+import Testing
+
+/// Pins what happens to pane widths dragged on a large display when
+/// the window ends up on a small one, which is what unplugging a
+/// monitor does.
+struct PaneLayoutTests {
+    @Test
+    func `widths dragged on a large display are left alone where they fit`() {
+        let layout = PaneLayout(width: 2_000, sidebar: 300, utility: 700, showsUtility: true)
+        #expect(layout.sidebar == 300)
+        #expect(layout.utility == 700)
+        #expect(layout.showsUtility)
+    }
+
+    @Test
+    func `the utility pane gives way first, then the sidebar`() {
+        // 300 + 700 + 420 needs 1,420; this window has 1,200.
+        let narrow = PaneLayout(width: 1_200, sidebar: 300, utility: 700, showsUtility: true)
+        #expect(narrow.sidebar == 300)
+        #expect(narrow.utility == 480)
+        #expect(narrow.showsUtility)
+
+        // Below what the utility pane's own minimum allows, the
+        // sidebar narrows too rather than the window overflowing.
+        let narrower = PaneLayout(width: 1_000, sidebar: 400, utility: 700, showsUtility: true)
+        #expect(narrower.utility == PaneLayout.utilityRange.lowerBound)
+        #expect(narrower.sidebar == 240)
+        #expect(narrower.showsUtility)
+    }
+
+    @Test
+    func `a window too narrow for three panes shows two`() {
+        // 150 + 340 + 420 is 910, so 800 cannot hold all three.
+        let layout = PaneLayout(width: 800, sidebar: 300, utility: 480, showsUtility: true)
+        #expect(layout.showsUtility == false)
+        #expect(layout.sidebar == 300)
+        // The sidebar still narrows to leave the conversation its
+        // own minimum.
+        #expect(PaneLayout(width: 600, sidebar: 300, utility: 480, showsUtility: true).sidebar == 180)
+    }
+
+    @Test
+    func `a hidden utility pane stays hidden and costs nothing`() {
+        let layout = PaneLayout(width: 900, sidebar: 300, utility: 900, showsUtility: false)
+        #expect(layout.showsUtility == false)
+        #expect(layout.sidebar == 300)
+    }
+
+    @Test
+    func `a window with no width yet changes nothing`() {
+        let layout = PaneLayout(width: 0, sidebar: 300, utility: 480, showsUtility: true)
+        #expect(layout.sidebar == 300)
+        #expect(layout.utility == 480)
+        #expect(layout.showsUtility)
+    }
+}

--- a/Tests/PRFeatureTests/PullRequestsModelTests+Fixtures.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests+Fixtures.swift
@@ -32,9 +32,7 @@ extension PullRequestsModelTests {
         }
         model.fetchCurrentBranch = { _ in nil }
         model.fetchRebaseNeed = { _ in .nothing }
-        model.performPush = { _ in
-            // Succeeds without side effects.
-        }
+        model.performPush = { _ in .origin }
         model.performRebase = { _ in
             // Succeeds without side effects.
         }

--- a/Tests/PRFeatureTests/PullRequestsModelTests+Fork.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests+Fork.swift
@@ -20,4 +20,27 @@ extension PullRequestsModelTests {
         #expect(PushDestination.fork(owner: "MikeMcQuaid").head(branch: "feature") == "MikeMcQuaid:feature")
         #expect(PushDestination.origin.head(branch: "feature") == nil)
     }
+
+    @Test
+    func `the checked-out branch drives listing and actions`() async {
+        let model = makeModel(items: [item(branch: "feature", ahead: 1)])
+        model.fetchCurrentBranch = { _ in "switched" }
+        var listed: GitHubClient.ListScope?
+        model.fetchList = { scope, _ in
+            listed = scope
+            return [summary(1, head: "switched")]
+        }
+        var pushed: String?
+        model.performPush = { worktree in
+            pushed = worktree.branch
+            return .origin
+        }
+
+        await model.reload()
+        #expect(listed == .branch("switched"))
+        #expect(model.needsCreateForm == false)
+
+        _ = await model.push()
+        #expect(pushed == "switched")
+    }
 }

--- a/Tests/PRFeatureTests/PullRequestsModelTests+Fork.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests+Fork.swift
@@ -1,0 +1,23 @@
+import AgentIDEData
+@testable import PRFeature
+import Testing
+
+/// Working in someone else's repository: the branch goes to a fork
+/// and the pull request has to say so.
+extension PullRequestsModelTests {
+    @Test
+    func `a push to a fork says whose fork it went to`() async {
+        let model = makeModel(items: [item(branch: "feature", ahead: 2)])
+        model.performPush = { _ in .fork(owner: "MikeMcQuaid") }
+        #expect(await model.push())
+        // The footer and the messages pane both say where it went,
+        // since pushing somewhere other than the repository you are
+        // looking at is worth knowing.
+        #expect(model.status == "Pushed.")
+
+        // A branch in a fork names itself for the pull request; one
+        // in the repository does not.
+        #expect(PushDestination.fork(owner: "MikeMcQuaid").head(branch: "feature") == "MikeMcQuaid:feature")
+        #expect(PushDestination.origin.head(branch: "feature") == nil)
+    }
+}

--- a/Tests/PRFeatureTests/PullRequestsModelTests.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests.swift
@@ -277,24 +277,4 @@ struct PullRequestsModelTests {
         await pending.performMergeAction()
         #expect(pendingCleaned == false)
     }
-
-    @Test
-    func `the checked-out branch drives listing and actions`() async {
-        let model = makeModel(items: [item(branch: "feature", ahead: 1)])
-        model.fetchCurrentBranch = { _ in "switched" }
-        var listed: GitHubClient.ListScope?
-        model.fetchList = { scope, _ in
-            listed = scope
-            return [summary(1, head: "switched")]
-        }
-        var pushed: String?
-        model.performPush = { worktree in pushed = worktree.branch }
-
-        await model.reload()
-        #expect(listed == .branch("switched"))
-        #expect(model.needsCreateForm == false)
-
-        _ = await model.push()
-        #expect(pushed == "switched")
-    }
 }

--- a/Tests/PRFeatureTests/PullRequestsModelTests.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests.swift
@@ -177,7 +177,10 @@ struct PullRequestsModelTests {
     func `creating a pull request appends the template, never pushes`() async {
         let model = makeModel(items: [item(branch: "feature", ahead: 0)])
         var pushed = false
-        model.performPush = { _ in pushed = true }
+        model.performPush = { _ in
+            pushed = true
+            return .origin
+        }
         var created: (title: String, body: String)?
         model.performCreate = { _, title, body in
             created = (title, body)


### PR DESCRIPTION
- Ensure windows fit display after fullscreen disruption  
- Resume sessions after dead exits by preserving name and context  
- Redirect pushes to owner forks with clear branch naming  
- Keep worktree conversations isolated from sandbox  
- Archive running sessions hourly with transcript tracking  
- Capture failing job steps without full run logs  
- Return to shell after editor completes  
- Close dead panes on click with proper session cleanup  
- Document Metal build issues in sandbox environment