### PR TITLE
Enable flexible agent setup and remote sandbox access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,10 @@ conventional-commit prefixes such as `feat:`, `fix:` or `chore:`.
 - `App/`: the app shell; `project.yml` defines the XcodeGen target
   (the generated `.xcodeproj` stays gitignored)
 - `bin/`: the `agentide` command shipped inside the app bundle: the
-  editor shim a shell pane puts on its `PATH`, and `agentide new`,
+  editor shim a shell pane puts on its `PATH` (waiting only with
+  `--wait`, and taking a directory anywhere inside a worktree or
+  checkout to switch the window to it),
+  and `agentide new`,
   which asks its way to a session over SSH the way the app does,
   defaulting to what the window last chose (published by the app as
   `agentide/session-defaults`). Nothing installs it: an SSH login

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,16 @@ conventional-commit prefixes such as `feat:`, `fix:` or `chore:`.
 - `Package.swift`, `Sources/`, `Tests/`: the Swift package targets
 - `App/`: the app shell; `project.yml` defines the XcodeGen target
   (the generated `.xcodeproj` stays gitignored)
-- `bin/`: commands shipped inside the app bundle (the `agentide`
-  editor shim a shell pane puts on its `PATH`)
+- `bin/`: the `agentide` command shipped inside the app bundle: the
+  editor shim a shell pane puts on its `PATH`, and `agentide new`,
+  which asks its way to a session over SSH the way the app does,
+  defaulting to what the window last chose (published by the app as
+  `agentide/session-defaults`). Nothing installs it: an SSH login
+  aliases the bundled path. It speaks the way Homebrew's own scripts
+  do, a blue `==>` before each step, bold labels, green defaults and
+  bold `Warning:`/`Error:` labels, colour only on a terminal that has
+  not set `NO_COLOR`. `CommandLineSessionTests` pins its names to
+  `SessionName`
 - `docs/`: the images `README.md` embeds
 - `script/`: development tasks
 - `Brewfile`: development dependencies

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -164,7 +164,15 @@ bare exit code.
   defaults, plain whenever the output is not a terminal. It then makes the worktree, writes the prompt file, creates the
   labelled workspace and attaches, which is how a phone over SSH starts
   work. Nothing is installed for it: the command is aliased from the app
-  bundle, which the sandbox can read. It
+  bundle, which the sandbox can read. The same command speaks to a running
+  app through the edit spool, whose requests now say what they are: an
+  `edit` holds the command until the file is saved (what `EDITOR` needs and
+  the only kind judged by whether its process still lives), an `open` hands
+  a file over and returns, and a `select` names a checkout or worktree for
+  the window to switch to. A directory is walked up until it is one of
+  those rows, a name under `repositories` or two under `worktrees`, so
+  `agentide .` anywhere inside a tree selects the worktree holding it, and
+  a path with no row above it is refused rather than guessed at. It
   computes the branch, label and paths by the rules below rather than
   reading anything the app owns, so the app needs telling nothing: every
   session it shows is derived from herdr and git. What it cannot do is

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -158,7 +158,11 @@ bare exit code.
   repository, agent, effort, model and prompt, each defaulting to what
   the window last had chosen (the app publishes those, and the discovered
   model and effort lists, as `agentide/session-defaults` in the shared
-  workspace, `key=value` lines because the sandbox has no JSON tool). An
+  workspace, `key=value` lines because the sandbox has no JSON tool). The
+  model and effort are published under the agent they were chosen for,
+  since the form keeps one pair and Codex's model means nothing to Claude,
+  and an agent the window kept none for offers `default`, which asks for
+  no flag rather than showing an empty bracket. An
   answer that is neither a number nor a name is asked again rather than
   taken, in Homebrew's own idiom of blue arrows, bold labels and green
   defaults, plain whenever the output is not a terminal. It then makes the worktree, writes the prompt file, creates the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -153,6 +153,23 @@ bare exit code.
   `XDG_CONFIG_HOME` into throwaway per-run scratch directories, so
   building, testing and development can never list or kill the installed
   app's sessions.
+- A session can also be started from outside the app entirely:
+  `agentide new`, the same command as the editor shim, asks for the
+  repository, agent, effort, model and prompt, each defaulting to what
+  the window last had chosen (the app publishes those, and the discovered
+  model and effort lists, as `agentide/session-defaults` in the shared
+  workspace, `key=value` lines because the sandbox has no JSON tool). An
+  answer that is neither a number nor a name is asked again rather than
+  taken, in Homebrew's own idiom of blue arrows, bold labels and green
+  defaults, plain whenever the output is not a terminal. It then makes the worktree, writes the prompt file, creates the
+  labelled workspace and attaches, which is how a phone over SSH starts
+  work. Nothing is installed for it: the command is aliased from the app
+  bundle, which the sandbox can read. It
+  computes the branch, label and paths by the rules below rather than
+  reading anything the app owns, so the app needs telling nothing: every
+  session it shows is derived from herdr and git. What it cannot do is
+  host-only: no on-device branch naming, no GitHub, and no recorded
+  prompt or CLI version until that session is next started from the Mac.
 - Each agent conversation is one herdr workspace whose single pane runs a
   login shell; the agent command is submitted to that shell (`pane run`)
   behind `export TMPDIR="$(mktemp -d)"`, the per-session temporary

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -156,13 +156,16 @@ bare exit code.
 - A session can also be started from outside the app entirely:
   `agentide new`, the same command as the editor shim, asks for the
   repository, agent, effort, model and prompt, each defaulting to what
