### PR TITLE
Refactor session and update workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ fastlane/test_output
 
 # Sandboxed builds
 .DerivedData/
+
+# Test scratch
+.test-scratch/

--- a/.swiftformat
+++ b/.swiftformat
@@ -5,3 +5,6 @@
 # Group digits from four up so numberFormatting agrees with
 # SwiftLint's number_separator instead of fighting it.
 --decimalgrouping 3,4
+
+# Scratch repositories the integration tests build and sweep.
+--exclude .build,.DerivedData,.test-scratch

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -49,3 +49,5 @@ disabled_rules:
 excluded:
   - .build
   - .DerivedData
+  # Scratch repositories the integration tests build and sweep.
+  - .test-scratch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,5 +180,6 @@ Hard-won on macOS 27 beta; check before assuming they expired.
    by product name, in every committed file.
 9. Never place app files in bare `/tmp`: cross-user files belong in
    the shared workspace or the owning user's home, per-user scratch
-   in that user's macOS temporary directory.
+   in that user's macOS temporary directory, and test scratch in the
+   gitignored `.test-scratch` of the checkout, which each run sweeps.
 10. Keep diffs minimal and follow existing structure.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -478,7 +478,11 @@ Sendable` and `nonisolated(unsafe)` are banned.
    slice deepens, alongside the move to STTextView), with line numbers
    and visible whitespace in both the diff (tabs and trailing whitespace
    carry a background tint, so copied diff text stays character-exact)
-   and the editor (substitute glyphs).
+   and the editor (substitute glyphs). Diff lines wrap to the pane's
+   width as the editor's do, each line beside its own gutter entry so
+   the numbers keep their places; a hunk's context menu copies its
+   lines whole, since wrapping ends the drag across a single text
+   block. The branch's commit listing wraps for the same reason.
 4. Rejecting selected lines builds a minimal reverse patch with
    `PatchBuilder` (pure, with recalculated hunk offsets), validates it with
    `git apply --check`, applies it with `git apply -R --index` so index and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -738,7 +738,18 @@ dead pane, so the name is taken and the terminal attaches to a corpse.
 Reopening therefore works through the ways in until one is still running a
 moment later: the recorded conversation, then the newest conversations the
 worktree's own transcripts name, then a fresh session there. Each attempt
-kills whatever holds the session name first. Relaunching with the original
+kills whatever holds the session name first, and creation is never
+attach-or-create: `new-session -A` hands back whatever is already there, so
+a start meant to be fresh would go on talking to the old agent process,
+which after a CLI upgrade is one whose own files have been deleted beneath
+it. tmux is how a session survives the app quitting, crashing or updating;
+it is not how an agent survives its own upgrade, so everything the user asks
+for by hand (starting, closing, resuming) replaces the process, while
+reattaching to what is already running is left to the app reopening. Each
+start also asks the CLI its version and records it under the session name,
+and the pane's tab shows that rather than the agent's family alone: a
+session that outlived an upgrade is the one worth spotting, and the number
+it started with is the only place that shows. Relaunching with the original
 prompt is never among them, since it would re-run the whole task against the
 already modified worktree.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -334,7 +334,6 @@ Third-party imports are confined (P3):
 | GRDB, Subprocess | AgentIDEData |
 | SwiftTerm | TerminalUI |
 | STTextView, SwiftTreeSitter and grammars | ReviewFeature |
-| Sparkle | AgentIDEApp |
 | WebKit | SessionFeature |
 
 ### The AgentRunner seam
@@ -900,10 +899,13 @@ official language or project organisation.
 | tree-sitter-ruby, tree-sitter-bash | grammars | official organisation; pinned to the latest ABI 14 releases the runtime accepts |
 | tree-sitter-swift (alex-pinkus) | Swift grammar | the grammar the tree-sitter ecosystem standardises on; no official-organisation build exists |
 | swift-subprocess | process spawning | official-organisation exception (swiftlang); planned, Foundation `Process` serves today |
-| Sparkle | app updates | later slice |
 
 System frameworks (WebKit, UserNotifications and FSEvents) and runtime tools
-(tmux, installed by Homebrew and never linked) sit outside the table.
+(tmux, installed by Homebrew and never linked) sit outside the table. There
+is no updater among them: releases ship as a Homebrew cask, so `brew
+upgrade` updates the app alongside the tools it already installs, rather
+than the app carrying an update framework of its own or living in the Mac
+App Store, whose sandbox forbids everything this app does.
 Versions are pinned by `Package.resolved`; the two exceptions are pinned
 exactly.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -751,6 +751,9 @@ Beyond the one live session, every earlier conversation in a worktree is
 discovered by listing its transcript directory, whoever created it, and
 shown as an inactive session tab with a readable log: Markdown rendered,
 code fences highlighted and tool steps showing the actual command run.
+The same list starts a fresh session in that worktree, since a worktree
+with conversations otherwise only offered to continue one; the form it
+opens is the one an empty worktree shows, with the way back beside it.
 An inactive session resumes either in place or into a fresh worktree and
 branch; in the latter case the transcript is first copied into the new
 working directory's transcript directory, because agents look

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,7 +44,7 @@ flowchart LR
     agents <--> shared
     app -->|"GraphQL and REST via URLSession,<br/>gh CLI for one-shots"| github
     agents -.->|"no credentials by default;<br/>optional read-only deploy key"| github
-    ios -->|"SSH as host user,<br/>then tmux attach"| tmux
+    ios -->|"SSH as sandbox user,<br/>then tmux attach"| tmux
 ```
 
 Boundary facts the design relies on:
@@ -221,11 +221,20 @@ Two visually unmistakable flavours ride that one client:
   prompt redrawn; agent panes ignore it, so an agent's conversation
   can never be cleared from view by a stray shortcut.
 
