### PR TITLE
Pin launch narration and start agent faster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,10 @@ conventional-commit prefixes such as `feat:`, `fix:` or `chore:`.
   delay over half a second. A transition made of several steps
   names each step and what it waits on as it happens, through
   `LaunchProgress`, and keeps something on screen changing at
-  least once a second. The same holds for every pane whose data
+  least once a second, the block pinned near the top of the pane so
+  it grows downwards. Work that need not be serial is not: anything
+  the launch does not depend on yet runs beside it. The same holds
+  for every pane whose data
   arrives later than the pane: it shows `LaunchProgressView` naming
   what it waits on until the first result lands, then snaps to the
   finished UI. An empty state ("Nothing running", "No changes")

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,9 @@ the README's Features subsections.
 
 AgentIDE is a native SwiftUI macOS app (macOS 27 or later, Swift 6.4,
 AGPL-3.0) that runs, steers and reviews sandboxed AI coding agents in
-parallel git worktrees. It is developed readme-first: this document describes
+parallel git worktrees. Its user supervises rather than types, so the
+window is arranged around the agent loop, not around an editor, and one
+window covers what four apps used to. It is developed readme-first: this document describes
 the target system and slices of it land in the order given in the README's
 Status section.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -425,7 +425,14 @@ Sendable` and `nonisolated(unsafe)` are banned.
    step log the service and the herdr client report into: the branch
    name, the worktree, the prompt file, the server check, the workspace,
    the command submitted and what is being waited on) under a clock of
-   the launch's elapsed time ticking every second, so a slow step names
+   the launch's elapsed time ticking every second and a dot a second on
+   the newest step, so a step that reports nothing while it waits still
+   shows the app working, the whole block pinned near the top of the pane
+   so it grows downwards rather than shifting every line each time a step
+   arrives; the version probe runs beside the naming and the worktree,
+   since it costs a sandbox launch of its own and only has to be finished
+   before the agent starts, and a kill that closed nothing skips the
+   listing that would confirm it. So a slow step names
    itself rather than showing a blank pane; resuming narrates the same
    way, one line per command tried. The narration stays until herdr
    detects the agent's interface (`awaitReady`, bounded at a minute), so

--- a/App/RootView+Panes.swift
+++ b/App/RootView+Panes.swift
@@ -53,6 +53,36 @@ extension RootView {
         }
     }
 
+    /// The primary column: the session strip over whichever pane
+    /// the worktree calls for. A covering page hides it rather than
+    /// unmounting it, so the agent's terminal keeps its herdr client
+    /// and its scrollback, and the utility toggle parks at its top
+    /// right while the utility pane is hidden, in exactly the spot
+    /// that pane's header shows it, so it never moves on toggle.
+    func primaryColumn(for item: WorktreeItem) -> some View {
+        VStack(spacing: 0) {
+            sessionStrip(for: item)
+            primary(for: item)
+        }
+        .opacity(isCovered ? 0 : 1)
+        .allowsHitTesting(isCovered == false)
+        .overlay { coveringPage }
+        .overlay(alignment: .topTrailing) {
+            if showsUtility == false {
+                utilityToggleButton
+                    .frame(height: Self.toggleRowHeight)
+                    .padding(.trailing, Self.stripSpacing)
+            }
+        }
+        .frame(
+            minWidth: PaneLayout.primaryMinimum,
+            maxWidth: .infinity,
+            maxHeight: .infinity,
+            alignment: .top,
+        )
+        .ignoresSafeArea(.container, edges: .top)
+    }
+
     /// What the detail shows with nothing selected: the first
     /// reading's progress until it lands, then the invitation.
     @ViewBuilder var unselectedDetail: some View {

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -248,7 +248,7 @@ extension RootView {
 
     // MARK: Private
 
-    private static let stripSpacing: CGFloat = 4
+    static let stripSpacing: CGFloat = 4
     private static let tabHorizontalPadding: CGFloat = 8
     private static let tabVerticalPadding: CGFloat = 3
 

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -16,6 +16,9 @@ struct RootView: View {
     /// titlebar band and that toggle.
     static let toggleRowHeight: CGFloat = 30
 
+    // Slim enough for icon-and-truncated-text rows while staying
+    // wider than the traffic lights band.
+
     let dependencies: AppDependencies
 
     /// Persisted as the tab's name rather than an index, so
@@ -175,6 +178,14 @@ struct RootView: View {
         }
     }
 
+    @ViewBuilder var coveringPage: some View {
+        if dependencies.dashboard.showsNewSession {
+            NewSessionPane(model: dependencies.dashboard)
+        } else if dependencies.dashboard.showsRepositoryFinder {
+            RepositoryFinderPane(model: dependencies.dashboard)
+        }
+    }
+
     /// The file a command is waiting on in a worktree, which its
     /// editor pane shows instead of the finder.
     func waitingEdit(in worktreePath: String) -> ExternalEdit? {
@@ -221,10 +232,6 @@ struct RootView: View {
     }
 
     // MARK: Private
-
-    /// Slim enough for icon-and-truncated-text rows while staying
-    /// wider than the traffic lights band.
-    private static let stripSpacing: CGFloat = 4
 
     /// The selected conversation's worktree on the repository page,
     /// nil when none exists; the review surfaces follow it. Internal
@@ -293,50 +300,46 @@ struct RootView: View {
         runningShells.isEmpty == false || runningWorktreePaths.isEmpty == false
     }
 
-    /// The middle pages, never sheets, cover the split rather than
-    /// replacing it: unmounting the split takes its panes with it,
-    /// and a pane can hold a running shell, which only destroying
-    /// its worktree should end.
+    /// The middle pages, never sheets, cover the primary pane
+    /// rather than replacing it: unmounting takes the panes with it,
+    /// and a pane can hold a running agent or shell, which only
+    /// destroying its worktree should end. They cover that pane
+    /// alone, so the utility pane stays where it was: the window
+    /// keeps one shape whatever it is showing.
     private var detail: some View {
         ZStack {
             if let item = dependencies.dashboard.selection {
                 split(for: item)
-                    .opacity(isCovered ? 0 : 1)
-                    .allowsHitTesting(isCovered == false)
-            } else if isCovered == false {
-                unselectedDetail
+            } else {
+                unselectedSplit
             }
-            if dependencies.dashboard.showsNewSession {
-                NewSessionPane(model: dependencies.dashboard)
-            } else if dependencies.dashboard.showsRepositoryFinder {
-                RepositoryFinderPane(model: dependencies.dashboard)
+        }
+    }
+
+    /// The same shape with nothing selected: the page fills the
+    /// primary pane and the utility pane's width is held empty
+    /// beside it, so a repository picker or a new session form sits
+    /// in the column it would occupy with a worktree open rather
+    /// than spreading across the window.
+    private var unselectedSplit: some View {
+        HStack(spacing: 0) {
+            Group {
+                if isCovered {
+                    coveringPage
+                } else {
+                    unselectedDetail
+                }
+            }
+            .frame(minWidth: PaneLayout.primaryMinimum, maxWidth: .infinity, maxHeight: .infinity)
+            if showsUtility {
+                Color.clear.frame(width: utilityPaneWidth)
             }
         }
     }
 
     private func split(for item: WorktreeItem) -> some View {
         HStack(spacing: 0) {
-            VStack(spacing: 0) {
-                sessionStrip(for: item)
-                primary(for: item)
-            }
-            // With the utility pane hidden its toggle overlays the
-            // session strip's empty right end, in exactly the spot
-            // the pane header shows it, so it never moves on toggle.
-            .overlay(alignment: .topTrailing) {
-                if showsUtility == false {
-                    utilityToggleButton
-                        .frame(height: Self.toggleRowHeight)
-                        .padding(.trailing, Self.stripSpacing)
-                }
-            }
-            .frame(
-                minWidth: PaneLayout.primaryMinimum,
-                maxWidth: .infinity,
-                maxHeight: .infinity,
-                alignment: .top,
-            )
-            .ignoresSafeArea(.container, edges: .top)
+            primaryColumn(for: item)
             if showsUtility {
                 PaneDivider(width: $utilityPaneWidth, range: PaneLayout.utilityRange, controlsLeadingPane: false)
                     .ignoresSafeArea(.container, edges: .top)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # AgentIDE
 
-🪪 IDE for Agents
+🪪 IDE for Agents: prompt a worktree, review another, ship a third, repeat
 
 ![The worktree sidebar, an agent's terminal and its pull request side by side](docs/screenshot.png)
 
 A native macOS app for running, steering and reviewing sandboxed AI coding
 agents in parallel git worktrees, from problem statement to merged pull
-request. Built with SwiftUI on top of
+request. The window is built around that loop rather than around a text
+editor: the editor is here for the fixes review turns up, the terminals
+are the agents' own, and everything a task passes through, worktree,
+conversation, diff, pull request and CI, is one window rather than four
+apps you keep in sync by hand. Built with SwiftUI on top of
 [sandvault](https://github.com/webcoyote/sandvault),
 [`herdr`](https://herdr.dev) and the
 [`gh`](https://cli.github.com) CLI.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ before shipping.
   sandbox share one checkout with nothing to keep in sync)
 - **Creates** a worktree and branch from a typed problem statement or an existing
   issue or pull request, narrating each step and the command it is waiting
-  on with a clock that ticks every second and staying on that page until
+  on with a clock that ticks every second, a step that waits marking each
+  second it waits, and staying on that page until
   the agent's interface is up, the same when a conversation resumes (so
   starting work is one prompt, not a git ritual, a slow step is never a
   blank pane and the pane never appears before the agent does)

--- a/Sources/AgentIDEData/HerdrClient+Sessions.swift
+++ b/Sources/AgentIDEData/HerdrClient+Sessions.swift
@@ -260,10 +260,24 @@ public extension HerdrClient {
     @discardableResult
     func killSession(name: String) async throws -> Int {
         var closed = 0
+        var failure: (any Error)?
         for row in try await snapshotRows() where row.sessionName == name {
-            try await herdr(["workspace", "close", row.workspaceID])
-            closed += 1
+            // Every match is tried: stopping at the first refusal
+            // would leave the rest of a duplicated label running,
+            // and the refusal is thrown once they have all been
+            // attempted, so a caller still knows the pass was
+            // incomplete.
+            do {
+                try await herdr(["workspace", "close", row.workspaceID])
+                closed += 1
+            } catch {
+                failure = failure ?? error
+            }
         }
+        if let failure {
+            throw failure
+        }
+
         return closed
     }
 

--- a/Sources/AgentIDEData/HerdrClient+Sessions.swift
+++ b/Sources/AgentIDEData/HerdrClient+Sessions.swift
@@ -253,12 +253,18 @@ public extension HerdrClient {
     }
 
     /// Closes every workspace holding a label, killing the process
-    /// trees inside; absent labels are not an error, so kills stay
-    /// idempotent.
-    func killSession(name: String) async throws {
+    /// trees inside, and answers how many it closed; absent labels
+    /// are not an error, so kills stay idempotent, and a caller can
+    /// tell "nothing was there" from "something was killed" without
+    /// listing the server again.
+    @discardableResult
+    func killSession(name: String) async throws -> Int {
+        var closed = 0
         for row in try await snapshotRows() where row.sessionName == name {
             try await herdr(["workspace", "close", row.workspaceID])
+            closed += 1
         }
+        return closed
     }
 
     /// Types literal text into a session's terminal.

--- a/Sources/AgentIDEData/SessionService+Lifecycle.swift
+++ b/Sources/AgentIDEData/SessionService+Lifecycle.swift
@@ -87,6 +87,29 @@ public extension SessionService {
         }
     }
 
+    /// Adds the worktree a new session works in, under the
+    /// repository's own directory.
+    func createWorktreePath(repository: Repository, branch: String) async throws -> String {
+        let path = worktreeContainer(repository: repository) + "/" + branch.replacing("/", with: "-")
+        await progress("Running `git worktree add " + path + "`")
+        try await git.createWorktree(repository: repository, branch: branch, at: path)
+        await progress("Worktree ready at `" + path + "`")
+        return path
+    }
+
+    /// Adds a detached worktree, letting `gh pr checkout` create the
+    /// branch afterwards.
+    func createDetachedWorktreePath(repository: Repository, name: String) async throws -> String {
+        let path = worktreeContainer(repository: repository) + "/" + name
+        try await git.addDetachedWorktree(repository: repository, at: path)
+        return path
+    }
+
+    /// Fetches and prunes the repository's remotes.
+    func fetch(repository: Repository) async throws {
+        try await git.fetch(repositoryPath: repository.path)
+    }
+
     /// Removes the symlink an earlier release kept beside a
     /// uuid-layout worktree; the canonical path is what git knows,
     /// so this is cosmetic cleanup of the old layout.

--- a/Sources/AgentIDEData/SessionService+Sessions.swift
+++ b/Sources/AgentIDEData/SessionService+Sessions.swift
@@ -24,10 +24,12 @@ public extension SessionService {
     /// only lever.
     func killSession(name: String) async {
         // A name nothing holds is the common case on a fresh start,
-        // and confirming it costs a listing of every pane: only a
-        // kill that closed something is worth checking on.
-        let closed = await (try? herdr.killSession(name: name)) ?? 0
-        guard closed > 0, await sessionExists(name: name) else {
+        // and confirming it costs a listing of every pane, so only a
+        // kill that answered "nothing was there" skips the check. A
+        // kill that closed something, or failed part way and cannot
+        // say, is checked and retried.
+        let closed = await (try? herdr.killSession(name: name))
+        guard closed != 0, await sessionExists(name: name) else {
             return
         }
 
@@ -46,7 +48,7 @@ public extension SessionService {
         sessionName: String,
         directory: String,
         command: String,
-        probing version: Task<String?, Never>? = nil,
+        probed version: String? = nil,
     ) async throws {
         await progress("Closing any previous session")
         await killSession(name: sessionName)
@@ -61,7 +63,7 @@ public extension SessionService {
         // where the seconds it costs are free.
         await progress("Asking the agent's CLI its version")
         if let version {
-            await record(version: version.value, sessionName: sessionName)
+            record(version: version, sessionName: sessionName)
         } else {
             await recordAgentVersion(sessionName: sessionName)
         }

--- a/Sources/AgentIDEData/SessionService+Sessions.swift
+++ b/Sources/AgentIDEData/SessionService+Sessions.swift
@@ -23,8 +23,11 @@ public extension SessionService {
     /// processes and the sudoers rules stay narrow, so herdr is the
     /// only lever.
     func killSession(name: String) async {
-        try? await herdr.killSession(name: name)
-        guard await sessionExists(name: name) else {
+        // A name nothing holds is the common case on a fresh start,
+        // and confirming it costs a listing of every pane: only a
+        // kill that closed something is worth checking on.
+        let closed = await (try? herdr.killSession(name: name)) ?? 0
+        guard closed > 0, await sessionExists(name: name) else {
             return
         }
 
@@ -39,18 +42,29 @@ public extension SessionService {
     /// version whose files have been deleted fails in ways that read
     /// as the app's fault. Anything the user asks for by hand comes
     /// through here and gets a new process.
-    internal func startFresh(sessionName: String, directory: String, command: String) async throws {
+    internal func startFresh(
+        sessionName: String,
+        directory: String,
+        command: String,
+        probing version: Task<String?, Never>? = nil,
+    ) async throws {
         await progress("Closing any previous session")
         await killSession(name: sessionName)
         if let agent = agentKind(of: sessionName) {
             await clearQuarantine(for: agent)
         }
-        // The version probe runs before the launch, never beside it:
-        // it is a second copy of the same CLI, and Codex stages its
-        // execution host under a lock in its own home, which two
-        // copies starting at once contend for.
+        // The version probe finishes before the launch, never runs
+        // beside it: it is a second copy of the same CLI, and Codex
+        // stages its execution host under a lock in its own home,
+        // which two copies starting at once contend for. Creation
+        // hands one already running alongside the worktree, which is
+        // where the seconds it costs are free.
         await progress("Asking the agent's CLI its version")
-        await recordAgentVersion(sessionName: sessionName)
+        if let version {
+            await record(version: version.value, sessionName: sessionName)
+        } else {
+            await recordAgentVersion(sessionName: sessionName)
+        }
         try await herdr.newSession(name: sessionName, directory: directory, command: command)
     }
 
@@ -63,6 +77,12 @@ public extension SessionService {
             return
         }
 
+        await record(version: probeVersion(of: agent), sessionName: sessionName)
+    }
+
+    /// Asks a CLI its version, which costs a sandbox launch of its
+    /// own; callers with anything else to do run it beside that.
+    internal func probeVersion(of agent: AgentKind) async -> String? {
         let argv = launcher.command(
             payload: agent.rawValue + " --version </dev/null",
             initialDirectory: launcher.sharedWorkspace,
@@ -70,7 +90,14 @@ public extension SessionService {
             sessionName: "agentide-version",
         )
         let result = try? await processes.run(argv, workingDirectory: nil, environment: [:])
-        guard let version = runner(for: agent).parseVersion(result?.standardOutput ?? "") else {
+        return runner(for: agent).parseVersion(result?.standardOutput ?? "")
+    }
+
+    /// Remembers a probed version under the session name, so the
+    /// pane says which version it is running rather than which one
+    /// is installed now.
+    internal func record(version: String?, sessionName: String) {
+        guard let version else {
             return
         }
 

--- a/Sources/AgentIDEData/SessionService+Sources.swift
+++ b/Sources/AgentIDEData/SessionService+Sources.swift
@@ -43,13 +43,22 @@ public extension SessionService {
         options: AgentLaunchOptions = AgentLaunchOptions(),
     ) async throws -> String {
         let sessionName = SessionName.make(repository: worktree.repositoryName, branch: worktree.branch, agent: agent)
+        // Cleared first and probed beside the kill, as creation does.
+        await clearQuarantine(for: agent)
+        async let probed = probeVersion(of: agent)
         await killSession(name: sessionName)
         let slot = WorktreeSlot(
             repository: Repository(name: worktree.repositoryName, path: worktree.repositoryPath),
             branch: worktree.branch,
             path: worktree.path,
         )
-        return try await start(prompt: prompt, agent: agent, options: options, slot: slot)
+        return try await start(
+            prompt: prompt,
+            agent: agent,
+            options: options,
+            slot: slot,
+            probed: probed,
+        )
     }
 
     /// The models and efforts an agent's pickers offer when discovery
@@ -94,6 +103,8 @@ public extension SessionService {
         agent: AgentKind,
         options: AgentLaunchOptions = AgentLaunchOptions(),
     ) async throws -> String {
+        await clearQuarantine(for: agent)
+        async let probed = probeVersion(of: agent)
         let issue = try await github.issue(repositoryPath: repository.path, number: number)
         let prompt = GitHubClient.issuePrompt(
             number: number,
@@ -104,7 +115,13 @@ public extension SessionService {
         let branch = await availableBranch(repository: repository, prompt: "issue-\(number)-" + issue.title)
         let worktreePath = try await createWorktreePath(repository: repository, branch: branch)
         let slot = WorktreeSlot(repository: repository, branch: branch, path: worktreePath)
-        return try await start(prompt: prompt, agent: agent, options: options, slot: slot)
+        return try await start(
+            prompt: prompt,
+            agent: agent,
+            options: options,
+            slot: slot,
+            probed: probed,
+        )
     }
 
     /// Creates a session on a pull request's own branch: the worktree
@@ -117,6 +134,8 @@ public extension SessionService {
         agent: AgentKind,
         options: AgentLaunchOptions = AgentLaunchOptions(),
     ) async throws -> String {
+        await clearQuarantine(for: agent)
+        async let probed = probeVersion(of: agent)
         let detail = try await github.pullRequestDetail(repositoryPath: repository.path, number: number)
         let prompt = GitHubClient.pullRequestPrompt(
             number: number,
@@ -128,7 +147,13 @@ public extension SessionService {
         try await github.checkoutPullRequest(worktreePath: worktreePath, number: number)
         let branch = detail.headBranch.isEmpty ? "pr-\(number)" : detail.headBranch
         let slot = WorktreeSlot(repository: repository, branch: branch, path: worktreePath)
-        return try await start(prompt: prompt, agent: agent, options: options, slot: slot)
+        return try await start(
+            prompt: prompt,
+            agent: agent,
+            options: options,
+            slot: slot,
+            probed: probed,
+        )
     }
 
     /// How much of the prompt seeds the fallback branch name.
@@ -152,11 +177,6 @@ public extension SessionService {
             attempt += 1
         }
         return "\(base)-\(attempt)"
-    }
-
-    /// Fetches and prunes the repository's remotes.
-    func fetch(repository: Repository) async throws {
-        try await git.fetch(repositoryPath: repository.path)
     }
 
     /// Fetches origin and hard-resets the main checkout to its
@@ -373,12 +393,4 @@ public extension SessionService {
     }
 
     // MARK: Internal
-
-    /// Adds a detached worktree, letting `gh pr checkout` create the
-    /// branch afterwards.
-    func createDetachedWorktreePath(repository: Repository, name: String) async throws -> String {
-        let path = worktreeContainer(repository: repository) + "/" + name
-        try await git.addDetachedWorktree(repository: repository, at: path)
-        return path
-    }
 }

--- a/Sources/AgentIDEData/SessionService.swift
+++ b/Sources/AgentIDEData/SessionService.swift
@@ -136,12 +136,17 @@ public struct SessionService: Sendable {
         agent: AgentKind,
         options: AgentLaunchOptions = AgentLaunchOptions(),
     ) async throws -> String {
-        await progress("Naming the branch from the prompt")
+        // The version probe costs a sandbox launch of its own, so it
+        // runs beside the naming and the worktree rather than in
+        // front of the agent, and is waited on only when the launch
+        // is ready for it.
+        let version = Task { await probeVersion(of: agent) }
+        await progress("Naming the branch from the prompt, and asking the CLI its version beside it")
         let branch = await availableBranch(repository: repository, prompt: prompt)
         await progress("Creating the worktree for `" + branch + "`")
         let worktreePath = try await createWorktreePath(repository: repository, branch: branch)
         let slot = WorktreeSlot(repository: repository, branch: branch, path: worktreePath)
-        return try await start(prompt: prompt, agent: agent, options: options, slot: slot)
+        return try await start(prompt: prompt, agent: agent, options: options, slot: slot, probing: version)
     }
 
     // MARK: Internal
@@ -211,6 +216,7 @@ public struct SessionService: Sendable {
         agent: AgentKind,
         options: AgentLaunchOptions,
         slot: WorktreeSlot,
+        probing version: Task<String?, Never>? = nil,
     ) async throws -> String {
         let sessionName = SessionName.make(repository: slot.repository.name, branch: slot.branch, agent: agent)
         let arguments = runner(for: agent).optionArguments(model: options.model, effort: options.effort)
@@ -226,6 +232,7 @@ public struct SessionService: Sendable {
             sessionName: sessionName,
             directory: slot.path,
             command: runner(for: agent).launchCommand(extraArguments: arguments, promptFile: promptFile),
+            probing: version,
         )
 
         await progress("Recording the session `" + sessionName + "`")
@@ -249,7 +256,7 @@ public struct SessionService: Sendable {
 
     func createWorktreePath(repository: Repository, branch: String) async throws -> String {
         let path = worktreeContainer(repository: repository) + "/" + branch.replacing("/", with: "-")
-        await progress("Running `git worktree add " + path + "` after fetching origin")
+        await progress("Running `git worktree add " + path + "`")
         try await git.createWorktree(repository: repository, branch: branch, at: path)
         await progress("Worktree ready at `" + path + "`")
         return path

--- a/Sources/AgentIDEData/SessionService.swift
+++ b/Sources/AgentIDEData/SessionService.swift
@@ -138,15 +138,24 @@ public struct SessionService: Sendable {
     ) async throws -> String {
         // The version probe costs a sandbox launch of its own, so it
         // runs beside the naming and the worktree rather than in
-        // front of the agent, and is waited on only when the launch
-        // is ready for it.
-        let version = Task { await probeVersion(of: agent) }
+        // front of the agent. Structured, so a worktree that fails
+        // takes the probe with it, and after the quarantine is
+        // cleared, since Gatekeeper kills the probe on an install
+        // Homebrew left quarantined just as it would the agent.
+        await clearQuarantine(for: agent)
+        async let probed = probeVersion(of: agent)
         await progress("Naming the branch from the prompt, and asking the CLI its version beside it")
         let branch = await availableBranch(repository: repository, prompt: prompt)
         await progress("Creating the worktree for `" + branch + "`")
         let worktreePath = try await createWorktreePath(repository: repository, branch: branch)
         let slot = WorktreeSlot(repository: repository, branch: branch, path: worktreePath)
-        return try await start(prompt: prompt, agent: agent, options: options, slot: slot, probing: version)
+        return try await start(
+            prompt: prompt,
+            agent: agent,
+            options: options,
+            slot: slot,
+            probed: probed,
+        )
     }
 
     // MARK: Internal
@@ -216,7 +225,7 @@ public struct SessionService: Sendable {
         agent: AgentKind,
         options: AgentLaunchOptions,
         slot: WorktreeSlot,
-        probing version: Task<String?, Never>? = nil,
+        probed version: String? = nil,
     ) async throws -> String {
         let sessionName = SessionName.make(repository: slot.repository.name, branch: slot.branch, agent: agent)
         let arguments = runner(for: agent).optionArguments(model: options.model, effort: options.effort)
@@ -232,7 +241,7 @@ public struct SessionService: Sendable {
             sessionName: sessionName,
             directory: slot.path,
             command: runner(for: agent).launchCommand(extraArguments: arguments, promptFile: promptFile),
-            probing: version,
+            probed: version,
         )
 
         await progress("Recording the session `" + sessionName + "`")
@@ -252,14 +261,6 @@ public struct SessionService: Sendable {
         let promptFile = paths.promptsDirectory + "/" + sessionName + ".md"
         try prompt.write(toFile: promptFile, atomically: true, encoding: .utf8)
         return promptFile
-    }
-
-    func createWorktreePath(repository: Repository, branch: String) async throws -> String {
-        let path = worktreeContainer(repository: repository) + "/" + branch.replacing("/", with: "-")
-        await progress("Running `git worktree add " + path + "`")
-        try await git.createWorktree(repository: repository, branch: branch, at: path)
-        await progress("Worktree ready at `" + path + "`")
-        return path
     }
 
     /// The repository's worktree directory, a layout the app owns

--- a/Sources/TerminalUI/LaunchProgress.swift
+++ b/Sources/TerminalUI/LaunchProgress.swift
@@ -97,14 +97,17 @@ public struct LaunchProgressView: View {
                         .monospacedDigit()
                 }
                 ForEach(steps) { step in
-                    Text(Self.styled(step.text))
+                    Text(Self.styled(step.text + waitingDots(on: step, at: context.date)))
                         .font(.callout)
                         .lineLimit(Self.stepLines)
                 }
             }
             .frame(maxWidth: Self.blockWidth, alignment: .leading)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // Pinned near the top so the log grows downwards: centred,
+            // it shifted every line each time a step arrived.
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .padding()
+            .padding(.top, Self.topInset)
         }
     }
 
@@ -114,6 +117,8 @@ public struct LaunchProgressView: View {
     private static let spacing: CGFloat = 6
     private static let blockWidth: CGFloat = 560
     private static let stepLines = 3
+    private static let topInset: CGFloat = 40
+    private static let dotCycle = 3
 
     @State private var appearedAt: Date = .init()
 
@@ -132,6 +137,18 @@ public struct LaunchProgressView: View {
     private static func styled(_ text: String) -> AttributedString {
         (try? AttributedString(markdown: text, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
             ?? AttributedString(text)
+    }
+
+    /// A dot a second on the newest step, up to three: a step that
+    /// waits without reporting anything still has to show the app is
+    /// working rather than stopped.
+    private func waitingDots(on step: LaunchProgress.Step, at now: Date) -> String {
+        guard step.id == steps.last?.id else {
+            return ""
+        }
+
+        let ticks = Int(max(0, now.timeIntervalSince(step.startedAt)) / Self.tickSeconds)
+        return String(repeating: ".", count: 1 + ticks % Self.dotCycle)
     }
 
     /// How long the wait has run, from its first step.


### PR DESCRIPTION
- progress block now avoids constant repositioning and shows pending steps clearly  
- version probe runs independently to prevent host lock and simplifies launch flow  
- utility pane remains fixed beside work pages, maintaining consistent window layout  
- new session form and repo picker now occupy primary pane alone, preserving utility's position  
- empty utility width ensures picker fits correctly without spreading across workspace