### PR TITLE
Fix fullscreen frame handling and display blacking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,16 @@ Hard-won on macOS 27 beta; check before assuming they expired.
   has no request API. Codex's command host is the known case, so
   `Quarantine` clears the attribute from the agent's install before
   every launch.
+- A fullscreen space sent to another display leaves the display it
+  came from black until a space switch repaints it. This is macOS's
+  vacated space, not a pane of ours: the app owns exactly one window
+  (one `WindowGroup`, no panels, no `collectionBehavior` changes),
+  and `WindowConfigurator` says so in the messages pane when a
+  settled fullscreen window's frame does not match its screen, so a
+  silent Messages tab means the window is correctly framed on its
+  new display and is drawing nothing on the old one. Setting the
+  frame of a window in a fullscreen space to chase this blacks out
+  both displays until the app is killed; do not try it.
 - herdr servers and their workspaces outlive the app, so changes to
   launch commands, workspace shapes or server behaviour often need
   the running `agentide` or `agentide-dev` herdr session stopped

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -583,7 +583,22 @@ long as the thing inside them should live, not for as long as it is visible:
    covers fullscreen too: the frame is set to the screen the window is now
    on, and a redraw asked for, on entering and leaving fullscreen, on
    changing screen and on any change to the displays themselves, each
-   fitted twice since those transitions animate. A window left with no
+   fitted twice since those transitions animate. Only the display the
+   window was on going away sets a fullscreen frame by hand, though:
+   AppKit owns the frame of a window in a fullscreen space, and setting it
+   while a space merely moved between two live displays left both screens
+   black until the app was killed. Screen parameters change for
+   resolution, scaling and arrangement too, and a fullscreen space is live
+   through all of those, so the display the window was last seen on is
+   remembered by its `CGDirectDisplayID` and the manual path is taken only
+   when that display is absent from `NSScreen.screens`. Such a move posts no screen-parameter change and does not
+   always announce the screen change, so the window's own move is watched
+   as well, in fullscreen only (fitting a dragged window would stop it
+   being pulled past a screen edge on purpose), and all it does is lay
+   the content out again for the size AppKit gave it. A settled
+   fullscreen window whose frame still does not match its screen says so
+   once in the messages pane, since that frame is the one fact a window
+   needing fullscreen toggled by hand can offer. A window left with no
    screen at all leaves fullscreen, and then
    fits its frame back inside whichever screen it lands on, and the panes
    fit the width it ends up with: the utility pane narrows first, then the

--- a/App/WindowConfigurator.swift
+++ b/App/WindowConfigurator.swift
@@ -1,5 +1,8 @@
 import AppKit
 import SwiftUI
+import TerminalUI
+
+// MARK: - WindowConfigurator
 
 /// Configures the hosting window directly: a transparent, titleless
 /// titlebar over full-size content, with the standard window buttons
@@ -54,6 +57,7 @@ struct WindowConfigurator: NSViewRepresentable {
                 window.standardWindowButton(kind)?.isHidden = false
             }
             restoreFrame(of: window)
+            rememberDisplay()
         }
 
         // MARK: Private
@@ -66,6 +70,28 @@ struct WindowConfigurator: NSViewRepresentable {
         private static let settleSeconds = 0.6
 
         private var observers: [any NSObjectProtocol] = []
+
+        /// The last reported mismatch, so a window that stays wrong
+        /// says so once rather than on every move.
+        private var lastMismatch: String?
+
+        /// The display the window was last seen on, so a screen
+        /// change can tell one that has gone from one that merely
+        /// changed resolution or place.
+        private var lastDisplayID: CGDirectDisplayID?
+
+        /// Whether the display the window was last seen on has gone.
+        /// Screen parameters change for resolution, scaling and
+        /// arrangement too, and a fullscreen space is live through
+        /// all of those: only a display that is really absent earns
+        /// the frame being set by hand.
+        private var displayGone: Bool {
+            guard let last = lastDisplayID else {
+                return false
+            }
+
+            return NSScreen.screens.contains { $0.displayID == last } == false
+        }
 
         /// Displays come and go. Unplugging the one a fullscreen
         /// window is on leaves the window black on a space with no
@@ -88,29 +114,59 @@ struct WindowConfigurator: NSViewRepresentable {
             ]
             for (name, object) in names {
                 observers.append(centre.addObserver(forName: name, object: object, queue: .main) { [weak self] _ in
-                    MainActor.assumeIsolated { self?.moved() }
+                    MainActor.assumeIsolated { self?.moved(displayGone: self?.displayGone ?? false) }
                 })
             }
+            // A fullscreen space sent to another display posts no
+            // screen-parameter change and does not always announce
+            // the screen change, so the window's own move is the one
+            // signal it always gives. Only fullscreen acts on it:
+            // fitting a dragged window would stop it being pulled
+            // past a screen edge on purpose.
+            observers.append(centre.addObserver(
+                forName: NSWindow.didMoveNotification,
+                object: window,
+                queue: .main,
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.movedIfFullScreen() }
+            })
+        }
+
+        private func movedIfFullScreen() {
+            guard window?.styleMask.contains(.fullScreen) == true else {
+                return
+            }
+
+            moved(displayGone: false)
         }
 
         /// The window changed screen or fullscreen state. Fitting
         /// runs twice: entering and leaving fullscreen are animated,
         /// so the frame that needs fitting is not there yet when the
         /// notification arrives.