-Remote access is SSH to the Mac as the host user from an iOS client, then
-`script/attach <session>` (which also works from inside sandbox sessions).
-A session picker for that shell is a later slice: today the session name
-must be known or listed by hand.
-Remote Login must be enabled in macOS settings first. An SSH session is
+Remote access is SSH to the Mac as the sandbox user from an iOS client,
+which lands on the same tmux server the app drives; `script/attach
+<session>` covers the host user and sessions inside the sandbox. No picker
+ships here: [Moshi](https://getmoshi.app) lists the sessions and attaches
+to several at once by itself, and a picker of ours would be a second
+implementation of something the client already does. It needs only the
+socket directory, which sshd sets for that account (`SetEnv
+TMUX_TMPDIR`), since a login from outside the app inherits none of the
+sandbox's own environment.
+
+Remote Login must be enabled in macOS settings first, for that account
+alone: the sandbox user is hidden, so it never appears in the Sharing
+pane's list and is added to `com.apple.access_ssh` with `dseditgroup`
+instead. An SSH session is
 isolated by user permissions rather than sandbox-exec whichever account it
 targets, but attaching connects it to the sandboxed tmux server, so agent
 processes stay confined either way.
@@ -961,7 +970,6 @@ client already guards every call on the model's availability.
 | R7 | the worktree uuid layout is a compatibility choice, not ours | keep byte-compatibility while other tooling uses it; the friendly symlinks isolate everything user-facing; own the layout later |
 | R8 | resume ids depend on transcript internals | record defensively; fall back to a fresh session in the same worktree pointing at the old transcript |
 
-Open questions: the iOS SSH account model (host user with a wrapper versus
-SSH directly to the sandbox user), the default branch template,
+Open questions: the default branch template,
 notification preference granularity and how deep stacked pull request
 support goes in v1.

--- a/App/RootView+Panes.swift
+++ b/App/RootView+Panes.swift
@@ -31,13 +31,16 @@ extension RootView {
                 }
         } else if item.worktree.path == item.worktree.repositoryPath {
             repositoryConversations(for: item)
-        } else if item.pastSessions.isEmpty == false {
+        } else if item.pastSessions.isEmpty == false, startingSession != item.worktree.path {
             worktreeConversations(for: item)
         } else {
             CreateSessionPane(
                 worktree: item.worktree,
                 model: dependencies.dashboard,
                 canResume: dependencies.service.hasRecordedSession(worktreePath: item.worktree.path),
+                // Only a worktree with conversations to go back to
+                // shows the way back.
+                onShowConversations: item.pastSessions.isEmpty ? nil : { startingSession = nil },
                 onResume: { await resumeLatest(in: item) },
                 onStarted: { await sessionStarted() },
             )

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -95,13 +95,16 @@ extension RootView {
         )
     }
 
