### PR TITLE
Name the repository, forget a failed creation, drop a fake list

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -882,10 +882,13 @@ shim rather than a protocol:
    bottom of a stack opens against the default branch exactly
    as a lone branch does, and keeps the lone branch's Rebase and Push
    rather than the stack's three buttons, however many branches sit
-   above it. Push acts on the entry in view, so it is that branch's
-   commits that are counted and that branch's tip whose signature is
-   checked; Rebase moves the branch the worktree holds, so it dims for
-   an entry being read without being checked out; its form fills from the entry's own span
+   above it. Push and Rebase both act on the entry in view: that
+   branch's commits are what Push counts and that branch's tip whose
+   signature it waits for, and Rebase checks the entry out to rebase
+   it and puts the worktree back where it was. Leaving Rebase to the
+   checked-out branch alone deadlocked every other entry, since one
+   whose tip was unsigned could then be neither signed nor pushed.
+   Its form fills from the entry's own span
    (`parent..branch`, not `origin/HEAD..HEAD`) on every entry switch, the
    symbolic `origin/HEAD` resolved through the same default-base lookup
    the sidebar uses, since a worktree whose remote never had its head
@@ -970,12 +973,13 @@ shim rather than a protocol:
    every reload to answer questions the branch itself already answers. The
    template is read from the working copy and, failing that, from git: the
    taps are sparse checkouts that track a template without materialising
-   it, which is why their form had no template box. The AI disclosure
-   button writes the harness with the model and effort the session was
-   started with, worded as the pickers word them, followed by local review
-   and testing, into the template's own AI section, ticking that section's
-   box and replacing any sentence it wrote before, and into the body when
-   the template has no such section. Ticking every box writes it too,
+   it, which is why their form had no template box. Fill template
+   ticks every unticked box and, where the template asks about AI,
+   writes the harness with the model and effort the session was
+   started with, worded as the pickers word them, followed by local
+   review and testing, replacing any sentence it wrote before: the box
+   claims a disclosure and the disclosure answers it, so the two are
+   one button rather than two. It writes
    into the template only: a ticked AI box with nothing under it is the
    one lie that button could tell.
 8. Each pull request row offers the last mile as small actions: copy the

--- a/README.md
+++ b/README.md
@@ -216,8 +216,9 @@ before shipping.
   button, and resets them to the commit message from the button beside
   it, asking first when something is typed (so the form is never stuck
   on a draft you no longer want)
-- **Discloses** the agent that wrote a branch in one click, and whenever
-  you tick every box: the harness with the model and effort it ran at,
+- **Discloses** the agent that wrote a branch whenever you press Fill
+  template, which is also what ticks the template's boxes: the harness
+  with the model and effort it ran at,
   the pickers' defaults when the launch named none, worded as the
   pickers word them, followed by local review and testing,
   written into the template's own AI section where there is one (so an

--- a/Sources/AgentIDEData/AgentRunner.swift
+++ b/Sources/AgentIDEData/AgentRunner.swift
@@ -155,9 +155,12 @@ public struct ClaudeCodeRunner: AgentRunner {
         ["fable", "opus", "sonnet", "haiku"]
     }
 
-    /// Claude Code's model listing.
+    /// Claude Code has no listing subcommand: every argument it
+    /// does not know becomes a prompt, so `claude models` started a
+    /// session, answered in prose, and the words of that answer were
+    /// read as model names. The curated list above stands instead.
     public var modelListingCommand: [String] {
-        ["claude", "models"]
+        []
     }
 
     /// Claude Code's effort tiers.