-        private func moved() {
-            fit()
+        private func moved(displayGone: Bool) {
+            fit(displayGone: displayGone)
+            rememberDisplay()
             DispatchQueue.main.asyncAfter(deadline: .now() + Self.settleSeconds) { [weak self] in
-                self?.fit()
+                self?.fit(displayGone: displayGone)
+                self?.rememberDisplay()
+                self?.reportUnfittedFullScreen()
             }
         }
 
-        private func fit() {
+        private func rememberDisplay() {
+            if let current = window?.screen?.displayID {
+                lastDisplayID = current
+            }
+        }
+
+        private func fit(displayGone: Bool) {
             guard let window else {
                 return
             }
 
             if window.styleMask.contains(.fullScreen) {
-                fitFullScreen(of: window)
+                fitFullScreen(of: window, hasLostDisplay: displayGone)
             } else {
                 fitToScreen()
             }
@@ -125,18 +181,50 @@ struct WindowConfigurator: NSViewRepresentable {
         /// on when that display goes. macOS moves the space to a
         /// screen that exists, but the content stays drawn to the
         /// old, larger frame: what shows is the black behind it.
-        private func fitFullScreen(of window: NSWindow) {
+        /// Only the display the window was on going away is fitted
+        /// by hand: AppKit owns the frame of a window in a
+        /// fullscreen space, and setting it while a space merely
+        /// moved between two live displays left both screens black
+        /// until the app was killed, which a resolution, scaling or
+        /// arrangement change must not be able to reproduce. Every
+        /// other change lays the content out again for the size
+        /// AppKit gave it, and nothing more.
+        private func fitFullScreen(of window: NSWindow, hasLostDisplay: Bool) {
             guard let screen = window.screen else {
                 // No screen at all to fit: leaving fullscreen puts
                 // the window back on one that exists.
                 window.toggleFullScreen(nil)
                 return
             }
-            guard window.frame != screen.frame else {
+            guard hasLostDisplay, window.frame != screen.frame else {
+                window.contentView?.needsLayout = true
+                window.contentView?.layoutSubtreeIfNeeded()
                 return
             }
 
             window.setFrame(screen.frame, display: true, animate: false)
+        }
+
+        /// Says once, in Messages, when a settled fullscreen window
+        /// still does not match the screen it is on: the frame AppKit
+        /// left behind is the fact needed to fix a window that has to
+        /// be toggled out of fullscreen by hand, and it cannot be
+        /// read from outside the app.
+        private func reportUnfittedFullScreen() {
+            guard let window, window.styleMask.contains(.fullScreen), let screen = window.screen,
+                  window.frame != screen.frame
+            else {
+                return
+            }
+
+            let mismatch = "Fullscreen window is " + NSStringFromRect(window.frame)
+                + " on a screen of " + NSStringFromRect(screen.frame)
+            guard mismatch != lastMismatch else {
+                return
+            }
+
+            lastMismatch = mismatch
+            ErrorLog.shared.note(mismatch)
         }
 
         /// Brings the frame back inside the screen it is on, keeping
@@ -176,5 +264,16 @@ struct WindowConfigurator: NSViewRepresentable {
 
     func updateNSView(_ view: ConfiguringView, context _: Context) {
         view.configureWindow()
+    }
+}
+
+// MARK: - NSScreen display identity
+
+private extension NSScreen {
+    /// The display this screen renders on, which outlives the
+    /// `NSScreen` object a reconfiguration replaces.
+    var displayID: CGDirectDisplayID? {
+        (deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? Int)
+            .map(CGDirectDisplayID.init)
     }
 }

--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ before shipping.
   disposable: its transcripts are the one thing git and GitHub do not hold)
 - **Fits** itself to whatever display it is on: unplugging the monitor a
   fullscreen window is on drops it back onto the screen that is left, at a
-  size that screen can show, with the panes narrowed to match (so a window
-  is never stranded larger than the display under it)
+  size that screen can show, with the panes narrowed to match, and a
+  fullscreen window sent to another monitor lays itself out again for it
+  (so a window is never stranded larger than the display under it)
 - **Keeps** every running shell alive while you move around the app and
   keeps a worktree listed until it is really gone, rebases and failed
   listings included (so only closing a shell or destroying its worktree


### PR DESCRIPTION
- AppKit must preserve frame during fullscreen moves to prevent screen blackouts  
- Silent Messages confirms macOS repaint, not our pane issue  
- Window frame mismatch triggers clean layout on screen change  
- Handled vacated display state to avoid unintended black area