### PR TITLE
Open a link asked for twice, and ask about the checkout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,9 @@ Hard-won on macOS 27 beta; check before assuming they expired.
   light fields only and enrich one pull request on selection.
 - `@AppStorage` keys are the cross-module signal bus (utility tab
   name, finder mode and focus, browser address); tabs travel by
-  name, never index, so reordering cannot repoint them.
+  name, never index, so reordering cannot repoint them. A repeated
+  request needs a counter beside its value: writing the same string
+  publishes no change, so asking twice for one page did nothing.
 - Octicon SVG imagesets in `App/Assets.xcassets` render as template
   images; `ChecksStyle` maps GitHub states to them.
 - `cannot execute tool 'metal' due to missing Metal Toolchain` breaks

--- a/App/UtilityTabStrip.swift
+++ b/App/UtilityTabStrip.swift
@@ -23,7 +23,7 @@ struct UtilityTabStrip: View {
     private static let selectedOpacity = 0.25
     private static let hoverOpacity = 0.08
 
-    @AppStorage("utilityTab")
+    @AppStorage(UtilityTabTarget.key)
     private var utilityTab = UtilityTab.review.rawValue
 
     @State private var hovered: String?

--- a/Sources/DashboardFeature/DashboardModel+PullRequests.swift
+++ b/Sources/DashboardFeature/DashboardModel+PullRequests.swift
@@ -94,7 +94,12 @@ extension DashboardModel {
             // branch probes for a recovery and the rest wait; the
             // repository a refresh was asked for keeps asking.
             let ridesOutOutage = ServiceStatus.shared.isUnavailable && repositoryPath != group.repository.path
-            for item in group.items.dropFirst() {
+            // The repository's own checkout is asked about too when
+            // it is off its default branch: work done there has a
+            // pull request like any other, and skipping the row left
+            // it blank however often the poll came round.
+            let rows = group.items.filter { $0.worktree.path != group.repository.path || isOffDefaultBranch($0) }
+            for item in rows {
                 let key = item.worktree.repositoryPath + "#" + item.worktree.branch
                 if let due = nextPullRequestFetch[key], due > Date() {
                     continue

--- a/Sources/PRFeature/PullRequestCreateForm.swift
+++ b/Sources/PRFeature/PullRequestCreateForm.swift
@@ -46,7 +46,7 @@ struct PullRequestCreateForm: View {
     @State private var isGenerating = false
 
     /// The cross-module signal that switches the utility pane's tab.
-    @AppStorage("utilityTab")
+    @AppStorage(UtilityTabTarget.key)
     private var utilityTab = ""
 
     /// The repository's template with its tick-all shortcut.

--- a/Sources/PRFeature/PullRequestListView.swift
+++ b/Sources/PRFeature/PullRequestListView.swift
@@ -148,7 +148,7 @@ struct PullRequestFooterView: View {
     private static let padding: CGFloat = 8
 
     /// The cross-module signal that switches the utility pane's tab.
-    @AppStorage("utilityTab")
+    @AppStorage(UtilityTabTarget.key)
     private var utilityTab = ""
 
     /// Sidebar-style: how far the branch sits behind its base.

--- a/Sources/ReviewFeature/DiffFileView.swift
+++ b/Sources/ReviewFeature/DiffFileView.swift
@@ -81,6 +81,14 @@ struct DiffFileView: View {
         .padding(.bottom, isCollapsed ? Self.collapsedPadding : Self.filePadding)
     }
 
+    /// A hunk's lines as the file holds them: the displayed text
+    /// stands a space in for a blank line so its change colour has
+    /// something to paint, and copying that would put a space where
+    /// the file has nothing at all.
+    static func copyText(of hunk: DiffHunk) -> String {
+        hunk.lines.map(\.content).joined(separator: "\n")
+    }
+
     // MARK: Private
 
     private static let collapsedPadding: CGFloat = 1
@@ -159,7 +167,7 @@ struct DiffFileView: View {
     private func copyHunkAction(_ hunk: DiffHunk) -> some View {
         Button("Copy hunk") {
             NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(String(hunkText(hunk).characters), forType: .string)
+            NSPasteboard.general.setString(Self.copyText(of: hunk), forType: .string)
         }
         .hoverHelp("Copy this hunk's lines without their numbers or change markers")
     }
@@ -267,20 +275,6 @@ struct DiffFileView: View {
 
             content[from ..< upTo].backgroundColor = .yellow.opacity(Self.foundOpacity)
         }
-    }
-
-    /// The hunk's code as one attributed string: syntax colours per
-    /// token and change backgrounds per line, markers excluded so
-    /// copies paste cleanly.
-    private func hunkText(_ hunk: DiffHunk) -> AttributedString {
-        var result = AttributedString()
-        for (index, line) in hunk.lines.enumerated() {
-            result += lineText(line)
-            if index < hunk.lines.count - 1 {
-                result += AttributedString("\n")
-            }
-        }
-        return result
     }
 
     /// One line's text: a whitespace tint covers tabs and the

--- a/Sources/ReviewFeature/ReviewFooterView.swift
+++ b/Sources/ReviewFeature/ReviewFooterView.swift
@@ -56,7 +56,7 @@ struct ReviewFooterView: View {
     private static let resizeHandleHeight: CGFloat = 7
 
     /// The cross-module signal that switches the utility pane's tab.
-    @AppStorage("utilityTab")
+    @AppStorage(UtilityTabTarget.key)
     private var utilityTab = ""
 
     /// The footer's height, dragged by the handle above it and

--- a/Sources/SessionFeature/BrowserView.swift
+++ b/Sources/SessionFeature/BrowserView.swift
@@ -70,11 +70,17 @@ public struct BrowserView: View {
             }
         }
         // An address asked for from elsewhere goes to the pane on
-        // screen, never to the ones loaded behind it.
-        .onChange(of: requestedAddress) {
-            if isActive, requestedAddress.isEmpty == false {
-                address = requestedAddress
+        // screen, never to the ones loaded behind it. The count is
+        // what changes: the same page asked for twice writes the
+        // same address, and the pane would sit on whatever it had
+        // wandered to since.
+        .onChange(of: requestedCount) {
+            guard isActive, requestedAddress.isEmpty == false else {
+                return
             }
+
+            address = requestedAddress
+            load()
         }
         .onDisappear { BrowserPanes.shared.remove(worktreePath: worktreePath) }
     }
@@ -87,6 +93,8 @@ public struct BrowserView: View {
     /// own address, stored as path-address lines.
     @AppStorage("browserAddress")
     private var requestedAddress = ""
+    @AppStorage("browserRequest")
+    private var requestedCount = 0
     @AppStorage("browserAddresses")
     private var storedAddresses = ""
 

--- a/Sources/SessionFeature/BrowserView.swift
+++ b/Sources/SessionFeature/BrowserView.swift
@@ -91,9 +91,9 @@ public struct BrowserView: View {
 
     /// The address bus other panes write to, and every worktree's
     /// own address, stored as path-address lines.
-    @AppStorage("browserAddress")
+    @AppStorage(UtilityTabTarget.addressKey)
     private var requestedAddress = ""
-    @AppStorage("browserRequest")
+    @AppStorage(UtilityTabTarget.requestKey)
     private var requestedCount = 0
     @AppStorage("browserAddresses")
     private var storedAddresses = ""

--- a/Sources/TerminalUI/LinkOpener.swift
+++ b/Sources/TerminalUI/LinkOpener.swift
@@ -18,6 +18,17 @@ public enum UtilityTabTarget {
     /// The embedded browser tab.
     public static let browser = "browser"
 
+    /// The address the browser is being asked for, and the count of
+    /// times one has been asked for. The count is what a pane
+    /// watches: asking twice for the same page writes the same
+    /// string, which publishes no change, so a link clicked after
+    /// the browser had wandered off elsewhere did nothing at all.
+    public static let addressKey = "browserAddress"
+
+    /// The count of address requests, which is what changes when the
+    /// same page is asked for twice.
+    public static let requestKey = "browserRequest"
+
     /// The editor tab.
     public static let editor = "editor"
 
@@ -39,8 +50,10 @@ public enum LinkOpener {
                 NSWorkspace.shared.open(url)
             }
         } else {
-            UserDefaults.standard.set(address, forKey: "browserAddress")
-            UserDefaults.standard.set(UtilityTabTarget.browser, forKey: UtilityTabTarget.key)
+            let defaults = UserDefaults.standard
+            defaults.set(address, forKey: UtilityTabTarget.addressKey)
+            defaults.set(defaults.integer(forKey: UtilityTabTarget.requestKey) + 1, forKey: UtilityTabTarget.requestKey)
+            defaults.set(UtilityTabTarget.browser, forKey: UtilityTabTarget.key)
         }
     }
 }

--- a/Tests/ReviewFeatureTests/ReviewModelTests.swift
+++ b/Tests/ReviewFeatureTests/ReviewModelTests.swift
@@ -1,4 +1,5 @@
 import AgentIDEData
+import AgentIDEDomain
 import Foundation
 @testable import ReviewFeature
 import Testing
@@ -156,5 +157,27 @@ struct ReviewModelTests {
             workingDirectory: directory,
             environment: [:],
         )
+    }
+}
+
+// MARK: - HunkCopyTests
+
+/// Pins what a copied hunk holds: the file's own text, since the
+/// displayed text stands a space in for a blank line so its change
+/// colour has something to paint.
+@MainActor
+struct HunkCopyTests {
+    @Test
+    func `a copied hunk keeps blank lines blank`() {
+        let hunk = DiffHunk(
+            oldStart: 1,
+            newStart: 1,
+            lines: [
+                DiffLine(kind: .context, content: "let a = 1"),
+                DiffLine(kind: .addition, content: ""),
+                DiffLine(kind: .addition, content: "let b = 2"),
+            ],
+        )
+        #expect(DiffFileView.copyText(of: hunk) == "let a = 1\n\nlet b = 2")
     }
 }


### PR DESCRIPTION
- clicking a pull request number a second time wrote the same address, which publishes no change, so the pane flipped to the browser and sat on wherever it had wandered; a counter beside the address is what a pane watches now
- the poll skipped the repository's own checkout, so a branch worked on there never had its pull request fetched; it is asked about whenever it is off its default branch
- a copied hunk carries the file's own text: the displayed text stands a space in for a blank line so its change colour has something to paint