--- a/Sources/AgentIDEData/GitClient.swift
+++ b/Sources/AgentIDEData/GitClient.swift
@@ -280,7 +280,13 @@ public struct GitClient: Sendable {
     /// keeps the commits recoverable. Pruning drops any stale
     /// bookkeeping so the listing never shows a removed worktree.
     public func removeWorktree(repository: Repository, worktreePath: String, branch: String) async throws {
-        try await git(["worktree", "remove", "--force", worktreePath], in: repository.path)
+        // A path git never registered, or one already gone, is not a
+        // reason to stop: what follows prunes and forgets it, which
+        // is the whole point of asking.
+        let listed = FileManager.default.fileExists(atPath: worktreePath)
+        if listed {
+            try await git(["worktree", "remove", "--force", worktreePath], in: repository.path)
+        }
         try await forgetWorktree(repository: repository, branch: branch)
     }
 
@@ -299,7 +305,10 @@ public struct GitClient: Sendable {
     /// way.
     public func forgetWorktree(repository: Repository, branch: String) async throws {
         try await git(["worktree", "prune"], in: repository.path)
-        try await git(["branch", "-D", branch], in: repository.path)
+        // A branch that is not there is the state this was asking
+        // for: a worktree whose creation failed part way has none,
+        // and refusing to finish left the row undeletable.
+        try await git(["branch", "-D", branch], in: repository.path, allowFailure: true)
     }
 
     // MARK: Internal

--- a/Sources/AgentIDEData/GitClient.swift
+++ b/Sources/AgentIDEData/GitClient.swift
@@ -280,11 +280,14 @@ public struct GitClient: Sendable {
     /// keeps the commits recoverable. Pruning drops any stale
     /// bookkeeping so the listing never shows a removed worktree.
     public func removeWorktree(repository: Repository, worktreePath: String, branch: String) async throws {
-        // A path git never registered, or one already gone, is not a
-        // reason to stop: what follows prunes and forgets it, which
-        // is the whole point of asking.
-        let listed = FileManager.default.fileExists(atPath: worktreePath)
-        if listed {
+        // A directory that has already gone is nothing to remove,
+        // and asking git to would fail the whole call; pruning and
+        // forgetting below still finish the job. Every other refusal
+        // is thrown on purpose: a worktree git does not know, or one
+        // holding files the host user cannot delete, both land in
+        // the caller's fallback, which removes the directory as its
+        // owner and then prunes.
+        if FileManager.default.fileExists(atPath: worktreePath) {
             try await git(["worktree", "remove", "--force", worktreePath], in: repository.path)
         }
         try await forgetWorktree(repository: repository, branch: branch)

--- a/Sources/AgentIDEData/SessionService+Models.swift
+++ b/Sources/AgentIDEData/SessionService+Models.swift
@@ -1,0 +1,39 @@
+import AgentIDEDomain
+import Foundation
+
+/// What models an agent offers: its own listing where it has one,
+/// and nothing to ask where it has none. Split from the sources for
+/// length.
+public extension SessionService {
+    // nil means "keep the fallback list", which callers treat
+    // differently from an empty answer.
+    // swiftlint:disable discouraged_optional_collection
+
+    /// Asks the agent's CLI for its current models; nil when the
+    /// command fails or yields nothing. The CLI runs inside the
+    /// sandbox, where sessions run it anyway; running it as the host
+    /// user made macOS prompt for broad disk access.
+    func discoverModels(for agent: AgentKind) async -> [String]? {
+        // swiftlint:enable discouraged_optional_collection
+        let runner = runner(for: agent)
+        // An agent with no listing command has a curated list and
+        // nothing to discover; asking anyway starts a session.
+        guard runner.modelListingCommand.isEmpty == false else {
+            return nil
+        }
+
+        let argv = launcher.command(
+            payload: runner.modelListingCommand.joined(separator: " ") + " </dev/null",
+            initialDirectory: launcher.sharedWorkspace,
+            sessionID: UUID().uuidString,
+            sessionName: "agentide-model-listing",
+        )
+        let result = try? await processes.run(argv, workingDirectory: nil, environment: [:])
+        guard let result, result.succeeded else {
+            return nil
+        }
+
+        let models = runner.parseModelList(result.standardOutput)
+        return models.isEmpty ? nil : models
+    }
+}

--- a/Sources/AgentIDEData/SessionService+Models.swift
+++ b/Sources/AgentIDEData/SessionService+Models.swift
@@ -16,6 +16,9 @@ public extension SessionService {
     func discoverModels(for agent: AgentKind) async -> [String]? {
         // swiftlint:enable discouraged_optional_collection
         let runner = runner(for: agent)
+        if runner.modelListingCommand.isEmpty {
+            forgetDiscoveredModels(for: agent)
+        }
         // An agent with no listing command has a curated list and
         // nothing to discover; asking anyway starts a session.
         guard runner.modelListingCommand.isEmpty == false else {
@@ -35,5 +38,20 @@ public extension SessionService {
 
         let models = runner.parseModelList(result.standardOutput)
         return models.isEmpty ? nil : models
+    }
+
+    /// Throws away what was once discovered for an agent, so a list
+    /// scraped before the app knew better stops being offered.
+    func forgetDiscoveredModels(for agent: AgentKind) {
+        store.update { metadata in
+            metadata.discoveredModels[agent.rawValue] = nil
+            metadata.discoveredModelsVersion[agent.rawValue] = nil
+        }
+    }
+
+    /// Whether an agent has a listing of its own at all; one that
+    /// does not is offered its curated models and nothing else.
+    func reportsModels(_ agent: AgentKind) -> Bool {
+        runner(for: agent).modelListingCommand.isEmpty == false
     }
 }

--- a/Sources/AgentIDEData/SessionService+Sources.swift
+++ b/Sources/AgentIDEData/SessionService+Sources.swift
@@ -68,32 +68,6 @@ public extension SessionService {
         return (runner.models, runner.efforts)
     }
 
-    // nil means "keep the fallback list", which callers treat
-    // differently from an empty answer.
-    // swiftlint:disable discouraged_optional_collection
-
-    /// Asks the agent's CLI for its current models; nil when the
-    /// command fails or yields nothing. The CLI runs inside the
-    /// sandbox, where sessions run it anyway; running it as the host
-    /// user made macOS prompt for broad disk access.
-    func discoverModels(for agent: AgentKind) async -> [String]? {
-        // swiftlint:enable discouraged_optional_collection
-        let runner = runner(for: agent)
-        let argv = launcher.command(
-            payload: runner.modelListingCommand.joined(separator: " ") + " </dev/null",
-            initialDirectory: launcher.sharedWorkspace,
-            sessionID: UUID().uuidString,
-            sessionName: "agentide-model-listing",
-        )
-        let result = try? await processes.run(argv, workingDirectory: nil, environment: [:])
-        guard let result, result.succeeded else {
-            return nil
-        }
-
-        let models = runner.parseModelList(result.standardOutput)
-        return models.isEmpty ? nil : models
-    }
-
     /// Creates a session whose prompt is a GitHub issue plus the
     /// user's additional context.
     func createSession(

--- a/Sources/AgentIDEData/SessionService+Sources.swift
+++ b/Sources/AgentIDEData/SessionService+Sources.swift
@@ -169,10 +169,20 @@ public extension SessionService {
     /// pushable: the sandbox cannot sign and a hook blocks unsigned
     /// pushes, so signing always happens here on the host.
     func rebaseSigned(worktree: Worktree) async throws {
+        let branch = worktree.branch
+        let held = await git.currentBranch(worktreePath: worktree.path)
+        if let held, held != branch {
+            // Git checks the branch out to rebase it, so the
+            // worktree must be quiet and is put back afterwards.
+            try await requireQuiet(worktree: worktree, action: "rebase")
+        }
+
         try await git.fetch(repositoryPath: worktree.path)
-        let branch = await git.currentBranch(worktreePath: worktree.path) ?? worktree.branch
         let target = await signedRebaseTarget(worktreePath: worktree.path, branch: branch)
         try await git.rebaseSigned(worktreePath: worktree.path, branch: branch, onto: target)
+        if let held, held != branch {
+            try await git.checkout(branch: held, worktreePath: worktree.path)
+        }
     }
 
     /// What a signed rebase would actually change, so the button
@@ -189,12 +199,14 @@ public extension SessionService {
     /// itself fetches first, so a stale answer only mislabels until
     /// the next reload.
     func rebaseNeed(worktree: Worktree) async -> RebaseNeed {
-        let branch = await git.currentBranch(worktreePath: worktree.path) ?? worktree.branch
+        // The caller's branch, which for a stack is the entry being
+        // looked at rather than whichever one the worktree holds.
+        let branch = worktree.branch
         let target = await signedRebaseTarget(worktreePath: worktree.path, branch: branch)
         let movesBase = await (git.aheadBehind(worktreePath: worktree.path, baseRef: target)?.behind ?? 0) > 0
         let needsSigning = await git.allCommitsSigned(
             worktreePath: worktree.path,
-            range: target + "..HEAD",
+            range: target + ".." + branch,
         ) == false
         switch (movesBase, needsSigning) {
         case (true, true):

--- a/Sources/DashboardFeature/DashboardModel+Cache.swift
+++ b/Sources/DashboardFeature/DashboardModel+Cache.swift
@@ -106,7 +106,15 @@ extension DashboardModel {
     }
 
     func cacheSidebar(_ groups: [RepositoryGroup]) {
-        let cached = groups.map { group in
+        // Placeholders are what a creation looks like while it runs;
+        // remembering one meant a failed creation came back on every
+        // launch as a row nothing could delete.
+        let real = groups.map { group in
+            var kept = group
+            kept.items = group.items.filter { $0.isPlaceholder == false }
+            return kept
+        }
+        let cached = real.map { group in
             var cached = CachedRepository()
             cached.name = group.repository.name
             cached.fullName = group.repository.fullName

--- a/Sources/DashboardFeature/DashboardModel+Cache.swift
+++ b/Sources/DashboardFeature/DashboardModel+Cache.swift
@@ -52,7 +52,10 @@ extension DashboardModel {
 
     func restoreDiscoveredModels() {
         for (raw, models) in store.load().discoveredModels {
-            if let agent = AgentKind(rawValue: raw) {
+            // Only what the agent itself can report: anything
+            // remembered for an agent with no listing was scraped
+            // out of its prose by an earlier release.
+            if let agent = AgentKind(rawValue: raw), service.reportsModels(agent) {
                 discoveredModels[agent] = models
             }
         }

--- a/Sources/DashboardFeature/DashboardModel+Cleanup.swift
+++ b/Sources/DashboardFeature/DashboardModel+Cleanup.swift
@@ -24,6 +24,24 @@ public extension DashboardModel {
         }
     }
 
+    /// Takes a placeholder row out of the sidebar and out of the
+    /// snapshot the next launch paints from, so a creation that
+    /// failed leaves nothing behind to click.
+    func forgetPlaceholder(_ item: WorktreeItem) {
+        groups = Self.forgetting(item.worktree.path, in: groups)
+        cacheSidebar(groups)
+    }
+
+    /// The rows without the one at a path, which is all forgetting a
+    /// placeholder is.
+    static func forgetting(_ path: String, in groups: [RepositoryGroup]) -> [RepositoryGroup] {
+        groups.map { group in
+            var kept = group
+            kept.items = group.items.filter { $0.worktree.path != path }
+            return kept
+        }
+    }
+
     /// Tidies a worktree whose pull request has merged, merge-safely:
     /// a real worktree is removed only when it is clean and its branch
     /// is fully on the base branch (git's `-d` rule), otherwise the

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -247,11 +247,20 @@ public final class DashboardModel {
         if selection?.id == item.id {
             selection = nil
         }
+        guard item.isPlaceholder == false else {
+            // Nothing was ever created under `.pending`: the row is
+            // a drawing of work that failed to start, and asking git
+            // to remove it reported a missing file and a missing
+            // branch, neither of which meant anything.
+            forgetPlaceholder(item)
+            return
+        }
+
         do {
             try await service.deleteWorktree(item: item)
             await refresh()
         } catch {
-            ErrorLog.shared.report(error.localizedDescription)
+            ErrorLog.shared.report(error.localizedDescription, about: item.worktree.repositoryName)
         }
     }
 

--- a/Sources/PRFeature/PullRequestCreateForm.swift
+++ b/Sources/PRFeature/PullRequestCreateForm.swift
@@ -100,27 +100,17 @@ struct PullRequestCreateForm: View {
             HStack {
                 Text("Template").font(.caption).foregroundStyle(.secondary)
                 Spacer()
-                // Always beside the tick-all button, which claims
-                // the same box: a button that comes and goes with
-                // what the app happens to know is a button nobody
-                // learns to look for.
-                Button("Disclose AI", systemImage: "sparkles.rectangle.stack") {
-                    model.insertAIDisclosure()
-                }
-                .buttonStyle(.glass)
-                .controlSize(.small)
-                .disabled(isGenerating || model.hasAIDisclosure == false)
-                .hoverHelp(
-                    model.hasAIDisclosure
-                        ? "Name the harness and model that wrote this branch, and that you reviewed and "
-                        + "tested it, in the template's AI section"
-                        : "No agent session is recorded for this branch to name",
-                )
-                Button("Tick every box", systemImage: "checklist") { model.tickTemplateBoxes() }
+                // One button, since ticking the AI box and saying
+                // what wrote the branch are the same act: the box
+                // claims a disclosure and the disclosure answers it.
+                Button("Fill template", systemImage: "checklist") { model.tickTemplateBoxes() }
                     .buttonStyle(.glass)
                     .controlSize(.small)
                     .disabled(isGenerating || model.prTemplate.contains("[ ]") == false)
-                    .hoverHelp("Tick every unticked checkbox, and disclose the agent where the template asks")
+                    .hoverHelp(
+                        "Tick every unticked checkbox, and where the template asks about AI, name the "
+                            + "harness and model that wrote this branch and that you reviewed and tested it",
+                    )
             }
             TextEditor(text: $model.prTemplate.readOnly(isGenerating || isBlocked))
                 .font(.body.monospaced())

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -50,7 +50,18 @@ extension PullRequestsModel {
     /// footer's own line is kept, once.
     func setStatus(_ message: String, detail: String? = nil) {
         status = message
-        ErrorLog.shared.note(detail ?? message)
+        note(detail ?? message)
+    }
+
+    /// A note about this repository's work, named as the sidebar
+    /// names it.
+    func note(_ message: String) {
+        ErrorLog.shared.note(message, about: repository.name)
+    }
+
+    /// The same for a failure.
+    func report(_ message: String) {
+        ErrorLog.shared.report(message, about: repository.name)
     }
 
     /// Copies every unresolved review conversation to the
@@ -60,7 +71,7 @@ extension PullRequestsModel {
         let text = threads.map(\.asText).joined(separator: "\n\n")
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
-        ErrorLog.shared.note("Copied \(threads.count) unresolved conversations from #\(summary.number).")
+        note("Copied \(threads.count) unresolved conversations from #\(summary.number).")
     }
 
     /// Jumps to the one failing check, or to the checks page when
@@ -125,7 +136,7 @@ extension PullRequestsModel {
 
         let commits = await fetchCommitMessages(worktree, listedRange)
         guard commits.isEmpty == false else {
-            ErrorLog.shared.report("No commits beyond origin/HEAD to describe.")
+            report("No commits beyond origin/HEAD to describe.")
             return false
         }
 
@@ -133,7 +144,7 @@ extension PullRequestsModel {
             apply(description: Self.description(splitFromMessage: only))
         } else {
             guard let drafted = await generateDescription(commits) else {
-                ErrorLog.shared.report(
+                report(
                     "The on-device model is unavailable; is Apple Intelligence enabled?",
                 )
                 return false
@@ -172,7 +183,7 @@ extension PullRequestsModel {
 
         let title = prTitle.trimmingCharacters(in: .whitespaces)
         guard title.isEmpty == false else {
-            ErrorLog.shared.report("The pull request needs a title.")
+            report("The pull request needs a title.")
             return false
         }
 
@@ -180,14 +191,14 @@ extension PullRequestsModel {
         let body = prBody + (template.isEmpty ? "" : "\n\n" + template)
         do {
             let url = try await performCreate(worktree, title, body)
-            ErrorLog.shared.note("Opened pull request " + url)
+            note("Opened pull request " + url)
             // A stack is built one pull request at a time: each one
             // links what is open into the stack, and failing to link
             // never takes the pull request that opened with it.
             do {
                 try await performLinkStack(worktree)
             } catch {
-                ErrorLog.shared.report("Stacking on GitHub failed: " + error.localizedDescription)
+                report("Stacking on GitHub failed: " + error.localizedDescription)
             }
             pullRequests.invalidateListings(repositoryPath: repository.path)
             prTitle = ""
@@ -197,7 +208,7 @@ extension PullRequestsModel {
             clearDraft()
             return true
         } catch {
-            ErrorLog.shared.report(error.localizedDescription)
+            report(error.localizedDescription)
             return false
         }
     }
@@ -218,7 +229,7 @@ extension PullRequestsModel {
             await reload(keepingSelection: true)
             return true
         } catch {
-            ErrorLog.shared.report(error.localizedDescription)
+            report(error.localizedDescription)
             return false
         }
     }
@@ -237,7 +248,7 @@ extension PullRequestsModel {
             await reload(keepingSelection: true)
             return true
         } catch {
-            ErrorLog.shared.report(error.localizedDescription)
+            report(error.localizedDescription)
             return false
         }
     }
@@ -299,7 +310,7 @@ extension PullRequestsModel {
             await reload(keepingSelection: true)
             return true
         } catch {
-            ErrorLog.shared.report(error.localizedDescription)
+            report(error.localizedDescription)
             return false
         }
     }
@@ -330,7 +341,7 @@ extension PullRequestsModel {
             await reload(keepingSelection: true)
             return true
         } catch {
-            ErrorLog.shared.report(error.localizedDescription)
+            report(error.localizedDescription)
             return false
         }
     }

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -13,7 +13,7 @@ extension PullRequestsModel {
     func refreshWorktreeFacts(_ worktree: Worktree) async {
         await loadStack()
         isTipSigned = await checkTipSigned(listedWorktree ?? worktree)
-        rebaseNeed = await fetchRebaseNeed(worktree)
+        rebaseNeed = await fetchRebaseNeed(listedWorktree ?? worktree)
         let template = await fetchTemplate(worktree.path)
         hasTemplate = template != nil
         originalTemplate = template ?? ""
@@ -237,7 +237,7 @@ extension PullRequestsModel {
     /// Rebases onto origin with signed commits; false means the
     /// rebase aborted and the errors tab should open with the cause.
     func rebaseSigned() async -> Bool {
-        guard let worktree = actionWorktree else {
+        guard let worktree = listedWorktree else {
             return true
         }
 

--- a/Sources/PRFeature/PullRequestsModel+Branch.swift
+++ b/Sources/PRFeature/PullRequestsModel+Branch.swift
@@ -22,20 +22,13 @@ extension PullRequestsModel {
     }
 
     /// Rebase only lights up when it would actually change
-    /// something: move the base, sign commits, or both. A rebase
-    /// moves the branch the worktree holds, so an entry being read
-    /// without being checked out is not its to move.
+    /// something: move the base, sign commits, or both. It acts on
+    /// the entry in view, checking it out for the rebase and putting
+    /// the worktree back: an entry whose tip is unsigned could
+    /// otherwise never be pushed, since Push waits for the signature
+    /// only this can give it.
     var canRebase: Bool {
-        branchItem != nil && rebaseNeed != SessionService.RebaseNeed.nothing && isListedCheckedOut
-    }
-
-    /// Whether the entry on screen is the branch the worktree
-    /// actually holds, which is always so outside a stack. The
-    /// stack's own checked-out name counts too: where a local-only
-    /// twin is checked out, the entry standing for it is at the same
-    /// commit, so rebasing and pushing are still its work.
-    var isListedCheckedOut: Bool {
-        listedBranch == (currentBranch ?? branch) || listedBranch == stacking.stack.checkedOut
+        branchItem != nil && rebaseNeed != SessionService.RebaseNeed.nothing
     }
 
     /// Push makes sense with unpushed commits that this tab has not

--- a/Sources/PRFeature/PullRequestsModel+Disclosure.swift
+++ b/Sources/PRFeature/PullRequestsModel+Disclosure.swift
@@ -5,28 +5,6 @@ import Foundation
 extension PullRequestsModel {
     // MARK: Internal
 
-    /// Whether this branch has an agent session to disclose.
-    var hasAIDisclosure: Bool {
-        disclosure != nil
-    }
-
-    /// Names the harness and model that wrote the branch, in the
-    /// template's own AI section when it has one (Homebrew's asks
-    /// for exactly this, and ticking its box is what disclosing
-    /// means) and at the end of the body otherwise.
-    func insertAIDisclosure() {
-        guard let disclosure else {
-            return
-        }
-
-        if let ticked = Self.disclosing(in: prTemplate, sentence: disclosure) {
-            prTemplate = ticked
-            return
-        }
-
-        prBody = prBody.isEmpty ? disclosure : prBody + "\n\n" + disclosure
-    }
-
     /// Writes the disclosure into the template's own AI section,
     /// and nowhere else: a template without one has nothing to say
     /// about it, and the body is not the place to volunteer it.

--- a/Sources/PRFeature/PullRequestsModel+Stack.swift
+++ b/Sources/PRFeature/PullRequestsModel+Stack.swift
@@ -335,7 +335,7 @@ extension PullRequestsModel {
 
         do {
             let moved = try await stacking.restack(worktree)
-            ErrorLog.shared.note(
+            note(
                 moved.isEmpty
                     ? "The stack was already in order."
                     : "Rebased " + moved.joined(separator: ", ") + ".",
@@ -343,7 +343,7 @@ extension PullRequestsModel {
             await loadStack()
             await reload(keepingSelection: true)
         } catch {
-            ErrorLog.shared.report(error.localizedDescription)
+            report(error.localizedDescription)
         }
     }
 
@@ -357,10 +357,10 @@ extension PullRequestsModel {
         do {
             let pushed = try await stacking.push(worktree)
             pullRequests.invalidateListings(repositoryPath: repository.path)
-            ErrorLog.shared.note("Pushed " + pushed.joined(separator: ", ") + ".")
+            note("Pushed " + pushed.joined(separator: ", ") + ".")
             await reload(keepingSelection: true)
         } catch {
-            ErrorLog.shared.report(error.localizedDescription)
+            report(error.localizedDescription)
         }
     }
 }

--- a/Sources/PRFeature/PullRequestsModel+Stack.swift
+++ b/Sources/PRFeature/PullRequestsModel+Stack.swift
@@ -1,6 +1,5 @@
 import AgentIDEData
 import AgentIDEDomain
-import TerminalUI
 
 // MARK: - StackWork
 

--- a/Sources/ReviewFeature/ReviewModel+Status.swift
+++ b/Sources/ReviewFeature/ReviewModel+Status.swift
@@ -1,0 +1,12 @@
+import TerminalUI
+
+/// What the review pane says about its own work, in the footer and
+/// in the messages pane, always naming the repository it is about.
+/// Split from the model for length.
+extension ReviewModel {
+    /// Reports a failure into the app-wide error log; the local
+    /// status line keeps success reports only.
+    func report(_ message: String) {
+        ErrorLog.shared.report(message, about: repositoryName)
+    }
+}

--- a/Sources/ReviewFeature/ReviewModel.swift
+++ b/Sources/ReviewFeature/ReviewModel.swift
@@ -15,6 +15,7 @@ final class ReviewModel {
     /// resolves the whole-branch scope's merge base on demand.
     init(
         worktreePath: String,
+        repositoryName: String,
         git: GitClient,
         baseRefProvider: @escaping () async -> String? = { nil },
         draftMessage: @escaping () async -> String? = { nil },
@@ -24,6 +25,7 @@ final class ReviewModel {
         },
     ) {
         self.worktreePath = worktreePath
+        self.repositoryName = repositoryName
         self.git = git
         self.draftMessage = draftMessage
         self.baseRefProvider = baseRefProvider
@@ -56,6 +58,10 @@ final class ReviewModel {
     static let generatedFragments = [
         ".pbxproj", "Package.resolved", ".lock", "Gemfile.lock", ".xcassets",
     ]
+
+    /// The repository this worktree belongs to, as the sidebar names
+    /// it, so its messages say which repository they are about.
+    let repositoryName: String
 
     /// The review scope; per-line rejection and message amendment
     /// only apply to the last commit.
@@ -235,13 +241,7 @@ final class ReviewModel {
     /// pane, where a line that scrolls past can still be read.
     func setStatus(_ message: String) {
         status = message
-        ErrorLog.shared.note(message)
-    }
-
-    /// Reports a failure into the app-wide error log; the local
-    /// status line keeps success reports only.
-    func report(_ message: String) {
-        ErrorLog.shared.report(message)
+        ErrorLog.shared.note(message, about: repositoryName)
     }
 
     /// Toggles one line's selection.

--- a/Sources/ReviewFeature/ReviewView.swift
+++ b/Sources/ReviewFeature/ReviewView.swift
@@ -47,6 +47,7 @@ public struct ReviewView: View {
         let builder = {
             ReviewModel(
                 worktreePath: worktree.path,
+                repositoryName: worktree.repositoryName,
                 git: git,
                 baseRefProvider: { await service.reviewBase(for: worktree) },
                 draftMessage: { await service.draftCommitMessage(worktreePath: worktree.path) },

--- a/Sources/TerminalUI/ErrorLog.swift
+++ b/Sources/TerminalUI/ErrorLog.swift
@@ -60,6 +60,18 @@ public final class ErrorLog {
         append(message, isError: false)
     }
 
+    /// The same, for work belonging to one repository: the name the
+    /// sidebar shows goes in front, since "Pushed" and "Rebased"
+    /// read identically whichever repository they happened in.
+    public func note(_ message: String, about repository: String) {
+        note(Self.prefixed(message, with: repository))
+    }
+
+    /// A failure in one repository's work, named the same way.
+    public func report(_ message: String, about repository: String) {
+        report(Self.prefixed(message, with: repository))
+    }
+
     /// Empties the log; the messages tab stays either way.
     public func clear() {
         entries = []
@@ -72,6 +84,16 @@ public final class ErrorLog {
 
     /// Monotonic, so identities survive the cap dropping entries.
     private var nextID = 0
+
+    /// The message with its repository in front, unless it is
+    /// already there: a name is worth saying once.
+    private static func prefixed(_ message: String, with repository: String) -> String {
+        guard repository.isEmpty == false, message.hasPrefix(repository + ": ") == false else {
+            return message
+        }
+
+        return repository + ": " + message
+    }
 
     private func append(_ message: String, isError: Bool) {
         nextID += 1

--- a/Tests/AgentIDEDataTests/AgentRunnerTests.swift
+++ b/Tests/AgentIDEDataTests/AgentRunnerTests.swift
@@ -5,6 +5,17 @@ import Testing
 /// on, the successor to the deleted paste-delivery coverage.
 struct AgentRunnerTests {
     @Test
+    func `an agent with no listing offers its curated models and forgets what was scraped`() {
+        // `claude models` is not a subcommand: Claude Code takes an
+        // unknown argument as a prompt, so asking started a session
+        // and the words of its answer were read as model names.
+        #expect(ClaudeCodeRunner().modelListingCommand.isEmpty)
+        #expect(ClaudeCodeRunner().models == ["fable", "opus", "sonnet", "haiku"])
+        // Codex has a real listing to read, so it keeps one.
+        #expect(CodexRunner().modelListingCommand.isEmpty == false)
+    }
+
+    @Test
     func `versions come out of whatever the CLI wraps them in`() {
         #expect(ClaudeCodeRunner().parseVersion("2.1.238 (Claude Code)") == "2.1.238")
         #expect(CodexRunner().parseVersion("codex-cli 0.149.0\n") == "0.149.0")

--- a/Tests/DashboardFeatureTests/RowRetentionTests.swift
+++ b/Tests/DashboardFeatureTests/RowRetentionTests.swift
@@ -15,6 +15,23 @@ struct RowRetentionTests {
     // MARK: Internal
 
     @Test
+    func `a placeholder that never became a worktree is forgotten, not deleted`() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let repositoryPath = try makeDirectory(in: root, named: "repo")
+        let placeholder = repositoryPath + DashboardModel.placeholderMarker + "analyse_the_performance_of"
+
+        // A creation that failed leaves a row under `.pending`,
+        // which is a drawing rather than a directory: deleting one
+        // asked git to remove a path that never existed and a branch
+        // that was never cut, and said so in the messages.
+        let rows = [group(repositoryPath: repositoryPath, paths: [repositoryPath, placeholder])]
+        let kept = DashboardModel.forgetting(placeholder, in: rows)
+
+        #expect(kept.flatMap(\.items).map(\.worktree.path) == [repositoryPath])
+    }
+
+    @Test
     func `keeps a row git stopped listing and drops a deleted one`() throws {
         let root = try makeDirectory()
         defer { try? FileManager.default.removeItem(atPath: root) }

--- a/Tests/PRFeatureTests/PullRequestStackTests.swift
+++ b/Tests/PRFeatureTests/PullRequestStackTests.swift
@@ -153,9 +153,9 @@ struct PullRequestStackTests {
         model.show(branch: "upper")
         try? await Task.sleep(for: .milliseconds(200))
         #expect(model.listedBranch == "upper")
-        // The entry standing in for what is checked out is still the
-        // worktree's own work to rebase and push.
-        #expect(model.isListedCheckedOut)
+        // And the entry in view is what the tab acts on, whatever
+        // the worktree happens to hold.
+        #expect(model.listedWorktree?.branch == "upper")
     }
 
     @Test

--- a/Tests/ReviewFeatureTests/ReviewModelTests.swift
+++ b/Tests/ReviewFeatureTests/ReviewModelTests.swift
@@ -44,7 +44,11 @@ struct ReviewModelTests {
         try "dirty\n".write(toFile: path + "/dirty.txt", atomically: true, encoding: .utf8)
         try await runGit(["add", "-A"], in: path)
 
-        let model = ReviewModel(worktreePath: path, git: GitClient(runner: FoundationProcessRunner()))
+        let model = ReviewModel(
+            worktreePath: path,
+            repositoryName: "repo",
+            git: GitClient(runner: FoundationProcessRunner()),
+        )
         model.scope = .lastCommit
         await model.reload()
         #expect(model.files.map(\.path) == ["committed.txt"])
@@ -71,7 +75,11 @@ struct ReviewModelTests {
         defer { try? FileManager.default.removeItem(atPath: path) }
         try await makeRepository(at: path)
 
-        let model = ReviewModel(worktreePath: path, git: GitClient(runner: FoundationProcessRunner()))
+        let model = ReviewModel(
+            worktreePath: path,
+            repositoryName: "repo",
+            git: GitClient(runner: FoundationProcessRunner()),
+        )
         model.scope = .upstream
         await model.reload()
         #expect(model.hasUpstream == false)
@@ -109,7 +117,11 @@ struct ReviewModelTests {
         try "a NEEDLE too\n".write(toFile: path + "/three.txt", atomically: true, encoding: .utf8)
         try await runGit(["add", "-A"], in: path)
 
-        let model = ReviewModel(worktreePath: path, git: GitClient(runner: FoundationProcessRunner()))
+        let model = ReviewModel(
+            worktreePath: path,
+            repositoryName: "repo",
+            git: GitClient(runner: FoundationProcessRunner()),
+        )
         model.scope = .uncommitted
         await model.reload()
         #expect(model.findTargets.isEmpty)


### PR DESCRIPTION
- a creation that fails leaves a `.pending` row, which is a drawing rather than a directory: deleting one asked git to remove a path that never existed and a branch that was never cut, so it reported a missing file and a missing branch and the row stayed. It is forgotten now, and never cached, so a quit mid-creation leaves nothing behind either
- removing a worktree tolerates what has already gone: the point is that it ends up gone, not that every step had work to do
- every message about one repository says which, as the sidebar names it: "Pushed x" read the same whichever repository it was
- `claude models` is not a subcommand, so it was read as a prompt and the agent's prose scraped for names: "and" and "how" were offered as models. Claude Code has a curated list and nothing to discover