-  the window last had chosen (the app publishes those, and the discovered
-  model and effort lists, as `agentide/session-defaults` in the shared
-  workspace, `key=value` lines because the sandbox has no JSON tool). The
-  model and effort are published under the agent they were chosen for,
-  since the form keeps one pair and Codex's model means nothing to Claude,
-  and an agent the window kept none for offers `default`, which asks for
-  no flag rather than showing an empty bracket. An
+  was last chosen anywhere. Neither surface has a default model or effort:
+  until one has been picked the form refuses to start and the question
+  refuses to move on, and afterwards the last pick is what both come back
+  to. That memory is `agentide/session-defaults` in the shared workspace,
+  `key=value` lines because the sandbox has no JSON tool, written by
+  whichever surface starts a session and merged rather than replaced by
+  both, with the app publishing what only it can know (the repositories,
+  and each agent's discovered models and efforts) on every poll. The model
+  and effort are kept under their agent's name, since the form keeps one
+  pair and Codex's model means nothing to Claude. An
   answer that is neither a number nor a name is asked again rather than
   taken, in Homebrew's own idiom of blue arrows, bold labels and green
   defaults, plain whenever the output is not a terminal. It then makes the worktree, writes the prompt file, creates the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -163,8 +163,14 @@ bare exit code.
   taken, in Homebrew's own idiom of blue arrows, bold labels and green
   defaults, plain whenever the output is not a terminal. It then makes the worktree, writes the prompt file, creates the
   labelled workspace and attaches, which is how a phone over SSH starts
-  work. Nothing is installed for it: the command is aliased from the app
-  bundle, which the sandbox can read. The same command speaks to a running
+  work. Run as the host user it runs itself as the sandbox user through
+  the same sudo, `env -i` and `sandbox-exec` shape the app uses, since only
+  that user can reach the server's socket, and it defaults the session to
+  `agentide` so a terminal on the Mac needs no setup at all. A workspace
+  that cannot be made takes its half-built worktree, branch and prompt file
+  with it, so the same prompt can simply be asked again. Nothing is
+  installed for it: the command is aliased from the app bundle, which the
+  sandbox can read. The same command speaks to a running
   app through the edit spool, whose requests now say what they are: an
   `edit` holds the command until the file is saved (what `EDITOR` needs and
   the only kind judged by whether its process still lives), an `open` hands

--- a/App/WaitingEdits.swift
+++ b/App/WaitingEdits.swift
@@ -35,11 +35,17 @@ final class WaitingEdits {
     /// nothing is waiting, so a rebase returns to its own shell.
     func watch(service: SessionService, dashboard: DashboardModel) async {
         for await edits in service.pendingEdits() {
-            all = edits
-            if edits.isEmpty {
+            // Only a waiting request holds a pane; the others are
+            // acted on and dropped as they arrive.
+            all = edits.filter(\.waitsForAnswer)
+            if all.isEmpty {
                 restorePreviousPane()
             }
-            guard let edit = edits.first, edit.id != shown else {
+            for edit in edits where edit.waitsForAnswer == false {
+                act(on: edit, dashboard: dashboard)
+                await service.discardEdit(edit)
+            }
+            guard let edit = all.first, edit.id != shown else {
                 continue
             }
 
@@ -69,6 +75,36 @@ final class WaitingEdits {
     /// interrupts once, and the tab to go back to afterwards.
     private var shown: String?
     private var previousTab: String?
+
+    /// A request nothing waits on: a directory selects its worktree
+    /// or repository, a file selects the worktree holding it and
+    /// shows it in the editor. Anything outside every worktree says
+    /// so in the messages pane rather than silently doing nothing.
+    private func act(on edit: ExternalEdit, dashboard: DashboardModel) {
+        let items = dashboard.groups.flatMap(\.items)
+        let holder = items.first { item in
+            edit.path == item.worktree.path || edit.path.hasPrefix(item.worktree.path + "/")
+        }
+        guard let item = holder ?? items.first(where: { edit.belongs(toWorktree: $0.worktree.path) }) else {
+            ErrorLog.shared.report("Not a worktree AgentIDE knows: " + edit.path)
+            return
+        }
+
+        dashboard.select(item)
+        guard edit.kind == .open else {
+            return
+        }
+        guard edit.path.hasPrefix(item.worktree.path + "/") else {
+            ErrorLog.shared.report("Outside the worktree, so not opened: " + edit.path)
+            return
+        }
+
+        FileOpener.open(
+            relativePath: String(edit.path.dropFirst(item.worktree.path.count + 1)),
+            line: nil,
+            worktreePath: item.worktree.path,
+        )
+    }
 
     private func takeOverPane(for edit: ExternalEdit, dashboard: DashboardModel) {
         let items = dashboard.groups.flatMap(\.items)

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ before shipping.
   survives a phone changing network, so nothing is needed on this side
   beyond Remote Login for the sandbox account (so you can steer or add
   context away from your Mac)
-- **Starts** work from a terminal or that phone: `agentide new` takes no arguments
-  and asks for repository, agent, effort, model and prompt in turn, each
-  already set to what the window last had chosen, so four taps of Enter
-  and a sentence make the worktree, start the agent and attach to it,
-  under the same names the app uses (so a thought on the bus becomes a
+- **Starts** work from a terminal or that phone: `agentide new` takes no
+  arguments and asks for repository, agent, effort, model and prompt in
+  turn, each offering what was last chosen in either place, so four taps
+  of Enter and a sentence make the worktree, start the agent and attach to
+  it, under the same names the app uses (so a thought on the bus becomes a
   branch without a keyboard, and it is waiting in the sidebar later)
 
 ### 🔍 Review

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ before shipping.
   survives a phone changing network, so nothing is needed on this side
   beyond Remote Login for the sandbox account (so you can steer or add
   context away from your Mac)
+- **Starts** work from that phone too: `agentide new` takes no arguments
+  and asks for repository, agent, effort, model and prompt in turn, each
+  already set to what the window last had chosen, so four taps of Enter
+  and a sentence make the worktree, start the agent and attach to it,
+  under the same names the app uses (so a thought on the bus becomes a
+  branch without a keyboard, and it is waiting in the sidebar later)
 
 ### 🔍 Review
 
@@ -254,6 +260,14 @@ if [ -n "${AGENTIDE}" ]; then
   export EDITOR="$(command -v agentide) --wait"
   export VISUAL="${EDITOR}"
 fi
+```
+
+The same command starts sessions from a phone. Nothing installs it, so
+alias it wherever you SSH in, in the sandbox user's shell configuration:
+
+```bash
+alias an='/Applications/AgentIDE.app/Contents/Resources/bin/agentide new'
+export HERDR_SESSION=agentide
 ```
 
 ## 🚧 Status

--- a/README.md
+++ b/README.md
@@ -122,9 +122,13 @@ before shipping.
   dashes long (so code and commit messages survive being typed)
 - **Edits** whatever that terminal's commands open, a `git rebase -i` todo list
   or a commit message, in the same editor with their own highlighting, because
-  an `agentide` command on its `PATH` blocks until you save and close and
-  `EDITOR`, `VISUAL` and `GIT_EDITOR` there name it (so interactive rebasing
-  needs no terminal editor, and cancelling aborts the rebase as `:cq` would)
+  an `agentide` command on its `PATH` blocks until you save and close when
+  asked to with `--wait`, which is how `EDITOR`, `VISUAL` and `GIT_EDITOR`
+  there name it; without that it hands the file over and returns, and given a
+  directory instead it switches the window to the worktree or checkout
+  holding it (so interactive
+  rebasing needs no terminal editor, cancelling aborts the rebase as `:cq`
+  would, and `agentide .` is how you get from a terminal back to the window)
 
 ### 🚢 Ship
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ before shipping.
   survives a phone changing network, so nothing is needed on this side
   beyond Remote Login for the sandbox account (so you can steer or add
   context away from your Mac)
-- **Starts** work from that phone too: `agentide new` takes no arguments
+- **Starts** work from a terminal or that phone: `agentide new` takes no arguments
   and asks for repository, agent, effort, model and prompt in turn, each
   already set to what the window last had chosen, so four taps of Enter
   and a sentence make the worktree, start the agent and attach to it,

--- a/Sources/AgentIDEData/ExternalEditSpool.swift
+++ b/Sources/AgentIDEData/ExternalEditSpool.swift
@@ -27,9 +27,15 @@ struct ExternalEditSpool {
             let id = String(name.dropLast(Self.requestSuffix.count))
             let path = directory + "/" + name
             guard let data = manager.contents(atPath: path),
-                  let edit = ExternalEdit(id: id, json: data),
-                  kill(edit.processIdentifier, 0) == 0 || errno == EPERM
+                  let edit = ExternalEdit(id: id, json: data)
             else {
+                remove(id: id)
+                continue
+            }
+
+            // A command that did not wait is gone by now on purpose,
+            // so only a waiting one is judged by its process.
+            if edit.waitsForAnswer, kill(edit.processIdentifier, 0) != 0, errno != EPERM {
                 remove(id: id)
                 continue
             }
@@ -56,6 +62,12 @@ struct ExternalEditSpool {
     /// whose shim has gone is swept rather than answered.
     func finish(_ edit: ExternalEdit, saved: Bool) {
         write(saved ? "0" : "1", to: path(id: edit.id, suffix: Self.doneSuffix))
+    }
+
+    /// Drops a request nothing is waiting on, once it has been
+    /// acted on: there is no shim left to read an answer.
+    func discard(_ edit: ExternalEdit) {
+        remove(id: edit.id)
     }
 
     // MARK: Private

--- a/Sources/AgentIDEData/SessionService+Edits.swift
+++ b/Sources/AgentIDEData/SessionService+Edits.swift
@@ -9,19 +9,31 @@ public extension SessionService {
         EditorShim(paths: paths).environment
     }
 
-    /// Publishes what the window last had chosen, so `agentide new`
-    /// on a phone offers the same repositories, agents, models and
-    /// efforts with the same ones already selected. Written as
+    /// Publishes what a session was last started with, so
+    /// `agentide new` offers the same repositories, agents, models
+    /// and efforts with the last ones already chosen. Written as
     /// `key=value` lines because the sandbox has no JSON tool and
-    /// the command reading them is a shell script.
-    func publishSessionDefaults(_ values: [(key: String, value: String)]) {
-        let text = values.map { $0.key + "=" + $0.value }.joined(separator: "\n") + "\n"
+    /// the command reading them is a shell script, and merged with
+    /// what is there: the file is one memory shared with that
+    /// command, which writes its own choices into it.
+    func publishSessionChoices(_ values: [(key: String, value: String)]) {
+        let file = paths.agentideDirectory + "/session-defaults"
+        var merged = [String]()
+        var replaced = Set(values.map(\.key))
+        for line in (try? String(contentsOfFile: file, encoding: .utf8))?.split(separator: "\n") ?? [] {
+            let key = String(line.prefix { $0 != "=" })
+            if replaced.contains(key) == false {
+                merged.append(String(line))
+            }
+        }
+        replaced = []
+        merged += values.map { $0.key + "=" + $0.value }
         try? FileManager.default.createDirectory(
             atPath: paths.agentideDirectory,
             withIntermediateDirectories: true,
         )
-        try? text.write(
-            toFile: paths.agentideDirectory + "/session-defaults",
+        try? (merged.sorted().joined(separator: "\n") + "\n").write(
+            toFile: file,
             atomically: true,
             encoding: .utf8,
         )

--- a/Sources/AgentIDEData/SessionService+Edits.swift
+++ b/Sources/AgentIDEData/SessionService+Edits.swift
@@ -1,4 +1,5 @@
 import AgentIDEDomain
+import Foundation
 
 /// The files commands outside the app are waiting to have edited.
 public extension SessionService {
@@ -6,6 +7,24 @@ public extension SessionService {
     /// here, and for `agentide` to work as a command in it.
     func shellEnvironment() -> [String: String] {
         EditorShim(paths: paths).environment
+    }
+
+    /// Publishes what the window last had chosen, so `agentide new`
+    /// on a phone offers the same repositories, agents, models and
+    /// efforts with the same ones already selected. Written as
+    /// `key=value` lines because the sandbox has no JSON tool and
+    /// the command reading them is a shell script.
+    func publishSessionDefaults(_ values: [(key: String, value: String)]) {
+        let text = values.map { $0.key + "=" + $0.value }.joined(separator: "\n") + "\n"
+        try? FileManager.default.createDirectory(
+            atPath: paths.agentideDirectory,
+            withIntermediateDirectories: true,
+        )
+        try? text.write(
+            toFile: paths.agentideDirectory + "/session-defaults",
+            atomically: true,
+            encoding: .utf8,
+        )
     }
 
     /// Every file a command is waiting on, in the order they were

--- a/Sources/AgentIDEData/SessionService+Edits.swift
+++ b/Sources/AgentIDEData/SessionService+Edits.swift
@@ -59,6 +59,12 @@ public extension SessionService {
         ExternalEditSpool(directory: paths.editsDirectory).claim(edit)
     }
 
+    /// Drops a request nothing waits on, once it has been acted on.
+    @concurrent
+    func discardEdit(_ edit: ExternalEdit) async {
+        ExternalEditSpool(directory: paths.editsDirectory).discard(edit)
+    }
+
     /// Releases the waiting command: a saved file lets it carry on,
     /// a cancelled one fails it.
     @concurrent

--- a/Sources/AgentIDEDomain/ExternalEdit.swift
+++ b/Sources/AgentIDEDomain/ExternalEdit.swift
@@ -7,11 +7,18 @@ public struct ExternalEdit: Identifiable, Hashable, Sendable {
     // MARK: Lifecycle
 
     /// Creates a request.
-    public init(id: String, path: String, workingDirectory: String, processIdentifier: Int32) {
+    public init(
+        id: String,
+        path: String,
+        workingDirectory: String,
+        processIdentifier: Int32,
+        kind: Kind = .edit,
+    ) {
         self.id = id
         self.path = path
         self.workingDirectory = workingDirectory
         self.processIdentifier = processIdentifier
+        self.kind = kind
     }
 
     /// Decodes one spooled request, whose file name is its id; nil
@@ -26,10 +33,33 @@ public struct ExternalEdit: Identifiable, Hashable, Sendable {
             path: payload.path,
             workingDirectory: payload.workingDirectory,
             processIdentifier: payload.processIdentifier,
+            kind: payload.kind.flatMap(Kind.init(rawValue:)) ?? .edit,
         )
     }
 
     // MARK: Public
+
+    // The formatter strips raw values equal to their case name and
+    // the linter asks for them, so the rule is off here, as it is
+    // around coding keys.
+    // swiftlint:disable explicit_enum_raw_value
+
+    /// What the command asked the app for.
+    public enum Kind: String, Sendable {
+        /// Edit this file and hold the command until it is done.
+        case edit
+
+        /// Show this file; the command has already gone.
+        case open
+
+        /// Select this worktree or repository.
+        case select
+    }
+
+    // swiftlint:enable explicit_enum_raw_value
+
+    /// What was asked for.
+    public let kind: Kind
 
     /// The request's identity, which is its spool file's name.
     public let id: String
@@ -47,6 +77,12 @@ public struct ExternalEdit: Identifiable, Hashable, Sendable {
     /// be swept: the shim always waits, so its process being alive
     /// is exactly the request still mattering.
     public let processIdentifier: Int32
+
+    /// Whether the command is still there waiting for an answer;
+    /// only then does its process being alive mean anything.
+    public var waitsForAnswer: Bool {
+        kind == .edit
+    }
 
     /// The file's name, for the editor's header.
     public var name: String {
@@ -66,5 +102,7 @@ public struct ExternalEdit: Identifiable, Hashable, Sendable {
         let path: String
         let workingDirectory: String
         let processIdentifier: Int32
+        /// Absent in requests from an older shim, which all waited.
+        let kind: String?
     }
 }

--- a/Sources/DashboardFeature/AgentOptionPickers.swift
+++ b/Sources/DashboardFeature/AgentOptionPickers.swift
@@ -32,12 +32,18 @@ struct AgentOptionPickers: View {
             }
             .hoverHelp("The agent CLI to run")
             Picker("Model", selection: $model) {
+                // The unpicked state is a row of its own: a
+                // selection matching no row leaves the picker blank,
+                // which reads as a bug rather than as a choice
+                // waiting to be made.
+                Text("Choose…").tag("")
                 ForEach(choices(agent).models, id: \.self) { name in
                     Text(Self.display(name)).tag(name)
                 }
             }
             .hoverHelp("The model the agent uses; pick one to start")
             Picker("Effort", selection: $effort) {
+                Text("Choose…").tag("")
                 ForEach(choices(agent).efforts, id: \.self) { name in
                     Text(Self.display(name)).tag(name)
                 }

--- a/Sources/DashboardFeature/AgentOptionPickers.swift
+++ b/Sources/DashboardFeature/AgentOptionPickers.swift
@@ -3,8 +3,9 @@ import SwiftUI
 import TerminalUI
 
 /// The agent, model and effort dropdowns shared by every session
-/// creation surface. An empty model or effort keeps the agent's
-/// default.
+/// creation surface. Neither model nor effort has a default: until
+/// one has been picked the picker stands empty and the form refuses
+/// to start, and afterwards the last pick is what comes back.
 struct AgentOptionPickers: View {
     // MARK: Internal
 
@@ -31,19 +32,17 @@ struct AgentOptionPickers: View {
             }
             .hoverHelp("The agent CLI to run")
             Picker("Model", selection: $model) {
-                Text("Default").tag("")
                 ForEach(choices(agent).models, id: \.self) { name in
                     Text(Self.display(name)).tag(name)
                 }
             }
-            .hoverHelp("The model the agent uses; Default leaves it to the agent")
+            .hoverHelp("The model the agent uses; pick one to start")
             Picker("Effort", selection: $effort) {
-                Text("Default").tag("")
                 ForEach(choices(agent).efforts, id: \.self) { name in
                     Text(Self.display(name)).tag(name)
                 }
             }
-            .hoverHelp("How much reasoning the agent spends; Default leaves it to the agent")
+            .hoverHelp("How much reasoning the agent spends; pick one to start")
         }
         .labelsHidden()
         // On appearance as well as on change: the agent, model and
@@ -72,7 +71,8 @@ struct AgentOptionPickers: View {
     }
 
     /// A model or effort picked for one agent may not exist on
-    /// another; fall back to the default rather than sending it.
+    /// another; it is unpicked rather than sent, so the agent that
+    /// is chosen now gets a choice of its own.
     private func resetUnavailableChoices() {
         let available = choices(agent)
         if available.models.contains(model) == false {

--- a/Sources/DashboardFeature/AgentSessionForm.swift
+++ b/Sources/DashboardFeature/AgentSessionForm.swift
@@ -117,7 +117,7 @@ struct AgentSessionForm: View {
     }
 
     private var submitDisabled: Bool {
-        guard repository != nil else {
+        guard repository != nil, agentModel.isEmpty == false, agentEffort.isEmpty == false else {
             return true
         }
 

--- a/Sources/DashboardFeature/DashboardModel+Defaults.swift
+++ b/Sources/DashboardFeature/DashboardModel+Defaults.swift
@@ -1,0 +1,25 @@
+import AgentIDEDomain
+import Foundation
+
+extension DashboardModel {
+    /// Hands the window's own choices to the shared workspace, where
+    /// `agentide new` reads them: a session started from a phone
+    /// then offers exactly what the New Session form offers, already
+    /// set to what it was last set to.
+    func publishSessionDefaults() {
+        let defaults = UserDefaults.standard
+        var values: [(key: String, value: String)] = [
+            ("repository", selection?.worktree.repositoryName ?? repositories.first?.name ?? ""),
+            ("agent", defaults.string(forKey: "agentKind") ?? AgentKind.claudeCode.rawValue),
+            ("model", defaults.string(forKey: "agentModel") ?? ""),
+            ("effort", defaults.string(forKey: "agentEffort") ?? ""),
+            ("repositories", repositories.map(\.name).joined(separator: " ")),
+        ]
+        for agent in AgentKind.allCases {
+            let choices = launchChoices(for: agent)
+            values.append((agent.rawValue + "-models", choices.models.joined(separator: " ")))
+            values.append((agent.rawValue + "-efforts", choices.efforts.joined(separator: " ")))
+        }
+        service.publishSessionDefaults(values)
+    }
+}

--- a/Sources/DashboardFeature/DashboardModel+Defaults.swift
+++ b/Sources/DashboardFeature/DashboardModel+Defaults.swift
@@ -2,36 +2,37 @@ import AgentIDEDomain
 import Foundation
 
 extension DashboardModel {
-    /// Hands the window's own choices to the shared workspace, where
-    /// `agentide new` reads them: a session started from a phone
-    /// then offers exactly what the New Session form offers, already
-    /// set to what it was last set to.
-    func publishSessionDefaults() {
-        let defaults = UserDefaults.standard
-        // The form keeps one model and effort, for the agent it is
-        // set to, so they are published under that agent's name:
-        // Codex's model offered for a Claude session would be a
-        // model Claude has never heard of.
-        let chosen = defaults.string(forKey: "agentKind") ?? AgentKind.claudeCode.rawValue
+    /// Hands `agentide new` what only the app can know: which
+    /// repositories exist and what each agent offers. What was last
+    /// chosen is not published here, since the command chooses too
+    /// and its choice must survive the next poll.
+    func publishSessionChoices() {
         var values: [(key: String, value: String)] = [
-            ("repository", selection?.worktree.repositoryName ?? repositories.first?.name ?? ""),
-            ("agent", chosen),
             ("repositories", repositories.map(\.name).joined(separator: " ")),
         ]
         for agent in AgentKind.allCases {
             let choices = launchChoices(for: agent)
-            let isChosen = agent.rawValue == chosen
             values.append((agent.rawValue + "-models", choices.models.joined(separator: " ")))
             values.append((agent.rawValue + "-efforts", choices.efforts.joined(separator: " ")))
-            values.append((
-                agent.rawValue + "-model",
-                isChosen ? defaults.string(forKey: "agentModel") ?? "" : "",
-            ))
-            values.append((
-                agent.rawValue + "-effort",
-                isChosen ? defaults.string(forKey: "agentEffort") ?? "" : "",
-            ))
         }
-        service.publishSessionDefaults(values)
+        service.publishSessionChoices(values)
+    }
+
+    /// Remembers what a session was just started with, so the next
+    /// one, here or from a phone, comes back to it. The model and
+    /// effort are kept under their agent's name: the form keeps one
+    /// pair, and Codex's model means nothing to Claude.
+    func rememberLaunch(sessionName: String) {
+        let defaults = UserDefaults.standard
+        guard let agent = AgentKind.allCases.first(where: { sessionName.hasSuffix("--" + $0.rawValue) }) else {
+            return
+        }
+
+        service.publishSessionChoices([
+            ("repository", SessionName.repositorySlug(of: sessionName) ?? ""),
+            ("agent", agent.rawValue),
+            (agent.rawValue + "-model", defaults.string(forKey: "agentModel") ?? ""),
+            (agent.rawValue + "-effort", defaults.string(forKey: "agentEffort") ?? ""),
+        ])
     }
 }

--- a/Sources/DashboardFeature/DashboardModel+Defaults.swift
+++ b/Sources/DashboardFeature/DashboardModel+Defaults.swift
@@ -8,17 +8,29 @@ extension DashboardModel {
     /// set to what it was last set to.
     func publishSessionDefaults() {
         let defaults = UserDefaults.standard
+        // The form keeps one model and effort, for the agent it is
+        // set to, so they are published under that agent's name:
+        // Codex's model offered for a Claude session would be a
+        // model Claude has never heard of.
+        let chosen = defaults.string(forKey: "agentKind") ?? AgentKind.claudeCode.rawValue
         var values: [(key: String, value: String)] = [
             ("repository", selection?.worktree.repositoryName ?? repositories.first?.name ?? ""),
-            ("agent", defaults.string(forKey: "agentKind") ?? AgentKind.claudeCode.rawValue),
-            ("model", defaults.string(forKey: "agentModel") ?? ""),
-            ("effort", defaults.string(forKey: "agentEffort") ?? ""),
+            ("agent", chosen),
             ("repositories", repositories.map(\.name).joined(separator: " ")),
         ]
         for agent in AgentKind.allCases {
             let choices = launchChoices(for: agent)
+            let isChosen = agent.rawValue == chosen
             values.append((agent.rawValue + "-models", choices.models.joined(separator: " ")))
             values.append((agent.rawValue + "-efforts", choices.efforts.joined(separator: " ")))
+            values.append((
+                agent.rawValue + "-model",
+                isChosen ? defaults.string(forKey: "agentModel") ?? "" : "",
+            ))
+            values.append((
+                agent.rawValue + "-effort",
+                isChosen ? defaults.string(forKey: "agentEffort") ?? "" : "",
+            ))
         }
         service.publishSessionDefaults(values)
     }

--- a/Sources/DashboardFeature/DashboardModel+Sessions.swift
+++ b/Sources/DashboardFeature/DashboardModel+Sessions.swift
@@ -138,6 +138,7 @@ public extension DashboardModel {
         do {
             screenError = nil
             let sessionName = try await work()
+            rememberLaunch(sessionName: sessionName)
             await refreshUntil { items in items.contains { $0.session?.name == sessionName } }
             if let created = groups.flatMap(\.items).first(where: { $0.session?.name == sessionName }) {
                 launchProgress.report("Listed; opening the pane of `" + sessionName + "`")

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -225,7 +225,7 @@ public final class DashboardModel {
                 discoveredModels[agent] = models
             }
         }
-        publishSessionDefaults()
+        publishSessionChoices()
         while Task.isCancelled == false {
             await refresh()
             try? await Task.sleep(for: .seconds(Self.pollInterval))

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -225,6 +225,7 @@ public final class DashboardModel {
                 discoveredModels[agent] = models
             }
         }
+        publishSessionDefaults()
         while Task.isCancelled == false {
             await refresh()
             try? await Task.sleep(for: .seconds(Self.pollInterval))

--- a/Tests/AgentIDEDataTests/CommandLineSessionTests.swift
+++ b/Tests/AgentIDEDataTests/CommandLineSessionTests.swift
@@ -48,6 +48,17 @@ struct CommandLineSessionTests {
         #expect(plan["command"]?.contains("-c model_reasoning_effort=minimal") == true)
     }
 
+    @Test
+    func `an agent the window kept no model for launches without one`() async throws {
+        let shared = try Self.makeWorkspace()
+
+        // Codex, then Enter through its effort and model, neither of
+        // which the window kept: the launch passes no flags at all.
+        let plan = try await Self.plan(answering: "\n2\n\n\ntidy the docs\n", in: shared)
+
+        #expect(plan["command"]?.hasPrefix("codex \"") == true)
+    }
+
     // MARK: Private
 
     /// The command in the checkout, which is the copy the app bundles
@@ -74,13 +85,15 @@ struct CommandLineSessionTests {
         try """
         repository=brew
         agent=claude
-        model=opus-5
-        effort=high
         repositories=AgentIDE brew
         claude-models=opus-5 sonnet-5
         claude-efforts=low medium high xhigh max
+        claude-model=opus-5
+        claude-effort=high
         codex-models=gpt-5.6-sol
         codex-efforts=minimal low medium high xhigh
+        codex-model=
+        codex-effort=
 
         """.write(toFile: shared + "/agentide/session-defaults", atomically: true, encoding: .utf8)
         return shared

--- a/Tests/AgentIDEDataTests/CommandLineSessionTests.swift
+++ b/Tests/AgentIDEDataTests/CommandLineSessionTests.swift
@@ -1,0 +1,108 @@
+@testable import AgentIDEData
+import AgentIDEDomain
+import Foundation
+import Testing
+
+/// `agentide new` makes sessions the app has to recognise, so the
+/// names, paths and launch command it computes are pinned to the
+/// app's own, and its questions are answered the way a phone
+/// answers them: mostly by pressing Enter.
+struct CommandLineSessionTests {
+    // MARK: Internal
+
+    @Test
+    func `pressing enter through the questions names the session as the app would`() async throws {
+        let prompt = "Fix the flaky Formula test, please!"
+        let shared = try Self.makeWorkspace()
+
+        let plan = try await Self.plan(answering: "\n\n\n\n" + prompt + "\n", in: shared)
+
+        let branch = SessionName.slug(String(prompt.prefix(40))).replacing("-", with: "_")
+        let label = SessionName.make(repository: "brew", branch: branch, agent: .claudeCode)
+        #expect(plan["branch"] == branch)
+        #expect(plan["label"] == label)
+        #expect(plan["worktree"] == shared + "/worktrees/brew/" + branch)
+        #expect(plan["prompt"] == shared + "/agentide/prompts/" + label + ".md")
+        // The window's own last choices, which the app publishes.
+        #expect(plan["command"]?.hasPrefix("claude --model opus-5 --effort high ") == true)
+    }
+
+    @Test
+    func `an answer that is neither a number nor a name is asked again`() async throws {
+        let shared = try Self.makeWorkspace()
+
+        let plan = try await Self.plan(answering: "9\nnonsense\n2\n\n\n\n\nfix it\n", in: shared)
+
+        // The rejected answers cost nothing: the run reached the same
+        // session the accepted ones name.
+        #expect(plan["label"] == SessionName.make(repository: "brew", branch: "fix_it", agent: .claudeCode))
+    }
+
+    @Test
+    func `choices are picked by number, and each agent spells its own effort`() async throws {
+        let shared = try Self.makeWorkspace()
+
+        let plan = try await Self.plan(answering: "2\n2\n1\n1\ntidy the docs\n", in: shared)
+
+        #expect(plan["label"] == SessionName.make(repository: "brew", branch: "tidy_the_docs", agent: .codexCLI))
+        #expect(plan["command"]?.contains("-c model_reasoning_effort=minimal") == true)
+    }
+
+    // MARK: Private
+
+    /// The command in the checkout, which is the copy the app bundles
+    /// and installs into the shared workspace.
+    private static let command = URL(filePath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appending(path: "bin/agentide")
+        .path
+
+    /// A shared workspace holding one repository and the defaults the
+    /// app publishes from the window.
+    private static func makeWorkspace() throws -> String {
+        let shared = try TestSupport.temporaryDirectory("command-line")
+        try FileManager.default.createDirectory(
+            atPath: shared + "/repositories/brew/.git",
+            withIntermediateDirectories: true,
+        )
+        try FileManager.default.createDirectory(
+            atPath: shared + "/agentide",
+            withIntermediateDirectories: true,
+        )
+        try """
+        repository=brew
+        agent=claude
+        model=opus-5
+        effort=high
+        repositories=AgentIDE brew
+        claude-models=opus-5 sonnet-5
+        claude-efforts=low medium high xhigh max
+        codex-models=gpt-5.6-sol
+        codex-efforts=minimal low medium high xhigh
+
+        """.write(toFile: shared + "/agentide/session-defaults", atomically: true, encoding: .utf8)
+        return shared
+    }
+
+    /// What the command says it would make, given those answers.
+    private static func plan(answering answers: String, in shared: String) async throws -> [String: String] {
+        let script = "printf '%s' " + answers.shellQuoted + " | " + command.shellQuoted + " new"
+        let result = try await TestSupport.run([
+            "/usr/bin/env",
+            "SHARED_WORKSPACE=" + shared,
+            "AGENTIDE_DRY_RUN=1",
+            "/bin/sh",
+            "-c",
+            script,
+        ])
+        try #require(result.succeeded)
+        return result.standardOutput.split(separator: "\n").reduce(into: [:]) { plan, line in
+            let parts = line.split(separator: "=", maxSplits: 1)
+            if parts.count == 2 {
+                plan[String(parts[0])] = String(parts[1])
+            }
+        }
+    }
+}

--- a/Tests/AgentIDEDataTests/CommandLineSessionTests.swift
+++ b/Tests/AgentIDEDataTests/CommandLineSessionTests.swift
@@ -49,14 +49,24 @@ struct CommandLineSessionTests {
     }
 
     @Test
-    func `an agent the window kept no model for launches without one`() async throws {
+    func `a choice nothing was made before insists, and is remembered after`() async throws {
         let shared = try Self.makeWorkspace()
+        let file = shared + "/agentide/session-defaults"
+        // Nothing chosen for Codex yet: Enter is refused until its
+        // effort and model are picked.
+        let plan = try await Self.plan(answering: "\n2\n\n1\n1\ntidy the docs\n", in: shared)
 
-        // Codex, then Enter through its effort and model, neither of
-        // which the window kept: the launch passes no flags at all.
-        let plan = try await Self.plan(answering: "\n2\n\n\ntidy the docs\n", in: shared)
+        #expect(plan["command"]?.contains("--model gpt-5.6-sol") == true)
+        #expect(plan["command"]?.contains("-c model_reasoning_effort=minimal") == true)
 
-        #expect(plan["command"]?.hasPrefix("codex \"") == true)
+        // What was chosen is what the next session, in either
+        // surface, comes back to.
+        let kept = try String(contentsOfFile: file, encoding: .utf8)
+        #expect(kept.contains("codex-model=gpt-5.6-sol"))
+        #expect(kept.contains("codex-effort=minimal"))
+        #expect(kept.contains("agent=codex"))
+        // Everything else in the file survives the write.
+        #expect(kept.contains("claude-models=opus-5 sonnet-5"))
     }
 
     // MARK: Private
@@ -90,10 +100,8 @@ struct CommandLineSessionTests {
         claude-efforts=low medium high xhigh max
         claude-model=opus-5
         claude-effort=high
-        codex-models=gpt-5.6-sol
+        codex-models=gpt-5.6-sol gpt-5.5
         codex-efforts=minimal low medium high xhigh
-        codex-model=
-        codex-effort=
 
         """.write(toFile: shared + "/agentide/session-defaults", atomically: true, encoding: .utf8)
         return shared

--- a/Tests/AgentIDEDataTests/EditorShimIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/EditorShimIntegrationTests.swift
@@ -70,6 +70,73 @@ struct EditorShimIntegrationTests {
     }
 
     @Test
+    func `without waiting a file is asked for and the command returns at once`() async throws {
+        let root = try TestSupport.temporaryDirectory("shim-open")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let shim = shim(root: root)
+        let spool = ExternalEditSpool(directory: paths(root: root).editsDirectory)
+        let file = root + "/notes.md"
+        try "notes\n".write(toFile: file, atomically: true, encoding: .utf8)
+
+        let process = try run(shim, arguments: ["notes.md"], in: root)
+        try await exit(of: process)
+        #expect(process.terminationStatus == 0)
+
+        // The request outlives the command that made it, since
+        // nothing is waiting to be answered.
+        let edit = try #require(spool.pending().first)
+        #expect(edit.kind == .open)
+        #expect(edit.path == file)
+        #expect(edit.waitsForAnswer == false)
+    }
+
+    @Test
+    func `anywhere inside a worktree selects it, and outside the workspace is refused`() async throws {
+        let root = try TestSupport.temporaryDirectory("shim-select")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let shim = shim(root: root)
+        let spool = ExternalEditSpool(directory: paths(root: root).editsDirectory)
+        let shared = paths(root: root).sharedWorkspace
+        let worktree = shared + "/worktrees/brew/fix_it"
+        // Deep inside the worktree: the row is what gets selected.
+        let inside = worktree + "/Sources/Deep"
+        // Under the workspace, but no row above it.
+        let outside = shared + "/worktrees"
+        for directory in [inside, outside] {
+            try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        }
+
+        let selecting = try run(shim, arguments: [inside], in: root, sharedWorkspace: shared)
+        try await exit(of: selecting)
+        #expect(selecting.terminationStatus == 0)
+        let edit = try #require(spool.pending().first)
+        #expect(edit.kind == .select)
+        #expect(edit.path == worktree)
+
+        let refused = try run(shim, arguments: [outside], in: root, sharedWorkspace: shared)
+        try await exit(of: refused)
+        #expect(refused.terminationStatus == 66)
+        #expect(spool.pending().count == 1)
+    }
+
+    @Test
+    func `help is offered, and printed for anything it cannot make sense of`() async throws {
+        let root = try TestSupport.temporaryDirectory("shim-help")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let shim = shim(root: root)
+
+        let helping = try run(shim, arguments: ["--help"], in: root)
+        try await exit(of: helping)
+        #expect(helping.terminationStatus == 0)
+
+        for arguments in [["--nonsense"], []] {
+            let refused = try run(shim, arguments: arguments, in: root)
+            try await exit(of: refused)
+            #expect(refused.terminationStatus == 64)
+        }
+    }
+
+    @Test
     func `a shell pane is told where the shim is and that it is one`() throws {
         let root = try TestSupport.temporaryDirectory("shim-env")
         defer { try? FileManager.default.removeItem(atPath: root) }
@@ -119,12 +186,22 @@ struct EditorShimIntegrationTests {
         )
     }
 
-    private func run(_ shim: EditorShim, arguments: [String], in directory: String) throws -> Process {
+    private func run(
+        _ shim: EditorShim,
+        arguments: [String],
+        in directory: String,
+        sharedWorkspace: String? = nil,
+    ) throws -> Process {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shim.path)
         process.arguments = arguments
         process.currentDirectoryURL = URL(fileURLWithPath: directory)
-        process.environment = ProcessInfo.processInfo.environment.merging(shim.environment) { _, new in new }
+        var environment = shim.environment
+        // The command judges a directory against this workspace, and
+        // the tests own one of their own; without it the checkout's
+        // real workspace would judge the scratch directories.
+        environment["SHARED_WORKSPACE"] = sharedWorkspace ?? (directory + "/nowhere")
+        process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
         try process.run()
         return process
     }

--- a/bin/agentide
+++ b/bin/agentide
@@ -52,6 +52,39 @@ fail() {
   exit "${2:-64}"
 }
 
+# Everything this command does, printed by --help and by anything it
+# cannot make sense of.
+usage() {
+  cat >&2 <<USAGE
+$(bold 'agentide') — AgentIDE from the command line
+
+$(bold 'agentide') [-w|--wait] <file>...
+    Show a file in the app's editor. Waits until the file is saved
+    and closed only with --wait, which is what EDITOR, VISUAL and
+    GIT_EDITOR want; without it the command returns at once.
+
+$(bold 'agentide') <directory>
+    Select that worktree or repository in the app. Only a checkout
+    under \$SHARED_WORKSPACE/repositories or a worktree under
+    \$SHARED_WORKSPACE/worktrees is accepted.
+
+$(bold 'agentide new')
+    Start a session: asks for the repository, agent, effort, model
+    and prompt, each already set to what the app last used, then
+    makes the worktree, launches the agent and attaches to it.
+
+$(bold 'agentide') --help
+    This.
+
+Environment:
+    SHARED_WORKSPACE   the sandvault workspace (default: /Users/Shared/sv-\$USER)
+    AGENTIDE_EDITS     the request spool the app reads
+    HERDR_SESSION      the herdr session sessions are created in
+    NO_COLOR           plain output; AGENTIDE_COLOR forces colour
+USAGE
+  exit "${1:-64}"
+}
+
 # Where the app publishes what the window last had chosen, so the
 # phone offers the same repositories, agents, models and efforts,
 # with the same ones already selected.
@@ -247,26 +280,29 @@ spool="${AGENTIDE_EDITS:-${HOME}/.agentide/edits}"
 claim_tries=50
 poll_seconds=0.2
 
+wait_for_answer=no
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    # Waiting is the only behaviour, but editors are configured
-    # with the flag either way, so both spellings are accepted.
-    -w | --wait) shift ;;
+    # Only an editor waits: EDITOR, VISUAL and GIT_EDITOR are set
+    # with the flag, and anything else wants its shell back.
+    -w | --wait)
+      wait_for_answer=yes
+      shift
+      ;;
+    -h | --help) usage 0 ;;
     --)
       shift
       break
       ;;
     -*)
-      fail "unknown option: $1"
+      warn "unknown option: $1"
+      usage
       ;;
     *) break ;;
   esac
 done
 
-if [ "$#" -eq 0 ]; then
-  printf 'usage: %s [-w|--wait] file...\n' "$(bold agentide)" >&2
-  exit 64
-fi
+[ "$#" -gt 0 ] || usage
 
 mkdir -p "${spool}"
 
@@ -279,14 +315,56 @@ for file in "$@"; do
     /*) path="${file}" ;;
     *) path="${cwd}/${file}" ;;
   esac
+  kind=open
+  [ "${wait_for_answer}" = no ] || kind=edit
+  request_cwd="${cwd}"
+  if [ -d "${path}" ]; then
+    # A directory is a place to go to, and only a checkout or a
+    # worktree of the shared workspace is one the app can show.
+    shared="${SHARED_WORKSPACE:-/Users/Shared/sv-$(printf '%s' "${USER}" | sed 's/^sandvault-//')}"
+    # Both sides physical, since a temporary directory or a home on
+    # a symlink would otherwise never match its own workspace.
+    shared="$(cd "${shared}" 2>/dev/null && pwd -P || printf '%s' "${shared}")"
+    path="$(cd "${path}" && pwd -P)"
+    # A checkout is one name under `repositories`, a worktree two
+    # under `worktrees`, and those are the rows the app can select.
+    # Anywhere inside one counts as it: `agentide .` deep in a tree
+    # is how you get back to the window, so the path walks up until
+    # it is a row or has left the workspace.
+    row=""
+    candidate="${path}"
+    while [ "${candidate}" != "/" ]; do
+      case "${candidate}" in
+        "${shared}/"*) rest="${candidate#"${shared}/"}" ;;
+        *) break ;;
+      esac
+      case "${rest}" in
+        repositories/*/* | worktrees/*/*/*) ;;
+        repositories/* | worktrees/*/*)
+          row="${candidate}"
+          break
+          ;;
+        *) break ;;
+      esac
+      candidate="$(dirname "${candidate}")"
+    done
+    [ -n "${row}" ] || fail "not inside a repository or worktree of ${shared}: ${path}" 66
+    path="${row}"
+    kind=select
+    request_cwd="${path}"
+  fi
   id="$(/usr/bin/uuidgen)"
   request="${spool}/${id}.request"
   trap 'rm -f "${request}" "${spool}/${id}.open" "${spool}/${id}.done"; exit 130' HUP INT TERM
-  printf '{"path":"%s","workingDirectory":"%s","processIdentifier":%s}\n' \
+  printf '{"path":"%s","workingDirectory":"%s","processIdentifier":%s,"kind":"%s"}\n' \
     "$(printf '%s' "${path}" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
-    "$(printf '%s' "${cwd}" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
-    "$$" >"${request}.partial"
+    "$(printf '%s' "${request_cwd}" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
+    "$$" "${kind}" >"${request}.partial"
   mv "${request}.partial" "${request}"
+
+  # Only an editor waits for the app; everything else has said what
+  # it wanted and is done.
+  [ "${kind}" = edit ] || continue
 
   # The app claims a request as soon as it shows the file, so an
   # unclaimed one means it is not running.

--- a/bin/agentide
+++ b/bin/agentide
@@ -1,10 +1,241 @@
 #!/bin/sh
-# AgentIDE's editor shim, shipped inside the app bundle and put on a
-# shell pane's PATH. It hands a file to the app's own editor and
-# waits there until the file is saved and closed, so it can serve as
-# EDITOR, VISUAL or GIT_EDITOR. A cancelled edit exits non-zero,
-# which is how git is told to abort.
+# AgentIDE's command, shipped inside the app bundle and copied into
+# the shared workspace so the sandbox user has it over SSH too.
+#
+# Without a subcommand it is the editor shim: a shell pane finds it
+# on its PATH, so `git rebase -i` and `git commit` there edit their
+# files in the app's own editor and wait until they are saved and
+# closed. A cancelled edit exits non-zero, which is how git is told
+# to abort.
+#
+# `agentide new` starts a session the way the app does, for a phone
+# over SSH. It takes no arguments: it asks for the repository, agent,
+# effort, model and prompt in turn, each offering what the window
+# last had chosen, so Enter four times and a sentence is a session.
+# It then makes the worktree, writes the prompt file, creates the
+# herdr workspace under the label the app recognises, launches the
+# agent and attaches to it. The app needs telling nothing, since it
+# derives every session from herdr and git.
 set -eu
+
+# Colour on the same terms Homebrew uses: a terminal that has not
+# asked for plain output, or an explicit request. Everything the
+# command says goes to stderr, so that is the stream judged.
+colour_enabled() {
+  [ -n "${AGENTIDE_COLOR:-}" ] && return 0
+  [ -t 2 ] && [ -z "${NO_COLOR:-}" ]
+}
+
+tint() {
+  if colour_enabled; then
+    printf '\033[%sm%s\033[0m' "$1" "$2"
+  else
+    printf '%s' "$2"
+  fi
+}
+
+bold() {
+  tint 1 "$1"
+}
+
+# A step, as `==> Doing something`: blue arrow, bold text.
+headline() {
+  printf '%s %s\n' "$(tint 34 '==>')" "$(bold "$1")" >&2
+}
+
+warn() {
+  printf '%s %s\n' "$(tint '1;33' 'Warning:')" "$1" >&2
+}
+
+fail() {
+  printf '%s %s\n' "$(tint '1;31' 'Error:')" "$1" >&2
+  exit "${2:-64}"
+}
+
+# Where the app publishes what the window last had chosen, so the
+# phone offers the same repositories, agents, models and efforts,
+# with the same ones already selected.
+defaults_file() {
+  printf '%s' "${1}/agentide/session-defaults"
+}
+
+# One key's value out of that file, empty when it or the file is
+# missing.
+default_for() {
+  [ -f "$2" ] || return 0
+  sed -n "s/^$1=//p" "$2" | head -1
+}
+
+# Asks a question with a numbered list, where Enter takes the
+# default, a number takes that item and a name takes itself. Kept to
+# two lines, since the reader is on a phone, and asked again when the
+# answer is neither, so a mistyped number never starts the wrong
+# agent.
+ask_choice() {
+  label="$1"
+  default="$2"
+  shift 2
+  index=0
+  line=""
+  for option in "$@"; do
+    index=$((index + 1))
+    line="${line}$(tint '1;34' "${index}") ${option}  "
+  done
+  while true; do
+    [ -z "${line}" ] || printf '%s\n' "${line%  }" >&2
+    printf '%s [%s]: ' "$(bold "${label}")" "$(tint 32 "${default}")" >&2
+    if ! IFS= read -r answer; then
+      printf '\n' >&2
+      fail "nothing to read" 65
+    fi
+    # Enter takes the default, whatever it is, including nothing.
+    if [ -z "${answer}" ]; then
+      printf '%s' "${default}"
+      return 0
+    fi
+    # A list the app has not published yet cannot judge an answer.
+    if [ "$#" -eq 0 ]; then
+      printf '%s' "${answer}"
+      return 0
+    fi
+    index=0
+    for option in "$@"; do
+      index=$((index + 1))
+      if [ "${answer}" = "${index}" ] || [ "${answer}" = "${option}" ]; then
+        printf '%s' "${option}"
+        return 0
+      fi
+    done
+    warn "not one of those"
+
+  done
+}
+
+# Asks for a line of text, again while it is empty.
+ask_text() {
+  while true; do
+    printf '%s: ' "$(bold "$1")" >&2
+    if ! IFS= read -r answer; then
+      printf '\n' >&2
+      fail "nothing to read" 65
+    fi
+    if [ -n "${answer}" ]; then
+      printf '%s' "${answer}"
+      return 0
+    fi
+  done
+}
+
+# The app's own slug: lowercase, anything else a dash, runs collapsed
+# and the ends trimmed, never empty.
+slug() {
+  out="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' |
+    sed -e 's/[^a-z0-9-]/-/g' -e 's/--*/-/g' -e 's/^-//' -e 's/-$//')"
+  [ -n "${out}" ] || out="unnamed"
+  printf '%s' "${out}"
+}
+
+# What the app calls a branch it names from a prompt: the same slug
+# over the prompt's first words, with underscores between them.
+branch_from_prompt() {
+  printf '%s' "$(slug "$(printf '%s' "$1" | cut -c1-40)")" | tr '-' '_'
+}
+
+agentide_new() {
+  # The sandbox user's launcher exports this; a plain SSH login does
+  # not, so the host user's name is read off this account's own.
+  shared="${SHARED_WORKSPACE:-/Users/Shared/sv-$(printf '%s' "${USER}" | sed 's/^sandvault-//')}"
+  defaults="$(defaults_file "${shared}")"
+
+  repositories="$(default_for repositories "${defaults}")"
+  if [ -z "${repositories}" ] && [ -d "${shared}/repositories" ]; then
+    repositories="$(ls "${shared}/repositories" 2>/dev/null | tr '\n' ' ')"
+  fi
+
+  # shellcheck disable=SC2086
+  repository="$(ask_choice Repository "$(default_for repository "${defaults}")" ${repositories})"
+  [ -n "${repository}" ] || fail "no repository to choose from in ${shared}/repositories" 66
+
+  agent="$(ask_choice Agent "$(default_for agent "${defaults}")" claude codex)"
+  [ -n "${agent}" ] || agent=claude
+
+  efforts="$(default_for "${agent}-efforts" "${defaults}")"
+  models="$(default_for "${agent}-models" "${defaults}")"
+  # shellcheck disable=SC2086
+  effort="$(ask_choice Effort "$(default_for effort "${defaults}")" ${efforts})"
+  # shellcheck disable=SC2086
+  model="$(ask_choice Model "$(default_for model "${defaults}")" ${models})"
+
+  prompt="$(ask_text Prompt)"
+
+  repository_path="${shared}/repositories/${repository}"
+  branch="$(branch_from_prompt "${prompt}")"
+
+  # Branch names are unique, as the app makes them: an existing one
+  # counts up rather than failing or joining someone else's work.
+  if [ -d "${repository_path}/.git" ] || [ -f "${repository_path}/.git" ]; then
+    attempt=2
+    while git -C "${repository_path}" rev-parse --verify --quiet \
+      "refs/heads/${branch}" >/dev/null 2>&1; do
+      branch="$(printf '%s' "${branch}" | sed 's/_[0-9]*$//')_${attempt}"
+      attempt=$((attempt + 1))
+    done
+  elif [ -z "${AGENTIDE_DRY_RUN:-}" ]; then
+    fail "no repository at ${repository_path}" 66
+  fi
+
+  label="agentide--$(slug "${repository}")--$(slug "${branch}")--${agent}"
+  worktree="${shared}/worktrees/${repository}/$(printf '%s' "${branch}" | tr '/' '-')"
+  prompt_file="${shared}/agentide/prompts/${label}.md"
+
+  # The launch flags the app would pass for the chosen model and
+  # effort; Codex spells its effort as a config override.
+  arguments=""
+  [ -z "${model}" ] || arguments="--model ${model}"
+  if [ -n "${effort}" ]; then
+    case "${agent}" in
+      codex) arguments="${arguments} -c model_reasoning_effort=${effort}" ;;
+      *) arguments="${arguments} --effort ${effort}" ;;
+    esac
+  fi
+  arguments="$(printf '%s' "${arguments}" | sed -e 's/^ *//' -e 's/ *$//')"
+  command="${agent}"
+  [ -z "${arguments}" ] || command="${command} ${arguments}"
+  command="${command} \"\$(cat '${prompt_file}')\""
+
+  if [ -n "${AGENTIDE_DRY_RUN:-}" ]; then
+    printf 'branch=%s\nlabel=%s\nworktree=%s\nprompt=%s\ncommand=%s\n' \
+      "${branch}" "${label}" "${worktree}" "${prompt_file}" "${command}"
+    return 0
+  fi
+
+  # The app's session, made the app's way: worktree, prompt file,
+  # then a labelled herdr workspace whose shell runs the agent under
+  # a temporary directory of its own, which Codex's execution host
+  # needs to survive its handshake.
+  headline "Creating ${worktree}"
+  mkdir -p "$(dirname "${worktree}")" "$(dirname "${prompt_file}")"
+  git -C "${repository_path}" worktree add -b "${branch}" "${worktree}" HEAD >&2
+  printf '%s\n' "${prompt}" >"${prompt_file}"
+
+  headline "Starting ${agent} in ${label}"
+  created="$(herdr workspace create --cwd "${worktree}" --label "${label}" \
+    --env "AGENTIDE_SESSION=${label}" --env "INITIAL_DIR=${worktree}" --no-focus)"
+  pane="$(printf '%s' "${created}" |
+    grep -o '"pane_id":"[^"]*"' | head -1 | cut -d '"' -f4)"
+  [ -n "${pane}" ] || fail "herdr did not name a pane for ${label}" 70
+  herdr pane run "${pane}" "export TMPDIR=\"\$(mktemp -d)\"; ${command}"
+
+  workspace="$(printf '%s' "${created}" |
+    grep -o '"workspace_id":"[^"]*"' | head -1 | cut -d '"' -f4)"
+  [ -z "${workspace}" ] || herdr workspace focus "${workspace}" >/dev/null 2>&1 || true
+  exec herdr
+}
+
+if [ "${1:-}" = "new" ]; then
+  agentide_new
+  exit 0
+fi
 
 # The app names its own spool, so a development build never answers
 # the installed app's shells; anything else means the installed one.
@@ -26,15 +257,14 @@ while [ "$#" -gt 0 ]; do
       break
       ;;
     -*)
-      printf 'agentide: unknown option: %s\n' "$1" >&2
-      exit 64
+      fail "unknown option: $1"
       ;;
     *) break ;;
   esac
 done
 
 if [ "$#" -eq 0 ]; then
-  printf 'usage: agentide [-w|--wait] file...\n' >&2
+  printf 'usage: %s [-w|--wait] file...\n' "$(bold agentide)" >&2
   exit 64
 fi
 
@@ -64,8 +294,7 @@ for file in "$@"; do
   while [ ! -e "${spool}/${id}.open" ] && [ ! -e "${spool}/${id}.done" ]; do
     if [ "${tries}" -ge "${claim_tries}" ]; then
       rm -f "${request}"
-      printf 'agentide: AgentIDE did not answer; is it running?\n' >&2
-      exit 69
+      fail "AgentIDE did not answer; is it running?" 69
     fi
     tries=$((tries + 1))
     sleep "${poll_seconds}"

--- a/bin/agentide
+++ b/bin/agentide
@@ -101,6 +101,18 @@ default_for() {
   sed -n "s/^$1=//p" "$2" | head -1
 }
 
+# What the app kept for this agent, or the word standing for the
+# agent choosing for itself: the window keeps no model or effort
+# while it is letting the CLI decide, and a question showing nothing
+# says less than one showing what will happen.
+own_choice="default"
+
+kept() {
+  value="$(default_for "$1" "$2")"
+  [ -n "${value}" ] || value="${own_choice}"
+  printf '%s' "${value}"
+}
+
 # Asks a question with a numbered list, where Enter takes the
 # default, a number takes that item and a name takes itself. Kept to
 # two lines, since the reader is on a phone, and asked again when the
@@ -233,9 +245,11 @@ agentide_new() {
   efforts="$(default_for "${agent}-efforts" "${defaults}")"
   models="$(default_for "${agent}-models" "${defaults}")"
   # shellcheck disable=SC2086
-  effort="$(ask_choice Effort "$(default_for effort "${defaults}")" ${efforts})"
+  effort="$(ask_choice Effort "$(kept "${agent}-effort" "${defaults}")" ${efforts})"
   # shellcheck disable=SC2086
-  model="$(ask_choice Model "$(default_for model "${defaults}")" ${models})"
+  model="$(ask_choice Model "$(kept "${agent}-model" "${defaults}")" ${models})"
+  [ "${effort}" != "${own_choice}" ] || effort=""
+  [ "${model}" != "${own_choice}" ] || model=""
 
   prompt="$(ask_text Prompt)"
 

--- a/bin/agentide
+++ b/bin/agentide
@@ -70,19 +70,10 @@ $(bold 'agentide') <directory>
 
 $(bold 'agentide new')
     Start a session: asks for the repository, agent, effort, model
-    and prompt, each already set to what the app last used, then
-    makes the worktree, launches the agent and attaches to it. Run
-    as yourself it runs itself as the sandbox user, which owns the
+    and prompt, each offering what was last chosen, then makes the
+    worktree, launches the agent and attaches to it. Run as
+    yourself it runs itself as the sandbox user, which owns the
     herdr server the sessions live in.
-
-$(bold 'agentide') --help
-    This.
-
-Environment:
-    SHARED_WORKSPACE   the sandvault workspace (default: /Users/Shared/sv-\$USER)
-    AGENTIDE_EDITS     the request spool the app reads
-    HERDR_SESSION      the herdr session to use (default: agentide)
-    NO_COLOR           plain output; AGENTIDE_COLOR forces colour
 USAGE
   exit "${1:-64}"
 }
@@ -101,16 +92,22 @@ default_for() {
   sed -n "s/^$1=//p" "$2" | head -1
 }
 
-# What the app kept for this agent, or the word standing for the
-# agent choosing for itself: the window keeps no model or effort
-# while it is letting the CLI decide, and a question showing nothing
-# says less than one showing what will happen.
-own_choice="default"
-
-kept() {
-  value="$(default_for "$1" "$2")"
-  [ -n "${value}" ] || value="${own_choice}"
-  printf '%s' "${value}"
+# Writes choices back into the defaults file, keeping every other
+# line: the file is one memory shared with the app, which merges the
+# same way, so a session started here is what both offer next.
+remember() {
+  file="$1"
+  shift
+  kept="$(cat "${file}" 2>/dev/null || true)"
+  for pair in "$@"; do
+    kept="$(printf '%s\n' "${kept}" | sed "/^${pair%%=*}=/d")"
+  done
+  mkdir -p "$(dirname "${file}")"
+  {
+    printf '%s\n' "${kept}" | sed '/^$/d'
+    printf '%s\n' "$@"
+  } | sort >"${file}.partial"
+  mv "${file}.partial" "${file}"
 }
 
 # Asks a question with a numbered list, where Enter takes the
@@ -130,15 +127,25 @@ ask_choice() {
   done
   while true; do
     [ -z "${line}" ] || printf '%s\n' "${line%  }" >&2
-    printf '%s [%s]: ' "$(bold "${label}")" "$(tint 32 "${default}")" >&2
+    if [ -n "${default}" ]; then
+      printf '%s [%s]: ' "$(bold "${label}")" "$(tint 32 "${default}")" >&2
+    else
+      # Nothing has been chosen before, so nothing is chosen for
+      # them: the question waits until it is answered.
+      printf '%s: ' "$(bold "${label}")" >&2
+    fi
     if ! IFS= read -r answer; then
       printf '\n' >&2
       fail "nothing to read" 65
     fi
-    # Enter takes the default, whatever it is, including nothing.
+    # Enter takes what was chosen last time, when there was one.
     if [ -z "${answer}" ]; then
-      printf '%s' "${default}"
-      return 0
+      if [ -n "${default}" ]; then
+        printf '%s' "${default}"
+        return 0
+      fi
+      warn "pick one"
+      continue
     fi
     # A list the app has not published yet cannot judge an answer.
     if [ "$#" -eq 0 ]; then
@@ -245,11 +252,9 @@ agentide_new() {
   efforts="$(default_for "${agent}-efforts" "${defaults}")"
   models="$(default_for "${agent}-models" "${defaults}")"
   # shellcheck disable=SC2086
-  effort="$(ask_choice Effort "$(kept "${agent}-effort" "${defaults}")" ${efforts})"
+  effort="$(ask_choice Effort "$(default_for "${agent}-effort" "${defaults}")" ${efforts})"
   # shellcheck disable=SC2086
-  model="$(ask_choice Model "$(kept "${agent}-model" "${defaults}")" ${models})"
-  [ "${effort}" != "${own_choice}" ] || effort=""
-  [ "${model}" != "${own_choice}" ] || model=""
+  model="$(ask_choice Model "$(default_for "${agent}-model" "${defaults}")" ${models})"
 
   prompt="$(ask_text Prompt)"
 
@@ -289,6 +294,8 @@ agentide_new() {
   command="${command} \"\$(cat '${prompt_file}')\""
 
   if [ -n "${AGENTIDE_DRY_RUN:-}" ]; then
+    remember "${defaults}" "repository=${repository}" "agent=${agent}" \
+      "${agent}-model=${model}" "${agent}-effort=${effort}"
     printf 'branch=%s\nlabel=%s\nworktree=%s\nprompt=%s\ncommand=%s\n' \
       "${branch}" "${label}" "${worktree}" "${prompt_file}" "${command}"
     return 0

--- a/bin/agentide
+++ b/bin/agentide
@@ -71,7 +71,9 @@ $(bold 'agentide') <directory>
 $(bold 'agentide new')
     Start a session: asks for the repository, agent, effort, model
     and prompt, each already set to what the app last used, then
-    makes the worktree, launches the agent and attaches to it.
+    makes the worktree, launches the agent and attaches to it. Run
+    as yourself it runs itself as the sandbox user, which owns the
+    herdr server the sessions live in.
 
 $(bold 'agentide') --help
     This.
@@ -79,7 +81,7 @@ $(bold 'agentide') --help
 Environment:
     SHARED_WORKSPACE   the sandvault workspace (default: /Users/Shared/sv-\$USER)
     AGENTIDE_EDITS     the request spool the app reads
-    HERDR_SESSION      the herdr session sessions are created in
+    HERDR_SESSION      the herdr session to use (default: agentide)
     NO_COLOR           plain output; AGENTIDE_COLOR forces colour
 USAGE
   exit "${1:-64}"
@@ -174,7 +176,43 @@ branch_from_prompt() {
   printf '%s' "$(slug "$(printf '%s' "$1" | cut -c1-40)")" | tr '-' '_'
 }
 
+# The sessions live in a herdr server the sandbox user owns, and
+# only that user can reach its socket. Run as the host user, the
+# command therefore runs itself as the sandbox user, through the
+# same sudo, env and sandbox-exec shape the app uses, so a terminal
+# on the Mac needs no setup of its own.
+reexec_in_sandbox() {
+  host="${USER}"
+  exec sudo --login --set-home --user="sandvault-${host}" \
+    /usr/bin/env -i \
+    "HOME=/Users/sandvault-${host}" \
+    "USER=sandvault-${host}" \
+    SHELL=/bin/zsh \
+    "TERM=${TERM:-xterm-256color}" \
+    COLORTERM=truecolor \
+    LANG=en_US.UTF-8 \
+    "SHARED_WORKSPACE=/Users/Shared/sv-${host}" \
+    "HERDR_SESSION=${HERDR_SESSION:-agentide}" \
+    "AGENTIDE_COLOR=${AGENTIDE_COLOR:-1}" \
+    PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin \
+    GIT_CONFIG_COUNT=1 \
+    GIT_CONFIG_KEY_0=safe.directory \
+    "GIT_CONFIG_VALUE_0=/Users/Shared/sv-${host}/*" \
+    /usr/bin/sandbox-exec -f "/var/sandvault/sandbox-sandvault-${host}.sb" \
+    /bin/zsh -c "exec ${0} new"
+}
+
 agentide_new() {
+  # Already the sandbox user when its home is this account's own.
+  case "${HOME}" in
+    /Users/sandvault-*) ;;
+    *) reexec_in_sandbox ;;
+  esac
+
+  # The app's session, unless something else is asked for; the
+  # server it names is the one the app starts and attaches to.
+  export HERDR_SESSION="${HERDR_SESSION:-agentide}"
+
   # The sandbox user's launcher exports this; a plain SSH login does
   # not, so the host user's name is read off this account's own.
   shared="${SHARED_WORKSPACE:-/Users/Shared/sv-$(printf '%s' "${USER}" | sed 's/^sandvault-//')}"

--- a/bin/agentide
+++ b/bin/agentide
@@ -222,10 +222,18 @@ reexec_in_sandbox() {
 }
 
 agentide_new() {
-  # Already the sandbox user when its home is this account's own.
+  # Already the sandbox user when its home is this account's own,
+  # and a dry run never reaches the server, so it stays where it is:
+  # tests run as neither user and have no sandbox to enter.
   case "${HOME}" in
     /Users/sandvault-*) ;;
-    *) reexec_in_sandbox ;;
+    *)
+      if [ -z "${AGENTIDE_DRY_RUN:-}" ]; then
+        [ -f "/var/sandvault/sandbox-sandvault-${USER}.sb" ] ||
+          fail "no sandvault sandbox for ${USER}; sessions run as its user" 69
+        reexec_in_sandbox
+      fi
+      ;;
   esac
 
   # The app's session, unless something else is asked for; the


### PR DESCRIPTION
- Add phone session launch with auto-fill and clear prompts, improved UX and shared state
  - Allow non-blocking opens via path navigation and automatic window switching
  - Enable host terminal reach via sandbox execution with proper environment isolation
  - Require explicit model and effort per agent, with clear handling for empty agents
  - Eliminate default inheritance by enforcing explicit selection and centralized session defaults