-    /// One worktree's own past conversations.
+    /// One worktree's own past conversations, which can also start
+    /// a fresh session in the same worktree.
     func worktreeConversations(for item: WorktreeItem) -> some View {
         RepositorySessionsView(
             repository: repository(of: item),
             service: dependencies.service,
             worktreePath: item.worktree.path,
-        ) { await sessionStarted() }
+            onNewSession: { startingSession = item.worktree.path },
+            onResumed: { await sessionStarted() },
+        )
     }
 
     func repository(of item: WorktreeItem) -> Repository {
@@ -138,6 +141,7 @@ extension RootView {
     }
 
     func sessionStarted() async {
+        startingSession = nil
         await dependencies.dashboard.refresh()
     }
 

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -26,9 +26,13 @@ extension RootView {
             .items ?? []
     }
 
+    /// The version rather than the family alone: an agent whose CLI
+    /// was upgraded while it ran goes on running the old one, and
+    /// the number is the only place that shows.
     func sessionTitle(for session: AgentSession) -> String {
         let state = session.status == .running ? "●" : "○"
-        return state + " " + (session.agent?.displayName ?? "Agent")
+        let agent = session.agent?.displayName ?? "Agent"
+        return state + " " + agent + (session.version.map { " " + $0 } ?? "")
     }
 
     var utilityToggleButton: some View {

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -65,6 +65,16 @@ struct RootView: View {
         visitedBrowsers.sorted()
     }
 
+    /// The worktree showing its new session form rather than its
+    /// conversations, which is how a worktree that already has
+    /// conversations starts a fresh session; internal and settable
+    /// because the extension files that build those panes cannot
+    /// see the view's own state.
+    var startingSession: String? {
+        get { startingIn }
+        nonmutating set { startingIn = newValue }
+    }
+
     var body: some View {
         // Plain panes with our own dividers: the navigation split
         // view's floating toggle covered nearby controls and split
@@ -219,6 +229,8 @@ struct RootView: View {
     /// The selected conversation's worktree on the repository page,
     /// nil when none exists; the review surfaces follow it. Internal
     /// so the extension file's tabs can read it.
+    @State private var startingIn: String?
+
     @State private var conversationWorktreePath: String?
 
     /// Whether the launch's one automatic resume has run, so later

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,6 @@
 brew "actionlint"
 brew "gh"
+brew "mosh"
 brew "periphery"
 brew "ripgrep"
 brew "shellcheck"

--- a/README.md
+++ b/README.md
@@ -227,31 +227,7 @@ fi
 Unstable and changing daily. AgentIDE is being designed exclusively
 for [@MikeMcQuaid](https://github.com/MikeMcQuaid)'s personal
 workflow; nothing here promises to suit anyone else's, interfaces
-and behaviour break without notice and there is no support. If it
-fits your workflow anyway, expect sharp edges.
-
-Readme-driven development: this README described the complete intended
-workflow before any of it existed. Slices land in order, each one usable when
-done:
-
-1. Documentation and guardrails: these documents, linting and CI (done)
-2. Skeleton: XcodeGen project, Swift packages and an empty dashboard app
-   (done)
-3. Core loop: create worktrees, launch and attach to sandboxed agents
-   (basic, this pull request)
-4. Monitoring: notifications, unread tracking and resumable sessions
-   (basic, this pull request)
-5. Review: diffs, per-line rejection and editing (basic and plain text
-   until the editor stack lands, this pull request)
-6. Embedded terminal and browser (basic, this pull request)
-7. GitHub pull request creation, dashboards and one-click fixes
-   (basic, this pull request)
-8. Lifecycle: cleanup on merge, past conversation browsing and foreign
-   session discovery (basic, this pull request)
-9. Polish, including checking the Brewfile's tools are installed at
-   startup and offering to install any that are missing from a copy
-   vendored in the app bundle, and releasing as a Homebrew cask so
-   `brew upgrade` keeps the app current
+and behaviour break without notice and there is no support.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for how AgentIDE is designed and
 [AGENTS.md](AGENTS.md) if you are working on this repository, human or agent.

--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ before shipping.
   notes and pull request bodies, and a copied script still runs)
 - **Commits** work the agent forgot to commit, clearly authored as such (so
   nothing is stranded in a worktree and review still sees everything)
-- **Lets** you SSH into any session from an iOS SSH client (so you can steer or
-  add context away from your Mac)
+- **Lets** you SSH into any session from an iOS SSH client, with
+  [Moshi](https://getmoshi.app) the one to reach for: it lists the running
+  agent sessions, attaches to several at once and survives a phone changing
+  network, so nothing is needed on this side beyond Remote Login for the
+  sandbox account (so you can steer or add context away from your Mac)
 
 ### 🔍 Review
 
@@ -244,10 +247,6 @@ done:
 9. Polish, including checking the Brewfile's tools are installed at
    startup and offering to install any that are missing from a copy
    vendored in the app bundle
-10. A terminal session picker for SSH: one command on the sandbox
-    user's `PATH` that lists the running agent sessions and attaches
-    to the chosen one, so steering from an iOS SSH client needs no
-    remembered session names
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for how AgentIDE is designed and
 [AGENTS.md](AGENTS.md) if you are working on this repository, human or agent.

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ before shipping.
   on GitHub (so finished work disappears without ceremony)
 - **Keeps** every conversation a repository has ever run browsable and
   resumable from the repository's own page, whichever worktree it used and
-  even after that worktree is deleted (so tidying up never loses a
-  conversation)
+  even after that worktree is deleted, and starts a fresh session in a
+  worktree from the same list (so tidying up never loses a conversation)
 
 ### 🛟 Resilience
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,10 @@ before shipping.
   user and shared workspace)
 - [`gh`](https://cli.github.com) authenticated as you (it stays with your user;
   agents never see it)
-- [`tmux`](https://github.com/tmux/tmux/wiki) (installed by
-  `script/bootstrap` via the `Brewfile`)
+- [`tmux`](https://github.com/tmux/tmux/wiki) and
+  [`mosh`](https://mosh.org) (installed by `script/bootstrap` via the
+  `Brewfile`; `mosh` is only needed to reach sessions from a phone over a
+  connection that comes and goes)
 - **Xcode** 27 or later (only needed to build from source)
 
 ## 🖥️ Usage

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ open /Applications/AgentIDE.app
   for quick development runs.
 - **Features** land slice by slice (see [Status](#-status)); the app launches
   to an empty dashboard until the first slices fill it.
+- **Updates** come from Homebrew: releases ship as a cask, so `brew upgrade`
+  moves the app on with the rest of your tools. There is no built-in
+  updater, and no Mac App Store build: its sandbox forbids running agents
+  as another user, which is the whole design.
 
 A shell pane runs your login shell, so anything your shell configuration
 exports wins over what the pane was started with. It sets `AGENTIDE=1` and
@@ -246,7 +250,8 @@ done:
    session discovery (basic, this pull request)
 9. Polish, including checking the Brewfile's tools are installed at
    startup and offering to install any that are missing from a copy
-   vendored in the app bundle
+   vendored in the app bundle, and releasing as a Homebrew cask so
+   `brew upgrade` keeps the app current
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for how AgentIDE is designed and
 [AGENTS.md](AGENTS.md) if you are working on this repository, human or agent.

--- a/Sources/AgentIDEData/AgentRunner.swift
+++ b/Sources/AgentIDEData/AgentRunner.swift
@@ -48,6 +48,22 @@ public protocol AgentRunner: Sendable {
 }
 
 extension AgentRunner {
+    /// The version out of a `--version` answer: the CLIs wrap it in
+    /// their own names and notes ("2.1.238 (Claude Code)",
+    /// "codex-cli 0.149.0"), so the first token that looks like a
+    /// version is taken and anything else is no answer at all.
+    func parseVersion(_ output: String) -> String? {
+        output
+            .split(whereSeparator: \.isWhitespace)
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: "()v")) }
+            .first { token in
+                // Two dotted numbers at least, so a bare word in the
+                // CLI's answer is never mistaken for a version.
+                let numbers = token.split(separator: ".").filter { $0.allSatisfy(\.isNumber) }
+                return numbers.count == token.split(separator: ".").count && numbers.count > 1
+            }
+    }
+
     /// Joins a base command, verbatim extra arguments and an
     /// optional initial prompt read from a file at launch time,
     /// inside the sandbox where the shared workspace is readable.

--- a/Sources/AgentIDEData/AppMetadata.swift
+++ b/Sources/AgentIDEData/AppMetadata.swift
@@ -143,6 +143,10 @@ public struct AppMetadata: Codable, Sendable {
     /// The extra agent arguments each session was started with.
     public var arguments: [String: String] = [:]
 
+    /// The CLI version each session started with, which stays what
+    /// it was when the CLI is upgraded under a running session.
+    public var agentVersions: [String: String] = [:]
+
     /// The session name last launched in each worktree, so a closed
     /// session can be resumed without a live tmux session to name it.
     public var sessionsByWorktree: [String: String] = [:]

--- a/Sources/AgentIDEData/GitHubClient+Issues.swift
+++ b/Sources/AgentIDEData/GitHubClient+Issues.swift
@@ -109,7 +109,11 @@ public extension GitHubClient {
             heading: "Work on issue #\(number): \(title)",
             body: body,
             context: context,
-            closing: "Commit your work. Do not push.",
+            // The reference belongs in the commit, not only the pull
+            // request: a commit that closes an issue says so wherever
+            // it is read, and the pull request inherits it anyway.
+            closing: "Commit your work, with \"Fixes #\(number)\" in the commit message."
+                + " Do not push.",
         )
     }
 

--- a/Sources/AgentIDEData/GitHubClient.swift
+++ b/Sources/AgentIDEData/GitHubClient.swift
@@ -179,7 +179,7 @@ public struct GitHubClient: Sendable {
     /// open pull request timed out (HTTP 504) on busy repositories,
     /// so the open scope skips them and rows enrich on selection.
     static let statusFields =
-        "mergeable,reviewDecision,statusCheckRollup,autoMergeRequest,headRefOid,closedAt"
+        "mergeable,reviewDecision,statusCheckRollup,autoMergeRequest,closedAt"
 
     /// A merge commit preferred, then rebase, then squash; an
     /// unreadable answer defaults to the merge commit, the one
@@ -238,7 +238,6 @@ public struct GitHubClient: Sendable {
                 state: row.state ?? "OPEN",
                 isDraft: row.isDraft ?? false,
                 hasAutomerge: row.autoMergeRequest != nil,
-                headOID: row.headRefOid ?? "",
                 author: row.author?.login,
                 body: row.body,
                 closedAt: row.closedAt,
@@ -286,7 +285,6 @@ public struct GitHubClient: Sendable {
         // swiftlint:disable:next discouraged_optional_boolean
         let isDraft: Bool?
         let autoMergeRequest: AutoMergeRow?
-        let headRefOid: String?
         let closedAt: Date?
         // Absent from the JSON when a pull request has no checks.
         // swiftlint:disable:next discouraged_optional_collection

--- a/Sources/AgentIDEData/SessionService+Resuming.swift
+++ b/Sources/AgentIDEData/SessionService+Resuming.swift
@@ -14,9 +14,8 @@ extension SessionService {
     func start(sessionName: String, directory: String, trying commands: [String]) async throws {
         var failure: (any Error)?
         for command in commands {
-            await killTmuxSession(name: sessionName, isHostShell: false)
             do {
-                try await tmux.newSession(name: sessionName, directory: directory, command: command)
+                try await startFresh(sessionName: sessionName, directory: directory, command: command)
             } catch {
                 failure = error
                 continue

--- a/Sources/AgentIDEData/SessionService+Sessions.swift
+++ b/Sources/AgentIDEData/SessionService+Sessions.swift
@@ -64,6 +64,44 @@ public extension SessionService {
         await issueKill(name: name, isHostShell: isHostShell)
     }
 
+    /// Starts a session under a name, replacing whatever holds it
+    /// rather than joining in. tmux is how sessions survive the app
+    /// quitting, crashing or updating; it is not how an agent
+    /// survives its own upgrade, since an agent still running from a
+    /// version whose files have been deleted fails in ways that read
+    /// as the app's fault. Anything the user asks for by hand comes
+    /// through here and gets a new process.
+    internal func startFresh(sessionName: String, directory: String, command: String) async throws {
+        await killTmuxSession(name: sessionName, isHostShell: false)
+        try await tmux.newSession(name: sessionName, directory: directory, command: command)
+        await recordAgentVersion(sessionName: sessionName)
+    }
+
+    /// Asks the agent's CLI what version it is and remembers it
+    /// under the session name, so the pane says which version it is
+    /// running rather than which one is installed now: a session
+    /// that outlived an upgrade is the one worth spotting.
+    internal func recordAgentVersion(sessionName: String) async {
+        guard let agent = agentKind(of: sessionName) else {
+            return
+        }
+
+        let argv = launcher.command(
+            payload: agent.rawValue + " --version </dev/null",
+            initialDirectory: launcher.sharedWorkspace,
+            sessionID: UUID().uuidString,
+            sessionName: "agentide-version",
+        )
+        let result = try? await processes.run(argv, workingDirectory: nil, environment: [:])
+        guard let version = runner(for: agent).parseVersion(result?.standardOutput ?? "") else {
+            return
+        }
+
+        var metadata = store.load()
+        metadata.agentVersions[sessionName] = version
+        store.save(metadata)
+    }
+
     /// Marks a worktree viewed: clears its unread state, including a
     /// manual mark.
     func markSeen(worktreePath: String) {
@@ -243,8 +281,8 @@ public extension SessionService {
 
         let agentRunner = runner(for: past.agent)
         copyTranscript(past, intoWorktree: worktreePath, using: agentRunner)
-        try await tmux.newSession(
-            name: sessionName,
+        try await startFresh(
+            sessionName: sessionName,
             directory: worktreePath,
             command: agentRunner.resumeCommand(resumeID: past.resumeID, extraArguments: ""),
         )

--- a/Sources/AgentIDEData/SessionService.swift
+++ b/Sources/AgentIDEData/SessionService.swift
@@ -222,8 +222,8 @@ public struct SessionService: Sendable {
         // raced the agent's terminal setup, which flushed pending
         // input and lost the prompt (Codex reliably, Claude Code
         // sometimes).
-        try await tmux.newSession(
-            name: sessionName,
+        try await startFresh(
+            sessionName: sessionName,
             directory: slot.path,
             command: runner(for: agent).launchCommand(extraArguments: arguments, promptFile: promptFile),
         )
@@ -312,6 +312,7 @@ public struct SessionService: Sendable {
                 agent: agentKind(of: pane.sessionName),
                 status: pane.isDead ? .finished(pane.exitStatus) : .running,
                 workingDirectory: pane.currentPath,
+                version: metadata.agentVersions[pane.sessionName],
             )
         }
         let past = pastSessions(of: worktree, liveSession: session)

--- a/Sources/AgentIDEData/TmuxClient.swift
+++ b/Sources/AgentIDEData/TmuxClient.swift
@@ -85,16 +85,21 @@ public struct TmuxClient: Sendable {
         }
     }
 
-    /// Creates a detached session running a command. `remain-on-exit`
-    /// comes from the server config so even an agent that exits
-    /// immediately leaves an inspectable dead pane. The pane's
-    /// `INITIAL_DIR` is pinned because the sandbox's zshenv changes
-    /// directory to it, which would otherwise send agents to the
-    /// server's directory instead of their worktree. The first call
-    /// also births the server inside the sandbox.
+    /// Creates a detached session running a command. Deliberately
+    /// not `-A`: attach-or-create silently hands back whatever
+    /// already holds the name, so a session meant to start a fresh
+    /// agent would go on talking to the old process, which after a
+    /// CLI upgrade is one whose files have been deleted underneath
+    /// it. Callers kill the name first and a clash is an error.
+    /// `remain-on-exit` comes from the server config so even an
+    /// agent that exits immediately leaves an inspectable dead pane.
+    /// The pane's `INITIAL_DIR` is pinned because the sandbox's
+    /// zshenv changes directory to it, which would otherwise send
+    /// agents to the server's directory instead of their worktree.
+    /// The first call also births the server inside the sandbox.
     public func newSession(name: String, directory: String, command: String) async throws {
         try await tmux([
-            "new-session", "-A", "-d",
+            "new-session", "-d",
             "-s", name,
             "-c", directory,
             "-e", "AGENTIDE_SESSION=" + name,

--- a/Sources/AgentIDEDomain/AgentSession.swift
+++ b/Sources/AgentIDEDomain/AgentSession.swift
@@ -20,7 +20,9 @@ public struct AgentSession: Identifiable, Hashable, Sendable {
         agent: AgentKind?,
         status: SessionStatus,
         workingDirectory: String?,
+        version: String? = nil,
     ) {
+        self.version = version
         self.name = name
         self.agent = agent
         self.status = status
@@ -40,6 +42,11 @@ public struct AgentSession: Identifiable, Hashable, Sendable {
 
     /// The pane's current working directory, when known.
     public let workingDirectory: String?
+
+    /// The agent CLI version this session started with, when it was
+    /// recorded; upgrading the CLI does not change it, which is the
+    /// point of showing it.
+    public let version: String?
 
     /// The stable identity, the tmux session name.
     public var id: String {

--- a/Sources/AgentIDEDomain/PullRequestSummary.swift
+++ b/Sources/AgentIDEDomain/PullRequestSummary.swift
@@ -21,7 +21,6 @@ public struct PullRequestSummary: Identifiable, Hashable, Sendable, Codable {
         state: String = "OPEN",
         isDraft: Bool = false,
         hasAutomerge: Bool = false,
-        headOID: String = "",
         author: String? = nil,
         body: String? = nil,
         unresolvedComments: Int = 0,
@@ -40,7 +39,6 @@ public struct PullRequestSummary: Identifiable, Hashable, Sendable, Codable {
         self.state = state
         self.isDraft = isDraft
         self.hasAutomerge = hasAutomerge
-        self.headOID = headOID
         self.author = author
         self.body = body
         self.unresolvedComments = unresolvedComments
@@ -86,9 +84,6 @@ public struct PullRequestSummary: Identifiable, Hashable, Sendable, Codable {
     /// Whether automerge is enabled.
     public let hasAutomerge: Bool
 
-    /// The head commit the states describe.
-    public let headOID: String
-
     /// The author's GitHub login; optional so summaries cached by
     /// earlier releases still decode.
     public let author: String?
@@ -100,8 +95,10 @@ public struct PullRequestSummary: Identifiable, Hashable, Sendable, Codable {
     /// Whether it is in a merge queue right now. A repository
     /// having a queue, or a pull request being set to merge
     /// automatically, is not the same thing: only this says the
-    /// queue is what happens next.
-    public let isQueued: Bool
+    /// queue is what happens next. Settable, with the conversation
+    /// count, because both are stamped onto a fetched summary from
+    /// what the app already knows.
+    public var isQueued: Bool
 
     /// When it was merged or closed, nil while open. Branch names
     /// are reused, so a long-finished pull request matching a
@@ -113,7 +110,7 @@ public struct PullRequestSummary: Identifiable, Hashable, Sendable, Codable {
     /// query cannot answer: GitHub only counts them through GraphQL,
     /// so this stays zero until the pull request is looked at and
     /// the count is remembered.
-    public let unresolvedComments: Int
+    public var unresolvedComments: Int
 
     /// The pull request's checks page.
     public var checksPageURL: String {

--- a/Sources/DashboardFeature/CreateSessionPane.swift
+++ b/Sources/DashboardFeature/CreateSessionPane.swift
@@ -8,16 +8,19 @@ public struct CreateSessionPane: View {
     // MARK: Lifecycle
 
     /// Creates the pane; `canResume` offers `onResume` for the
-    /// worktree's most recent conversation and `onStarted` runs
-    /// after a successful launch.
+    /// worktree's most recent conversation, `onStarted` runs after a
+    /// successful launch and `onShowConversations`, when given, goes
+    /// back to the list this form was reached from.
     @preconcurrency
     public init(
         worktree: Worktree,
         model: DashboardModel,
         canResume: Bool,
+        onShowConversations: (@MainActor () -> Void)? = nil,
         onResume: @escaping @MainActor () async -> Void,
         onStarted: @escaping @MainActor () async -> Void,
     ) {
+        self.onShowConversations = onShowConversations
         self.worktree = worktree
         self.model = model
         self.canResume = canResume
@@ -38,6 +41,11 @@ public struct CreateSessionPane: View {
                     ProgressView().controlSize(.small)
                 }
                 Spacer()
+                if let onShowConversations {
+                    Button("Conversations", action: onShowConversations)
+                        .controlSize(.small)
+                        .hoverHelp("Back to this worktree's past conversations")
+                }
                 if canResume {
                     Button("Resume last session") { resume() }
                         .controlSize(.small)
@@ -66,6 +74,7 @@ public struct CreateSessionPane: View {
     /// Instant feedback while a resume launches.
     @State private var isResuming = false
 
+    private let onShowConversations: (@MainActor () -> Void)?
     private let worktree: Worktree
     private let model: DashboardModel
     private let canResume: Bool

--- a/Sources/DashboardFeature/DashboardModel+PullRequests.swift
+++ b/Sources/DashboardFeature/DashboardModel+PullRequests.swift
@@ -67,29 +67,13 @@ extension DashboardModel {
         let threads = store.load().threadsCache[key]?.threads ?? []
         let unresolved = threads.count { $0.isResolved == false }
         let queued = queuedNumbers[repositoryPath]?.contains(summary.number) ?? false
-        guard unresolved != summary.unresolvedComments || queued != summary.isQueued else {
-            return summary
-        }
-
-        return PullRequestSummary(
-            number: summary.number,
-            title: summary.title,
-            url: summary.url,
-            headBranch: summary.headBranch,
-            mergeable: summary.mergeable,
-            reviewDecision: summary.reviewDecision,
-            checks: summary.checks,
-            failingCheckLinks: summary.failingCheckLinks,
-            baseBranch: summary.baseBranch,
-            state: summary.state,
-            isDraft: summary.isDraft,
-            hasAutomerge: summary.hasAutomerge,
-            headOID: summary.headOID,
-            author: summary.author,
-            body: summary.body,
-            unresolvedComments: unresolved,
-            isQueued: queued,
-        )
+        // Copied rather than rebuilt field by field: a rebuild
+        // silently drops whatever field it forgets, as it did with
+        // the date a pull request closed.
+        var stamped = summary
+        stamped.unresolvedComments = unresolved
+        stamped.isQueued = queued
+        return stamped
     }
 
     /// One narrow query per due worktree branch instead of whole

--- a/Sources/ReviewFeature/DiffFileView.swift
+++ b/Sources/ReviewFeature/DiffFileView.swift
@@ -128,30 +128,40 @@ struct DiffFileView: View {
         }
     }
 
-    /// Numbers and markers sit in a tappable gutter while the code
-    /// itself is one selectable text block, so dragging copies
-    /// several lines without picking up `-`/`+` or line numbers.
+    /// Numbers and markers sit in a tappable gutter beside each
+    /// line, which wraps to the pane's width as the editor's does:
+    /// a long line is read rather than scrolled sideways to. Each
+    /// line is its own text, so Copy hunk rather than a drag is
+    /// what takes several lines at once, markers and numbers left
+    /// behind.
     private func hunkView(hunkIndex: Int, hunk: DiffHunk) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("@@ -\(hunk.oldStart) +\(hunk.newStart) @@")
                 .font(.caption.monospaced())
                 .foregroundStyle(.secondary)
                 .textSelection(.enabled)
-            HStack(alignment: .top, spacing: Self.gutterSpacing) {
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(numbered(hunk).enumerated()), id: \.offset) { lineIndex, entry in
-                        gutterRow(hunkIndex: hunkIndex, lineIndex: lineIndex, entry: entry)
-                    }
-                }
-                .hoverHelp("Click a changed line's number to select it for rejection")
-                ScrollView(.horizontal, showsIndicators: false) {
-                    Text(hunkText(hunk))
+            ForEach(Array(numbered(hunk).enumerated()), id: \.offset) { lineIndex, entry in
+                HStack(alignment: .top, spacing: Self.gutterSpacing) {
+                    gutterRow(hunkIndex: hunkIndex, lineIndex: lineIndex, entry: entry)
+                        .hoverHelp("Click a changed line's number to select it for rejection")
+                    Text(lineText(entry.line))
                         .font(CodeStyle.font)
                         .textSelection(.enabled)
-                        .fixedSize(horizontal: true, vertical: false)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
         }
+        .contextMenu { copyHunkAction(hunk) }
+    }
+
+    /// Copying a whole hunk, which wrapping took from dragging: the
+    /// code alone, so it pastes as code.
+    private func copyHunkAction(_ hunk: DiffHunk) -> some View {
+        Button("Copy hunk") {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(String(hunkText(hunk).characters), forType: .string)
+        }
+        .hoverHelp("Copy this hunk's lines without their numbers or change markers")
     }
 
     /// One gutter line: numbers and the change marker, tappable on

--- a/Sources/ReviewFeature/ReviewFooterView.swift
+++ b/Sources/ReviewFeature/ReviewFooterView.swift
@@ -184,11 +184,13 @@ struct ReviewFooterView: View {
         if model.scope == .branch || model.scope == .upstream {
             VStack(alignment: .leading, spacing: Self.commitListSpacing) {
                 Text("Commits under review").font(.headline)
-                ScrollView([.vertical, .horizontal]) {
+                ScrollView(.vertical) {
                     // One text block, not a row per commit: dragging
                     // then selects across lines, so hashes and whole
                     // ranges copy. Decorations name where each commit
-                    // sits in the local and remote log.
+                    // sits in the local and remote log. Long subjects
+                    // wrap to the pane, as the editor and the diff do,
+                    // rather than hiding off to the right.
                     // The listing always carries the base commit as
                     // its final row, so one row means no commits of
                     // the branch's own.
@@ -200,7 +202,6 @@ struct ReviewFooterView: View {
                         Text(styledCommits)
                             .font(.caption.monospaced())
                             .textSelection(.enabled)
-                            .fixedSize(horizontal: true, vertical: false)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }

--- a/Sources/SessionFeature/RepositorySessionsView.swift
+++ b/Sources/SessionFeature/RepositorySessionsView.swift
@@ -15,16 +15,20 @@ public struct RepositorySessionsView: View {
     /// worktree,
     /// `onResumed` runs after a resume launches and
     /// `onWorktreeFocus` reports the selected conversation's still
-    /// existing worktree, so other panes can follow along.
+    /// existing worktree, so other panes can follow along, and
+    /// `onNewSession`, when given, offers a fresh session in the
+    /// worktree the list is scoped to.
     @preconcurrency
     public init(
         repository: Repository,
         service: SessionService,
         worktreePath: String? = nil,
         onWorktreeFocus: (@MainActor (String?) -> Void)? = nil,
+        onNewSession: (@MainActor () -> Void)? = nil,
         onResumed: @escaping @MainActor () async -> Void,
     ) {
         self.onWorktreeFocus = onWorktreeFocus
+        self.onNewSession = onNewSession
         self.onResumed = onResumed
         identity = repository.id + "#" + (worktreePath ?? "")
         makeModel = {
@@ -91,6 +95,7 @@ public struct RepositorySessionsView: View {
 
     private let identity: String
     private let onWorktreeFocus: (@MainActor (String?) -> Void)?
+    private let onNewSession: (@MainActor () -> Void)?
     private let onResumed: @MainActor () async -> Void
     private let makeModel: () -> RepositorySessionsModel
 
@@ -103,6 +108,14 @@ public struct RepositorySessionsView: View {
             )
             .font(.subheadline.weight(.semibold))
             Spacer()
+            // Starting fresh comes before continuing something, in
+            // the order the two are read; resuming stays the
+            // prominent one, since it is why the list is here.
+            if let onNewSession {
+                Button("New session", action: onNewSession)
+                    .controlSize(.small)
+                    .hoverHelp("Start a fresh agent session in this worktree instead of continuing one")
+            }
             // One resume button: in place when the conversation's
             // worktree still exists, into a fresh worktree only when
             // it is gone and that is all that can be done.

--- a/Tests/AgentIDEDataTests/AgentRunnerTests.swift
+++ b/Tests/AgentIDEDataTests/AgentRunnerTests.swift
@@ -1,9 +1,19 @@
-import AgentIDEData
+@testable import AgentIDEData
 import Testing
 
 /// Exercises the launch command assembly the prompt delivery relies
 /// on, the successor to the deleted paste-delivery coverage.
 struct AgentRunnerTests {
+    @Test
+    func `versions come out of whatever the CLI wraps them in`() {
+        #expect(ClaudeCodeRunner().parseVersion("2.1.238 (Claude Code)") == "2.1.238")
+        #expect(CodexRunner().parseVersion("codex-cli 0.149.0\n") == "0.149.0")
+        #expect(CodexRunner().parseVersion("codex-cli v1.0\n") == "1.0")
+        // Nothing version-shaped is no answer, never a stray word.
+        #expect(ClaudeCodeRunner().parseVersion("command not found") == nil)
+        #expect(ClaudeCodeRunner().parseVersion("") == nil)
+    }
+
     @Test
     func `launch commands embed the prompt file shell-quoted`() {
         let command = ClaudeCodeRunner().launchCommand(

--- a/Tests/AgentIDEDataTests/GitHubClientTests.swift
+++ b/Tests/AgentIDEDataTests/GitHubClientTests.swift
@@ -109,6 +109,8 @@ struct GitHubClientTests {
         #expect(issue.contains("Steps"))
         #expect(issue.contains("Be careful"))
         #expect(issue.contains("Do not push."))
+        // The commit closes the issue, wherever the commit is read.
+        #expect(issue.contains("\"Fixes #3\" in the commit message"))
 
         let pullRequest = GitHubClient.pullRequestPrompt(number: 4, title: "Fix", body: "", context: "")
         #expect(pullRequest.contains("pull request #4: Fix"))

--- a/Tests/AgentIDEDataTests/TestSupport.swift
+++ b/Tests/AgentIDEDataTests/TestSupport.swift
@@ -8,21 +8,20 @@ import Foundation
 /// Shared helpers for integration tests that exercise real git, tmux
 /// and filesystem behaviour in isolated temporary locations.
 enum TestSupport {
+    // MARK: Internal
+
     /// A fresh temporary directory, fully resolved via `realpath` so
     /// its path matches what git and tmux report for it.
     static func temporaryDirectory(_ label: String) throws -> String {
-        let path = "/tmp/agentide-" + label + "-" + UUID().uuidString
-        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
-        return canonical(path)
+        try make(label)
     }
 
-    /// A short-lived, resolved tmux socket directory under `/tmp`; the
-    /// deep temp hierarchy overruns the 104-byte Unix socket path
-    /// limit.
+    /// A resolved tmux socket directory, named as briefly as it can
+    /// be: a Unix socket path cannot exceed 104 bytes, and the
+    /// user's own temporary directory, this root, the name and the
+    /// `tmux-<uid>/default` tmux appends come to 92 of them.
     static func socketDirectory() throws -> String {
-        let path = "/tmp/av-" + UUID().uuidString
-        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
-        return canonical(path)
+        try make("s")
     }
 
     /// The fully resolved path, matching git and tmux output.
@@ -129,6 +128,78 @@ enum TestSupport {
             try? await Task.sleep(for: .milliseconds(100))
         }
         return await condition()
+    }
+
+    // MARK: Private
+
+    /// Every test's scratch under one swept, gitignored directory in
+    /// the checkout, so what a run leaves behind is visible where the
+    /// work is rather than loose in a shared temporary directory: a
+    /// test that crashes cannot tidy up after itself, and strays were
+    /// piling up in `/tmp` a run at a time. A checkout far enough
+    /// down the filesystem to overrun a tmux socket's 104-byte path
+    /// falls back to this user's own temporary directory.
+    private static let root: String = {
+        let candidates = [checkoutRoot + "/" + scratchName, NSTemporaryDirectory() + scratchName]
+        let path = candidates.first { $0.count + socketBudget <= socketLimit } ?? candidates[1]
+        try? FileManager.default.createDirectory(
+            atPath: path,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700],
+        )
+        sweep(path)
+        return path
+    }()
+
+    /// The checkout this file belongs to: `Tests/<target>/` up.
+    private static let checkoutRoot = URL(filePath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .path()
+
+    private static let scratchName = ".test-scratch"
+
+    /// What a socket path needs beyond the root: `/s-XXXXXXXX` and
+    /// the `/tmux-<uid>/default` tmux appends inside it.
+    private static let socketBudget = 30
+
+    /// The Unix socket path limit, which a scratch root has to leave
+    /// room inside.
+    private static let socketLimit = 104
+
+    /// How long a leftover is left alone: long enough that another
+    /// test process still using its scratch is never robbed of it,
+    /// short enough that nothing survives the next run but the run
+    /// before it.
+    private static let staleSeconds: TimeInterval = 600
+
+    /// Enough of a UUID to be unique within a run, short enough to
+    /// keep socket paths inside their limit.
+    private static let idLength = 8
+
+    /// Creates a scratch directory under the swept root, named for
+    /// what it holds. The name is short so socket paths stay inside
+    /// their length limit.
+    private static func make(_ label: String) throws -> String {
+        let path = root + "/" + label + "-" + String(UUID().uuidString.prefix(Self.idLength))
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        return canonical(path)
+    }
+
+    /// Removes what earlier runs left behind.
+    private static func sweep(_ path: String) {
+        let manager = FileManager.default
+        let cutoff = Date().addingTimeInterval(-staleSeconds)
+        for name in (try? manager.contentsOfDirectory(atPath: path)) ?? [] {
+            let entry = path + "/" + name
+            let attributes = try? manager.attributesOfItem(atPath: entry)
+            guard let modified = attributes?[.modificationDate] as? Date, modified < cutoff else {
+                continue
+            }
+
+            try? manager.removeItem(atPath: entry)
+        }
     }
 }
 

--- a/Tests/AgentIDEDataTests/TmuxClientIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/TmuxClientIntegrationTests.swift
@@ -63,6 +63,31 @@ struct TmuxClientIntegrationTests {
     }
 
     @Test
+    func `an agent session refuses to join the one already holding its name`() async throws {
+        let (tmux, socket) = try TestSupport.makeTmuxClient()
+        let directory = try TestSupport.temporaryDirectory("fresh")
+        defer { TestSupport.killServerSync(socketDirectory: socket) }
+
+        try await tmux.newSession(name: "agentide--r--fresh--codex", directory: directory, command: "sleep 20")
+        let running = await TestSupport.poll {
+            let panes = await (try? tmux.panes()) ?? []
+            return panes.contains { $0.sessionName == "agentide--r--fresh--codex" && $0.isDead == false }
+        }
+        #expect(running)
+
+        // Attach-or-create would hand back the running agent, which
+        // after a CLI upgrade is one whose files have gone. Starting
+        // fresh means killing the name first, so a clash is a fault.
+        await #expect(throws: (any Error).self) {
+            try await tmux.newSession(
+                name: "agentide--r--fresh--codex",
+                directory: directory,
+                command: "sleep 20",
+            )
+        }
+    }
+
+    @Test
     func `finished panes keep their exit status`() async throws {
         let (tmux, socket) = try TestSupport.makeTmuxClient()
         let directory = try TestSupport.temporaryDirectory("dead")


### PR DESCRIPTION
- Wrap long lines in editor and commit listings to preserve context and readability  
- Preserve summary data by copying fields instead of rebuilding them  
- Enable fresh session creation from empty conversation lists with clean interface  
- Replace old session joins with new agent starts that record CLI and tab info  
- Store temporary test files in git-ignored scratch with automatic cleanup and issue linking  
- Add mosh and required deps for phone connectivity without app-level requirements  
- Route remote access via iOS client and SSH on shared tmux server without exposing account  
- Deploy updates via Homebrew cask to avoid external update tools and sandbox conflicts