### PR TITLE
Ensure pane selection, fetch timing, button behavior, commit counting, form persistence, branch reading, and stack integration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -861,10 +861,14 @@ shim rather than a protocol:
    bottom up with `--onto <parent> <the parent's recorded tip>` so only a
    branch's own commits replay, signing each; a branch already on its
    parent is skipped rather than rewritten, since renaming commits for
-   nothing is its own damage. The three stack actions sit where a lone
+   nothing is its own damage. The stack's two actions sit where a lone
    branch's Rebase and Push sit, in the footer's left, icon-only with
    their words in the hover help, and dim when they would do nothing:
-   nothing out of place, or nothing the remote lacks. Moving between a
+   nothing out of place, nothing the remote lacks, or a branch whose
+   tip is unsigned, which the hook would turn away exactly as it does
+   a lone branch's. Both report as their counterparts do, a line in
+   the footer and the sidebar told what moved, and a failure opens the
+   messages rather than being left in them. Moving between a
    stack's entries asks git nothing at all, since every entry shares one
    worktree: the listing paints from the cache and every entry's listing
    is fetched in the background as soon as one of them loads, so the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -909,7 +909,11 @@ shim rather than a protocol:
    a count of branches; Rebase shows how far it sits behind that
    base. That branch's tip is whose signature Push waits for, and
    Rebase checks the entry out to rebase
-   it and puts the worktree back where it was. Leaving Rebase to the
+   it, puts the worktree back where it was, and takes the branches
+   above it along: left where they were they fork from the default
+   branch rather than from the entry that moved, which is no stack at
+   all, and the tab then lost the entry it had just rebased and showed
+   whichever branch was checked out instead. Leaving Rebase to the
    checked-out branch alone deadlocked every other entry, since one
    whose tip was unsigned could then be neither signed nor pushed.
    Its form fills from the entry's own span

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -993,8 +993,12 @@ shim rather than a protocol:
    critical path. A derivation asks git about every branch's fork
    point and how far it has come, thirty processes for a repository
    of a few branches, so the answer is kept against the one line that
-   decides it: where every branch points, which one is checked out
-   and which are excluded, read in a single `for-each-ref`. A
+   decides it: where every branch and every remote-tracking ref
+   points, which branch is checked out and which are excluded, read
+   in a single `for-each-ref`. The remotes are in it because every
+   fork point is measured against the default branch: a fetch that
+   moves it changes what a stack is while every local branch stays
+   where it was. A
    worktree whose branches have not moved is answered from that
    rather than derived again, and the performance log says which
    (`stack#<path>`). A failure resets what moved, returns to the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -981,7 +981,14 @@ shim rather than a protocol:
    deriving every one was a hundred `merge-base` calls in the first
    second of every start), a few worktrees per
    refresh on a minute's rota to keep the git calls off the poll's
-   critical path. A failure resets what moved, returns to the
+   critical path. A derivation asks git about every branch's fork
+   point and how far it has come, thirty processes for a repository
+   of a few branches, so the answer is kept against the one line that
+   decides it: where every branch points, which one is checked out
+   and which are excluded, read in a single `for-each-ref`. A
+   worktree whose branches have not moved is answered from that
+   rather than derived again, and the performance log says which
+   (`stack#<path>`). A failure resets what moved, returns to the
    branch it started on and reports which branch conflicted. Pushing goes
    bottom up so a base is on the remote before the branch pointing at it.
 7. The listing and the footer act on the branch actually checked out in the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -799,7 +799,12 @@ shim rather than a protocol:
    worktree, and only a worktree on a detached head asks about itself.
    Uncommitted work stays the one question a worktree answers alone.
    Every read passes `--no-optional-locks`, so nothing the app asks
-   waits on the index lock an agent's own git is holding. A repository's full name comes from its remote's URL, a
+   waits on the index lock an agent's own git is holding. Which
+   branch a worktree holds is read from the `HEAD` file git keeps it
+   in rather than through `symbolic-ref`, since the stack asks it of
+   every worktree on every reading and a file is a hundredth of a
+   millisecond against a process; the command still answers when the
+   file is not where it should be. A repository's full name comes from its remote's URL, a
    local read, never from `gh repo view`, which was a network round trip
    per repository per poll; that name and the branch merges are judged
    against are read once and remembered until a fetch, since only a

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -882,7 +882,13 @@ shim rather than a protocol:
    bottom of a stack opens against the default branch exactly
    as a lone branch does, and keeps the lone branch's Rebase and Push
    rather than the stack's three buttons, however many branches sit
-   above it. Push and Rebase both act on the entry in view: that
+   above it. Every rebase fetches first, a branch's own and the
+   stack's alike, since rebasing onto a remote nobody has read is the
+   one thing the button must not do; a fetch inside the minute is
+   reused, so pressing Rebase after a Fetch and Reset, or after
+   another entry's rebase, does not wait on the network twice
+   (`gitFetchedAt` in the metadata store, stamped by every fetch the
+   app makes). Push and Rebase both act on the entry in view: that
    branch's commits are what Push counts and that branch's tip whose
    signature it waits for, and Rebase checks the entry out to rebase
    it and puts the worktree back where it was. Leaving Rebase to the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -773,7 +773,12 @@ shim rather than a protocol:
    keeps the cached answer. A pull request in flight jumps every tier:
    checks still running will pass or fail, and a queued one will merge
    or leave the queue within the hour, so both are asked about every
-   half minute, the one question allowed under the minute floor. The
+   half minute, the one question allowed under the minute floor. A
+   push looks again a minute afterwards, from the store's timers
+   outwards: asked at once, GitHub answers with the checks as they
+   were before it and the store then holds that stale green or red
+   for a minute more, where a minute's wait finds the run the push
+   started and the row goes yellow. The
    store remembers when a pull request's checks were first seen running;
    past an hour the row goes back to its tier, since a run that long is
    a stalled check or GitHub down, and an outage must not be polled at
@@ -892,9 +897,13 @@ shim rather than a protocol:
    reused, so pressing Rebase after a Fetch and Reset, or after
    another entry's rebase, does not wait on the network twice
    (`gitFetchedAt` in the metadata store, stamped by every fetch the
-   app makes). Push and Rebase both act on the entry in view: that
-   branch's commits are what Push counts and that branch's tip whose
-   signature it waits for, and Rebase checks the entry out to rebase
+   app makes). Push and Rebase both act on the entry in view, and count
+   it: Push shows the commits that entry has above its base, which is
+   what a push sends and what its pull request carries, and the
+   stack's Push shows the same number for the same entry rather than
+   a count of branches; Rebase shows how far it sits behind that
+   base. That branch's tip is whose signature Push waits for, and
+   Rebase checks the entry out to rebase
    it and puts the worktree back where it was. Leaving Rebase to the
    checked-out branch alone deadlocked every other entry, since one
    whose tip was unsigned could then be neither signed nor pushed.

--- a/Sources/AgentIDEData/AppMetadata.swift
+++ b/Sources/AgentIDEData/AppMetadata.swift
@@ -136,6 +136,7 @@ public struct AppMetadata: Codable, Sendable {
         discoveredModels = ledgers.discoveredModels
         discoveredModelsVersion = ledgers.discoveredModelsVersion
         etags = ledgers.etags
+        gitFetchedAt = ledgers.gitFetchedAt
         pendingSince = ledgers.pendingSince
         terminalSchemes = ledgers.terminalSchemes
     }
@@ -189,6 +190,12 @@ public struct AppMetadata: Codable, Sendable {
     /// once at startup and never again, so the pane must keep the
     /// palette the agent believes in for the session's whole life.
     public var terminalSchemes: [String: String] = [:]
+
+    /// When each repository's remotes were last fetched, by
+    /// repository path. Rebasing wants a current remote and fetching
+    /// takes seconds on a large repository, so a rebase within the
+    /// minute of another one's fetch reuses it.
+    public var gitFetchedAt: [String: Date] = [:]
 
     /// Branches a worktree's stack should leave out, by worktree
     /// path. The stack is inferred from ancestry, which cannot know
@@ -347,6 +354,7 @@ public struct AppMetadata: Codable, Sendable {
             etags = try container.decodeIfPresent([String: String].self, forKey: .etags) ?? [:]
             pendingSince = try container.decodeIfPresent([String: Date].self, forKey: .pendingSince) ?? [:]
             terminalSchemes = try container.decodeIfPresent([String: String].self, forKey: .terminalSchemes) ?? [:]
+            gitFetchedAt = try container.decodeIfPresent([String: Date].self, forKey: .gitFetchedAt) ?? [:]
         }
 
         // MARK: Internal
@@ -356,6 +364,7 @@ public struct AppMetadata: Codable, Sendable {
         var etags: [String: String] = [:]
         var pendingSince: [String: Date] = [:]
         var terminalSchemes: [String: String] = [:]
+        var gitFetchedAt: [String: Date] = [:]
     }
 
     /// How long a fetch stamp is worth keeping: longer than the
@@ -370,30 +379,4 @@ public struct AppMetadata: Codable, Sendable {
     /// without the file growing forever.
     private static let conversationCap = 80
     private static let listingCap = 40
-}
-
-// MARK: - PullRequestFormDraft
-
-/// A branch's unfinished pull request text, kept so leaving the tab
-/// and coming back does not lose the writing.
-public struct PullRequestFormDraft: Codable, Sendable {
-    // MARK: Lifecycle
-
-    /// Creates a draft.
-    public init(title: String, body: String, template: String) {
-        self.title = title
-        self.body = body
-        self.template = template
-    }
-
-    // MARK: Public
-
-    /// The drafted title.
-    public let title: String
-
-    /// The drafted body.
-    public let body: String
-
-    /// The template as edited.
-    public let template: String
 }

--- a/Sources/AgentIDEData/GitClient+Branches.swift
+++ b/Sources/AgentIDEData/GitClient+Branches.swift
@@ -36,12 +36,11 @@ public extension GitClient {
     /// checkout keeps both in `.git` itself.
     static func headFileBranch(worktreePath: String) -> String? {
         let dotGit = worktreePath + "/.git"
+        let pointer = (try? String(contentsOfFile: dotGit, encoding: .utf8)) ?? ""
+        let marker = "gitdir: "
         var directory = dotGit
-        if let pointer = try? String(contentsOfFile: dotGit, encoding: .utf8),
-           pointer.hasPrefix("gitdir: ") {
-            directory = pointer
-                .dropFirst("gitdir: ".count)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+        if pointer.hasPrefix(marker) {
+            directory = pointer.dropFirst(marker.count).trimmingCharacters(in: .whitespacesAndNewlines)
         }
         guard let head = try? String(contentsOfFile: directory + "/HEAD", encoding: .utf8) else {
             return nil

--- a/Sources/AgentIDEData/GitClient+Branches.swift
+++ b/Sources/AgentIDEData/GitClient+Branches.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Branch inspection and the repository-local exclude file, split
 /// from the client body for length.
 public extension GitClient {
@@ -40,7 +42,19 @@ public extension GitClient {
         let marker = "gitdir: "
         var directory = dotGit
         if pointer.hasPrefix(marker) {
-            directory = pointer.dropFirst(marker.count).trimmingCharacters(in: .whitespacesAndNewlines)
+            let named = pointer.dropFirst(marker.count).trimmingCharacters(in: .whitespacesAndNewlines)
+            // `git worktree add --relative-paths` writes a path
+            // relative to this file, not to wherever the app is
+            // running: resolved against the process's directory it
+            // would name nothing, and every read would fall back to
+            // asking git.
+            directory = named.hasPrefix("/")
+                ? named
+                : URL(fileURLWithPath: dotGit)
+                .deletingLastPathComponent()
+                .appendingPathComponent(named)
+                .standardizedFileURL
+                .path
         }
         guard let head = try? String(contentsOfFile: directory + "/HEAD", encoding: .utf8) else {
             return nil

--- a/Sources/AgentIDEData/GitClient+Branches.swift
+++ b/Sources/AgentIDEData/GitClient+Branches.swift
@@ -8,6 +8,15 @@ public extension GitClient {
     /// (`--abbrev-ref`) answered `heads/main` whenever an agent left
     /// a stray ref named `main` elsewhere in the repository.
     func currentBranch(worktreePath: String) async -> String? {
+        // git keeps this in a file, and reading it is the difference
+        // between a hundredth of a millisecond and a process: the
+        // stack asks which branch is held on every reading of every
+        // worktree, all day. The command still answers when the file
+        // is not where it is expected.
+        if let named = Self.headFileBranch(worktreePath: worktreePath) {
+            return named
+        }
+
         let name = await (try? git(["symbolic-ref", "HEAD"], in: worktreePath, allowFailure: true))
             .flatMap { $0.succeeded ? $0.standardOutput : nil }?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -17,6 +26,34 @@ public extension GitClient {
         }
 
         return String(name.dropFirst(prefix.count))
+    }
+
+    /// The branch named in the worktree's own `HEAD`, nil when it
+    /// holds a commit rather than a ref (a detached head, which is
+    /// what a rebase leaves behind while it runs) or when the file
+    /// cannot be found. A worktree's `.git` is a file naming the
+    /// directory git keeps for it, and `HEAD` lives in there; a
+    /// checkout keeps both in `.git` itself.
+    static func headFileBranch(worktreePath: String) -> String? {
+        let dotGit = worktreePath + "/.git"
+        var directory = dotGit
+        if let pointer = try? String(contentsOfFile: dotGit, encoding: .utf8),
+           pointer.hasPrefix("gitdir: ") {
+            directory = pointer
+                .dropFirst("gitdir: ".count)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard let head = try? String(contentsOfFile: directory + "/HEAD", encoding: .utf8) else {
+            return nil
+        }
+
+        let prefix = "ref: refs/heads/"
+        let line = head.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard line.hasPrefix(prefix) else {
+            return nil
+        }
+
+        return String(line.dropFirst(prefix.count))
     }
 
     /// Whether a commit carries a verifying GPG signature: good, or

--- a/Sources/AgentIDEData/GitClient+Facts.swift
+++ b/Sources/AgentIDEData/GitClient+Facts.swift
@@ -48,6 +48,18 @@ public extension GitClient {
         return Self.branchFacts(fromForEachRef: result.standardOutput)
     }
 
+    /// Every branch and the commit it points at, as one string.
+    /// Deriving a stack costs thirty processes; this costs one, and
+    /// nothing about a stack can change without changing it.
+    func refFingerprint(worktreePath: String) async -> String {
+        let result = try? await git(
+            ["for-each-ref", "--format=%(refname:short) %(objectname)", "refs/heads/"],
+            in: worktreePath,
+            allowFailure: true,
+        )
+        return result?.standardOutput ?? ""
+    }
+
     /// Parses what `for-each-ref` printed; separated for tests.
     static func branchFacts(fromForEachRef output: String) -> [String: BranchFacts] {
         var facts = [String: BranchFacts]()

--- a/Sources/AgentIDEData/GitClient+Facts.swift
+++ b/Sources/AgentIDEData/GitClient+Facts.swift
@@ -48,12 +48,21 @@ public extension GitClient {
         return Self.branchFacts(fromForEachRef: result.standardOutput)
     }
 
-    /// Every branch and the commit it points at, as one string.
-    /// Deriving a stack costs thirty processes; this costs one, and
-    /// nothing about a stack can change without changing it.
+    /// Every branch and remote-tracking ref with the commit it
+    /// points at, as one string. Deriving a stack costs thirty
+    /// processes; this costs one, and nothing a derivation reads can
+    /// change without changing it. The remotes are in it because the
+    /// default branch is what every fork point is measured against:
+    /// a fetch that moves it changes what a stack is while every
+    /// local branch stays exactly where it was.
     func refFingerprint(worktreePath: String) async -> String {
         let result = try? await git(
-            ["for-each-ref", "--format=%(refname:short) %(objectname)", "refs/heads/"],
+            [
+                "for-each-ref",
+                "--format=%(refname) %(objectname)",
+                "refs/heads/",
+                "refs/remotes/",
+            ],
             in: worktreePath,
             allowFailure: true,
         )

--- a/Sources/AgentIDEData/PullRequestFormDraft.swift
+++ b/Sources/AgentIDEData/PullRequestFormDraft.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// A branch's unfinished pull request text, kept so leaving the tab
+/// and coming back does not lose the writing.
+public struct PullRequestFormDraft: Codable, Sendable {
+    // MARK: Lifecycle
+
+    /// Creates a draft.
+    public init(title: String, body: String, template: String) {
+        self.title = title
+        self.body = body
+        self.template = template
+    }
+
+    // MARK: Public
+
+    /// The drafted title.
+    public let title: String
+
+    /// The drafted body.
+    public let body: String
+
+    /// The template as edited.
+    public let template: String
+}

--- a/Sources/AgentIDEData/PullRequestFormDraft.swift
+++ b/Sources/AgentIDEData/PullRequestFormDraft.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A branch's unfinished pull request text, kept so leaving the tab
 /// and coming back does not lose the writing.
 public struct PullRequestFormDraft: Codable, Sendable {

--- a/Sources/AgentIDEData/SessionService+Fetching.swift
+++ b/Sources/AgentIDEData/SessionService+Fetching.swift
@@ -1,0 +1,31 @@
+import AgentIDEDomain
+import Foundation
+
+/// When a repository's remotes were last fetched, and the one place
+/// that decides whether to fetch again. Split from the sources for
+/// length.
+public extension SessionService {
+    /// How long a fetch counts as current: a rebase started within
+    /// the minute of one reuses it rather than waiting again.
+    static let fetchInterval: TimeInterval = 60
+
+    /// Fetches a repository's remotes unless that has just happened,
+    /// and remembers when it did. Rebasing onto a stale remote is
+    /// the whole reason the button exists, so every path that
+    /// rebases comes through here first.
+    func fetchIfStale(repositoryPath: String, workingDirectory: String? = nil) async throws {
+        let last = store.load().gitFetchedAt[repositoryPath] ?? .distantPast
+        guard Date().timeIntervalSince(last) >= Self.fetchInterval else {
+            return
+        }
+
+        try await git.fetch(repositoryPath: workingDirectory ?? repositoryPath)
+        rememberFetch(repositoryPath: repositoryPath)
+    }
+
+    /// Records that a repository's remotes are current, for the
+    /// fetches that always run: the explicit ones a menu asks for.
+    func rememberFetch(repositoryPath: String) {
+        store.update { $0.gitFetchedAt[repositoryPath] = Date() }
+    }
+}

--- a/Sources/AgentIDEData/SessionService+Fetching.swift
+++ b/Sources/AgentIDEData/SessionService+Fetching.swift
@@ -1,4 +1,3 @@
-import AgentIDEDomain
 import Foundation
 
 /// When a repository's remotes were last fetched, and the one place

--- a/Sources/AgentIDEData/SessionService+Lifecycle.swift
+++ b/Sources/AgentIDEData/SessionService+Lifecycle.swift
@@ -108,6 +108,7 @@ public extension SessionService {
     /// Fetches and prunes the repository's remotes.
     func fetch(repository: Repository) async throws {
         try await git.fetch(repositoryPath: repository.path)
+        rememberFetch(repositoryPath: repository.path)
     }
 
     /// A tracked file's committed content; see `GitClient`.

--- a/Sources/AgentIDEData/SessionService+PullRequests.swift
+++ b/Sources/AgentIDEData/SessionService+PullRequests.swift
@@ -281,7 +281,7 @@ public extension SessionService {
 
         let repository = Repository(name: worktree.repositoryName, path: worktree.repositoryPath)
         do {
-            try await git.fetch(repositoryPath: worktree.path)
+            try await fetchIfStale(repositoryPath: worktree.repositoryPath, workingDirectory: worktree.path)
         } catch {
             report.failures.append("Fetching \(worktree.repositoryName) failed: " + error.localizedDescription)
         }

--- a/Sources/AgentIDEData/SessionService+PullRequests.swift
+++ b/Sources/AgentIDEData/SessionService+PullRequests.swift
@@ -207,6 +207,25 @@ public extension SessionService {
     /// entry's own span (`parent..branch`), nil the checked-out
     /// branch against the default.
     func commitMessages(worktree: Worktree, range: String? = nil) async -> [String] {
+        guard let span = await resolvedSpan(worktree: worktree, range: range) else {
+            return []
+        }
+
+        return await git.commitMessages(worktreePath: worktree.path, range: span)
+    }
+
+    /// How many commits a branch has of its own, which is how many a
+    /// pull request for it would carry.
+    func commitCount(worktree: Worktree, range: String? = nil) async -> Int {
+        guard let span = await resolvedSpan(worktree: worktree, range: range) else {
+            return 0
+        }
+
+        return await git.commitCount(worktreePath: worktree.path, range: span) ?? 0
+    }
+
+    /// The span a range names, with `origin/HEAD` resolved.
+    private func resolvedSpan(worktree: Worktree, range: String?) async -> String? {
         // `origin/HEAD` names the default branch symbolically; a
         // worktree whose remote never had its head set cannot
         // resolve it, and git then listed the branch back to the
@@ -234,12 +253,12 @@ public extension SessionService {
                 fork = await git.mergeBase(name, branch, worktreePath: worktree.path)
             }
             guard let fork else {
-                return []
+                return nil
             }
 
             span = fork + ".." + branch
         }
-        return await git.commitMessages(worktreePath: worktree.path, range: span)
+        return span
     }
 
     /// A pull request title and body drafted by the on-device model,

--- a/Sources/AgentIDEData/SessionService+Sources.swift
+++ b/Sources/AgentIDEData/SessionService+Sources.swift
@@ -161,6 +161,7 @@ public extension SessionService {
         }
 
         try await git.fetchAndReset(repositoryPath: repository.path, onto: ref)
+        rememberFetch(repositoryPath: repository.path)
     }
 
     /// Fetches, then rebases the worktree onto the signed-rebase
@@ -168,6 +169,11 @@ public extension SessionService {
     /// on conflict. This is how unsigned agent commits become
     /// pushable: the sandbox cannot sign and a hook blocks unsigned
     /// pushes, so signing always happens here on the host.
+    /// Fetches, then rebases the entry onto the signed-rebase target
+    /// with every replayed commit re-signed, aborting cleanly on
+    /// conflict. This is how unsigned agent commits become pushable:
+    /// the sandbox cannot sign and a hook blocks unsigned pushes, so
+    /// signing always happens here on the host.
     func rebaseSigned(worktree: Worktree) async throws {
         let branch = worktree.branch
         let held = await git.currentBranch(worktreePath: worktree.path)
@@ -177,7 +183,7 @@ public extension SessionService {
             try await requireQuiet(worktree: worktree, action: "rebase")
         }
 
-        try await git.fetch(repositoryPath: worktree.path)
+        try await fetchIfStale(repositoryPath: worktree.repositoryPath, workingDirectory: worktree.path)
         let target = await signedRebaseTarget(worktreePath: worktree.path, branch: branch)
         try await git.rebaseSigned(worktreePath: worktree.path, branch: branch, onto: target)
         if let held, held != branch {

--- a/Sources/AgentIDEData/SessionService+Stack.swift
+++ b/Sources/AgentIDEData/SessionService+Stack.swift
@@ -250,11 +250,35 @@ public extension SessionService {
         let stack = await stack(for: worktree)
         var pushed = [String]()
         for branch in stack.branches {
+            // What the single-branch push refuses, this refuses:
+            // unsigned commits are turned away by the hook, and the
+            // stack must not be left half pushed to learn that.
+            guard await git.isCommitSigned(worktreePath: worktree.path, ref: branch) else {
+                throw SessionServiceError(
+                    branch + "'s tip commit is not GPG signed; Rebase signs the stack before pushing.",
+                )
+            }
+
             await progress("Pushing `" + branch + "`")
             try await git.push(worktreePath: worktree.path, branch: branch)
             pushed.append(branch)
         }
         return pushed
+    }
+
+    /// The stack's branches whose tip is not signed, so the button
+    /// that would push them can dim the way a branch's own does
+    /// rather than failing on the first one.
+    func branchesUnsigned(worktree: Worktree) async -> [String] {
+        let stack = await stack(for: worktree)
+        var unsigned = [String]()
+        for branch in stack.branches where await git.isCommitSigned(
+            worktreePath: worktree.path,
+            ref: branch,
+        ) == false {
+            unsigned.append(branch)
+        }
+        return unsigned
     }
 
     /// The branches this worktree's stack has been told to leave

--- a/Sources/AgentIDEData/SessionService+Stack.swift
+++ b/Sources/AgentIDEData/SessionService+Stack.swift
@@ -23,6 +23,18 @@ public extension SessionService {
         // is a branch this worktree has been told to leave out;
         // whatever is checked out is part of it whatever it says.
         let excluded = Set(excludedStackBranches(worktreePath: path))
+        // Everything the answer depends on, in one process: where
+        // every branch points, which is held, and which are left
+        // out. The rota derives a stack for a worktree at a time all
+        // day, and almost none of them have moved since last time.
+        let fingerprint = await git.refFingerprint(worktreePath: path)
+            + checkedOut + baseRef + excluded.sorted().joined(separator: ",")
+        if let known = await StackCache.shared.stack(for: path, derivedFrom: fingerprint) {
+            PerformanceLog.record(cacheHit: true, "stack#" + path)
+            return known
+        }
+
+        PerformanceLog.record(cacheHit: false, "stack#" + path)
         let candidates = await git.branches(worktreePath: path)
             .filter { $0 != base && ($0 == checkedOut || excluded.contains($0) == false) }
         var related = [StackCandidate]()
@@ -62,11 +74,13 @@ public extension SessionService {
         // same commit, so the actions that move what is checked out
         // stay live rather than dimming on a name that has gone.
         let standingIn = await twin(of: checkedOut, among: branches, worktreePath: path)
-        return BranchStack(
+        let derived = BranchStack(
             base: base,
             branches: branches.isEmpty ? fallback : branches,
             checkedOut: standingIn ?? checkedOut,
         )
+        await StackCache.shared.remember(derived, for: path, derivedFrom: fingerprint)
+        return derived
     }
 
     /// The stack's entries in build order, with branches at one

--- a/Sources/AgentIDEData/SessionService+Stack.swift
+++ b/Sources/AgentIDEData/SessionService+Stack.swift
@@ -187,6 +187,9 @@ public extension SessionService {
         let path = worktree.path
         let stack = await stack(for: worktree)
         try await requireQuiet(worktree: worktree, action: "restack")
+        // The bottom entry rebases onto the default branch, which is
+        // only worth rebasing onto if the remote is current.
+        try await fetchIfStale(repositoryPath: worktree.repositoryPath, workingDirectory: path)
         guard let base = stack.base else {
             throw stackError("No default branch to stack on", in: path)
         }

--- a/Sources/AgentIDEData/StackCache.swift
+++ b/Sources/AgentIDEData/StackCache.swift
@@ -1,0 +1,39 @@
+import AgentIDEDomain
+import Foundation
+
+/// The stack each worktree was last found to be in, against the
+/// state it was derived from. Deriving one asks git about every
+/// branch's fork point and how far it has come, thirty processes
+/// for a repository of a few branches, and the sidebar's rota does
+/// it for a worktree at a time all day. Nothing about the answer
+/// can change while every branch still points where it did, the
+/// same branch is checked out and the same ones are excluded, so
+/// that is what the answer is kept against.
+actor StackCache {
+    // MARK: Internal
+
+    static let shared: StackCache = .init()
+
+    /// The remembered stack, or nil when anything it was derived
+    /// from has moved.
+    func stack(for worktreePath: String, derivedFrom fingerprint: String) -> BranchStack? {
+        guard let entry = entries[worktreePath], entry.fingerprint == fingerprint else {
+            return nil
+        }
+
+        return entry.stack
+    }
+
+    func remember(_ stack: BranchStack, for worktreePath: String, derivedFrom fingerprint: String) {
+        entries[worktreePath] = Entry(fingerprint: fingerprint, stack: stack)
+    }
+
+    // MARK: Private
+
+    private struct Entry {
+        let fingerprint: String
+        let stack: BranchStack
+    }
+
+    private var entries: [String: Entry] = [:]
+}

--- a/Sources/AgentIDEData/StackCache.swift
+++ b/Sources/AgentIDEData/StackCache.swift
@@ -1,5 +1,4 @@
 import AgentIDEDomain
-import Foundation
 
 /// The stack each worktree was last found to be in, against the
 /// state it was derived from. Deriving one asks git about every

--- a/Sources/PRFeature/PullRequestCreateForm.swift
+++ b/Sources/PRFeature/PullRequestCreateForm.swift
@@ -65,7 +65,7 @@ struct PullRequestCreateForm: View {
     /// nothing here can be opened until it is, so nothing is typed
     /// into a form that cannot be sent.
     private var isBlocked: Bool {
-        model.unpushedBelow != nil
+        model.unpushedBelow != nil || model.isOpening
     }
 
     /// Back to what the commits say. Typed text asks first; blank

--- a/Sources/PRFeature/PullRequestFooterView+Stack.swift
+++ b/Sources/PRFeature/PullRequestFooterView+Stack.swift
@@ -26,14 +26,18 @@ extension PullRequestFooterView {
             rebaseCount,
             busy: "Rebasing",
             systemImage: "arrow.triangle.2.circlepath",
-            accessibilityLabel: "Restack",
+            accessibilityLabel: "Rebase the stack",
             disabled: model.canRestack == false,
         ) {
-            await model.restack()
+            if await model.restack() == false {
+                utilityTab = UtilityTabTarget.errors
+            }
         }
         .hoverHelp(
             model.canRestack
-                ? "Rebase every branch onto the one below it, signed, leaving alone any already there"
+                ? "Fetch, then rebase every branch onto the one below it, signing every commit it "
+                + "replays and leaving alone any branch already in place; a conflict aborts and "
+                + "reports to Messages"
                 : "Every branch is already on the one below it",
         )
     }
@@ -47,13 +51,11 @@ extension PullRequestFooterView {
             disabled: model.canPushStack == false,
             keepsTitle: true,
         ) {
-            await model.pushStack()
+            if await model.pushStack() == false {
+                utilityTab = UtilityTabTarget.errors
+            }
         }
-        .hoverHelp(
-            model.canPushStack
-                ? "Push every branch of the stack, bottom first"
-                : "Every branch of the stack is already pushed",
-        )
+        .hoverHelp(model.pushStackHelp)
     }
 
     /// Why the stacked merge is in its current state: what it does

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -276,59 +276,6 @@ extension PullRequestsModel {
 
     /// Rebases onto origin with signed commits; false means the
     /// rebase aborted and the errors tab should open with the cause.
-    func rebaseSigned() async -> Bool {
-        guard let worktree = listedWorktree else {
-            return true
-        }
-
-        do {
-            try await performRebase(worktree)
-            setStatus("Rebased and signed.", detail: "Rebased and signed " + worktree.branch + ".")
-            Self.requestSidebarRefresh()
-            await reload(keepingSelection: true)
-            return true
-        } catch {
-            report(error.localizedDescription)
-            return false
-        }
-    }
-
-    /// The one merge action's label, naming exactly what a click
-    /// does right now; nil when no open conversation is selected.
-    var mergeActionTitle: String? {
-        guard let selected, selected.state == "OPEN" else {
-            return nil
-        }
-
-        if selected.hasAutomerge {
-            return hasMergeQueue ? "Dequeue" : "Cancel automerge"
-        }
-        if selected.checks == "SUCCESS", selected.mergeable == "MERGEABLE" {
-            return hasMergeQueue ? "Queue" : "Merge"
-        }
-        return "Automerge"
-    }
-
-    /// The present-tense form while the merge action runs.
-    var mergeActionBusyTitle: String {
-        switch mergeActionTitle {
-        case "Dequeue":
-            "Dequeuing"
-
-        case "Cancel automerge":
-            "Cancelling"
-
-        case "Queue":
-            "Queueing"
-
-        case "Merge":
-            "Merging"
-
-        default:
-            "Enabling automerge"
-        }
-    }
-
     /// Merges a stacked pull request together with every one below
     /// it, in order; false opens the errors surface. GitHub decides
     /// how each is merged, so the button says only that it merges.

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -215,6 +215,8 @@ extension PullRequestsModel {
 
         let template = prTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
         let body = prBody + (template.isEmpty ? "" : "\n\n" + template)
+        isOpening = true
+        defer { isOpening = false }
         do {
             let url = try await performCreate(worktree, title, body)
             note("Opened pull request " + url)
@@ -227,10 +229,21 @@ extension PullRequestsModel {
                 report("Stacking on GitHub failed: " + error.localizedDescription)
             }
             pullRequests.invalidateListings(repositoryPath: repository.path)
-            prTitle = ""
-            prBody = ""
             Self.requestSidebarRefresh()
             await reload(keepingSelection: true)
+            // Straight into what was just opened: the listing has it
+            // by number, and its conversation is what the form was
+            // for. Only once it is showing does the form let go of
+            // the text, so nothing blank is ever on screen.
+            let opened = Self.number(inURL: url)
+            if let summary = summaries.first(where: { $0.number == opened }) {
+                select(summary)
+            }
+            loadingDraft = true
+            prTitle = ""
+            prBody = ""
+            prTemplate = originalTemplate
+            loadingDraft = false
             clearDraft()
             return true
         } catch {

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -53,6 +53,32 @@ extension PullRequestsModel {
         note(detail ?? message)
     }
 
+    /// How long a push waits before looking again. Asking at once
+    /// answers with the checks as they were before it: GitHub takes
+    /// a moment to see the new commits, and the store would then
+    /// hold that stale answer for a minute more. A minute later the
+    /// run has been created and the row goes yellow.
+    static let checksDelay: Duration = .seconds(PullRequestStore.minimumInterval)
+
+    /// Looks at the branch's pull request again a minute after a
+    /// push, from the store's own timers outwards, so the row and
+    /// the header catch the checks the push started.
+    func refreshAfterPush() {
+        Task { [weak self] in
+            try? await Task.sleep(for: Self.checksDelay)
+            guard let self, Task.isCancelled == false else {
+                return
+            }
+
+            pullRequests.invalidateListings(repositoryPath: repository.path)
+            if let number = selected?.number {
+                pullRequests.invalidate(repositoryPath: repository.path, number: number)
+            }
+            Self.requestSidebarRefresh()
+            await reload(keepingSelection: true)
+        }
+    }
+
     /// A note about this repository's work, named as the sidebar
     /// names it.
     func note(_ message: String) {
@@ -227,6 +253,7 @@ extension PullRequestsModel {
             setStatus("Pushed.", detail: Self.describe(push: destination, branch: worktree.branch))
             Self.requestSidebarRefresh()
             await reload(keepingSelection: true)
+            refreshAfterPush()
             return true
         } catch {
             report(error.localizedDescription)

--- a/Sources/PRFeature/PullRequestsModel+Branch.swift
+++ b/Sources/PRFeature/PullRequestsModel+Branch.swift
@@ -31,6 +31,73 @@ extension PullRequestsModel {
         branchItem != nil && rebaseNeed != SessionService.RebaseNeed.nothing
     }
 
+    func rebaseSigned() async -> Bool {
+        guard let worktree = listedWorktree else {
+            return true
+        }
+
+        do {
+            try await performRebase(worktree)
+            // A stack member that moves takes the branches above it
+            // with it. Left where they were, they fork from the
+            // default branch instead of from it, which is not a
+            // stack at all: the tab lost the entry that had just
+            // moved and showed whichever branch was checked out, so
+            // the next press rebased that one instead.
+            if stacking.stack.isStacked {
+                do {
+                    _ = try await stacking.restack(worktree)
+                } catch {
+                    report("Rebasing the branches above " + worktree.branch + " failed: "
+                        + error.localizedDescription)
+                }
+            }
+            setStatus("Rebased and signed.", detail: "Rebased and signed " + worktree.branch + ".")
+            Self.requestSidebarRefresh()
+            await reload(keepingSelection: true)
+            return true
+        } catch {
+            report(error.localizedDescription)
+            return false
+        }
+    }
+
+    /// The one merge action's label, naming exactly what a click
+    /// does right now; nil when no open conversation is selected.
+    var mergeActionTitle: String? {
+        guard let selected, selected.state == "OPEN" else {
+            return nil
+        }
+
+        if selected.hasAutomerge {
+            return hasMergeQueue ? "Dequeue" : "Cancel automerge"
+        }
+        if selected.checks == "SUCCESS", selected.mergeable == "MERGEABLE" {
+            return hasMergeQueue ? "Queue" : "Merge"
+        }
+        return "Automerge"
+    }
+
+    /// The present-tense form while the merge action runs.
+    var mergeActionBusyTitle: String {
+        switch mergeActionTitle {
+        case "Dequeue":
+            "Dequeuing"
+
+        case "Cancel automerge":
+            "Cancelling"
+
+        case "Queue":
+            "Queueing"
+
+        case "Merge":
+            "Merging"
+
+        default:
+            "Enabling automerge"
+        }
+    }
+
     /// Push makes sense with unpushed commits that this tab has not
     /// already pushed and a GPG-signed tip; nil upstream means
     /// nothing was ever pushed. In a stack it is the listed entry's

--- a/Sources/PRFeature/PullRequestsModel+Draft.swift
+++ b/Sources/PRFeature/PullRequestsModel+Draft.swift
@@ -23,6 +23,11 @@ extension PullRequestsModel {
             && summaries.contains { $0.headBranch == listedBranch && $0.state == "OPEN" } == false
     }
 
+    /// The number a pull request URL ends with.
+    static func number(inURL url: String) -> Int? {
+        url.split(separator: "/").last.flatMap { Int($0) }
+    }
+
     /// Whether the last fetch filled its limit, so more pages may
     /// exist beyond what is loaded.
     var hasMore: Bool {

--- a/Sources/PRFeature/PullRequestsModel+Stack.swift
+++ b/Sources/PRFeature/PullRequestsModel+Stack.swift
@@ -384,6 +384,7 @@ extension PullRequestsModel {
             setStatus("Pushed.", detail: "Pushed " + pushed.joined(separator: ", ") + ".")
             Self.requestSidebarRefresh()
             await reload(keepingSelection: true)
+            refreshAfterPush()
             return true
         } catch {
             report(error.localizedDescription)

--- a/Sources/PRFeature/PullRequestsModel+Stack.swift
+++ b/Sources/PRFeature/PullRequestsModel+Stack.swift
@@ -22,6 +22,9 @@ struct StackWork {
 
     /// The branches with commits the remote lacks, bottom first.
     var unpushedBranches: [String] = []
+
+    /// The branches whose tip is unsigned, which no push will take.
+    var unsignedBranches: [String] = []
     var fetch: (Worktree) async -> BranchStack = { worktree in
         BranchStack(base: nil, branches: [worktree.branch], checkedOut: worktree.branch)
     }
@@ -30,6 +33,7 @@ struct StackWork {
     var push: (Worktree) async throws -> [String] = { _ in [] }
     var pending: (Worktree) async -> Bool = { _ in false }
     var unpushed: (Worktree) async -> [String] = { _ in [] }
+    var unsigned: (Worktree) async -> [String] = { _ in [] }
 }
 
 /// A stack of branches in one worktree, as the pull request tab sees
@@ -53,6 +57,9 @@ extension PullRequestsModel {
         }
         stacking.unpushed = { worktree in
             await service.branchesUnpushed(worktree: worktree)
+        }
+        stacking.unsigned = { worktree in
+            await service.branchesUnsigned(worktree: worktree)
         }
     }
 
@@ -92,7 +99,20 @@ extension PullRequestsModel {
     /// Whether any branch of the stack has commits the remote does
     /// not carry.
     var canPushStack: Bool {
-        stacking.needsPush
+        stacking.needsPush && stacking.unsignedBranches.isEmpty
+    }
+
+    /// Why the stack's push is in its current state, said the way a
+    /// branch's own push says it.
+    var pushStackHelp: String {
+        guard stacking.needsPush else {
+            return "Every branch of the stack is already pushed"
+        }
+        guard let unsigned = stacking.unsignedBranches.first else {
+            return "Push every branch of the stack, bottom first"
+        }
+
+        return unsigned + "'s tip commit is not GPG signed; Rebase signs the stack before pushing"
     }
 
     /// Fills in the listing cache for the stack's other branches,
@@ -140,6 +160,7 @@ extension PullRequestsModel {
         stacking.stack = await stacking.fetch(worktree)
         stacking.needsRestack = await stacking.pending(worktree)
         stacking.unpushedBranches = await stacking.unpushed(worktree)
+        stacking.unsignedBranches = await stacking.unsigned(worktree)
         stacking.needsPush = stacking.unpushedBranches.isEmpty == false
         // The entry in view: the one remembered for this worktree,
         // else the first that could have a pull request opened (the
@@ -327,39 +348,46 @@ extension PullRequestsModel {
     /// Puts every branch back on the one below it and says what
     /// moved; a branch already there is left alone, so no commit is
     /// renamed for nothing.
-    func restack() async {
+    func restack() async -> Bool {
         guard let worktree = branchItem?.worktree else {
-            return
+            return true
         }
 
         do {
             let moved = try await stacking.restack(worktree)
-            note(
-                moved.isEmpty
+            setStatus(
+                moved.isEmpty ? "Already in order." : "Rebased and signed.",
+                detail: moved.isEmpty
                     ? "The stack was already in order."
-                    : "Rebased " + moved.joined(separator: ", ") + ".",
+                    : "Rebased and signed " + moved.joined(separator: ", ") + ".",
             )
+            Self.requestSidebarRefresh()
             await loadStack()
             await reload(keepingSelection: true)
+            return true
         } catch {
             report(error.localizedDescription)
+            return false
         }
     }
 
     /// Pushes the stack bottom up, so each pull request's base is on
     /// the remote before the branch that points at it.
-    func pushStack() async {
+    func pushStack() async -> Bool {
         guard let worktree = branchItem?.worktree else {
-            return
+            return true
         }
 
         do {
             let pushed = try await stacking.push(worktree)
             pullRequests.invalidateListings(repositoryPath: repository.path)
-            note("Pushed " + pushed.joined(separator: ", ") + ".")
+            setStatus("Pushed.", detail: "Pushed " + pushed.joined(separator: ", ") + ".")
+            Self.requestSidebarRefresh()
             await reload(keepingSelection: true)
+            return true
         } catch {
             report(error.localizedDescription)
+            return false
         }
     }
 }

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -225,6 +225,10 @@ final class PullRequestsModel {
     /// never writes back what it just read.
     var loadingDraft = false
 
+    /// True while a pull request is being opened: the form keeps
+    /// every word it holds and takes no more until GitHub answers.
+    var isOpening = false
+
     /// Whether the repository has a pull request template; without
     /// one the form shows no template field at all.
     var hasTemplate = false

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -94,6 +94,9 @@ final class PullRequestsModel {
         fetchCommitMessages = { worktree, range in
             await service.commitMessages(worktree: worktree, range: range)
         }
+        fetchCommitCount = { worktree, range in
+            await service.commitCount(worktree: worktree, range: range)
+        }
         launchChoices = { agent in
             let choices = service.launchChoices(for: agent)
             return (choices.models, service.defaultEffort(for: agent))
@@ -186,6 +189,10 @@ final class PullRequestsModel {
     /// Set only by the actions extension's fact refresh.
     var rebaseNeed: SessionService.RebaseNeed = .nothing
 
+    /// The listed entry's own commits: what a push sends and what
+    /// its pull request carries, counted from the branch's base.
+    var commitsAboveBase = 0
+
     /// Whether the tip commit is GPG signed, refreshed on reload;
     /// pushing unsigned commits is never allowed, so Push dims until
     /// Rebase on origin signs the branch.
@@ -252,6 +259,10 @@ final class PullRequestsModel {
 
     var fetchTemplate: (String) async -> String?
     var fetchCommitMessages: (Worktree, String?) async -> [String]
+
+    /// How many commits the listed entry has of its own, which is
+    /// what the push button counts.
+    var fetchCommitCount: (Worktree, String?) async -> Int = { _, _ in 0 }
     var generateDescription: ([String]) async -> (title: String, body: String)?
     var fillTemplate: ([String], String) async -> String?
     var performMergeChange: (PullRequestSummary) async throws -> Void
@@ -332,6 +343,9 @@ final class PullRequestsModel {
                 // fills the form from this entry's own commits.
                 await prefillFromSingleCommit(worktree)
             }
+            // The count belongs to the entry, not to the worktree,
+            // so an entry switch reads it again.
+            commitsAboveBase = await fetchCommitCount(listedWorktree ?? worktree, listedRange)
         }
         defer {
             isLoading = false

--- a/Sources/TerminalUI/BlockSelector.swift
+++ b/Sources/TerminalUI/BlockSelector.swift
@@ -32,10 +32,7 @@ final class BlockSelector {
         switch event.type {
         case .leftMouseDown:
             let point = view.convert(event.locationInWindow, from: nil)
-            guard event.modifierFlags.contains(.option), view.bounds.contains(point),
-                  view.isHiddenOrHasHiddenAncestor == false,
-                  Self.hitsTerminal(event, in: view)
-            else {
+            guard event.modifierFlags.contains(.option), Self.hitsTerminal(event, in: view) else {
                 // Any other click puts the last block selection away,
                 // as clicking does to an ordinary one.
                 clear()
@@ -103,16 +100,20 @@ final class BlockSelector {
     private var heldRows: ClosedRange<Int>?
     private var heldColumns: ClosedRange<Int>?
 
-    /// Whether the window resolves the click to this terminal: a
-    /// pane kept mounted but covered or hidden must not steal drags
-    /// from the view actually under the pointer.
+    /// Whether this terminal is the one under the pointer: it is on
+    /// screen, and the click is inside it. Not the window's own hit
+    /// test, which was the rule before: panes stay mounted when
+    /// another worktree's are showing, faded out rather than
+    /// removed, and AppKit still resolves a click to one of those.
+    /// The pane the pointer was actually over was told the drag was
+    /// not its own, so a shell pane never started a selection while
+    /// the covered pane quietly took it.
     private static func hitsTerminal(_ event: NSEvent, in view: PaneTerminalView) -> Bool {
-        guard let content = view.window?.contentView, let root = content.superview else {
+        guard view.window != nil, view.isOnScreen else {
             return false
         }
 
-        let hit = content.hitTest(root.convert(event.locationInWindow, from: nil))
-        return hit === view || hit?.isDescendant(of: view) == true
+        return view.bounds.contains(view.convert(event.locationInWindow, from: nil))
     }
 
     private func begin(at point: CGPoint, in view: PaneTerminalView) {

--- a/Sources/TerminalUI/NSView+OnScreen.swift
+++ b/Sources/TerminalUI/NSView+OnScreen.swift
@@ -1,0 +1,19 @@
+import AppKit
+
+extension NSView {
+    /// Whether this view is actually visible: not hidden and not
+    /// faded out, itself or through any view above it. A pane kept
+    /// mounted behind another is transparent rather than hidden,
+    /// which `isHiddenOrHasHiddenAncestor` alone does not catch.
+    var isOnScreen: Bool {
+        var current: NSView? = self
+        while let view = current {
+            if view.isHidden || view.alphaValue <= 0 {
+                return false
+            }
+
+            current = view.superview
+        }
+        return true
+    }
+}

--- a/Tests/AgentIDEDataTests/GitClientIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/GitClientIntegrationTests.swift
@@ -191,6 +191,30 @@ struct GitClientIntegrationTests {
     }
 
     @Test
+    func `the checked-out branch is read from the file git keeps it in`() async throws {
+        let root = try TestSupport.temporaryDirectory("head-file")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let path = root + "/repo"
+        try await TestSupport.makeRepository(at: path)
+        _ = try await TestSupport.runGit(["checkout", "-q", "-b", "feature"], in: path)
+
+        // The same answer the command gives, for a hundredth of the
+        // time: the stack asks this of every worktree on every read.
+        #expect(GitClient.headFileBranch(worktreePath: path) == "feature")
+        #expect(await git.currentBranch(worktreePath: path) == "feature")
+
+        // A detached head holds a commit rather than a ref, and is
+        // what a rebase leaves behind while it runs.
+        let tip = try await TestSupport.runGit(["rev-parse", "HEAD"], in: path)
+            .standardOutput
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await TestSupport.runGit(["checkout", "-q", tip], in: path)
+
+        #expect(GitClient.headFileBranch(worktreePath: path) == nil)
+        #expect(await git.currentBranch(worktreePath: path) == nil)
+    }
+
+    @Test
     func `one read answers for every branch in a repository`() async throws {
         let root = try TestSupport.temporaryDirectory("facts")
         defer { try? FileManager.default.removeItem(atPath: root) }

--- a/Tests/AgentIDEDataTests/MetadataStoreTests.swift
+++ b/Tests/AgentIDEDataTests/MetadataStoreTests.swift
@@ -57,6 +57,24 @@ struct MetadataStoreTests {
     }
 
     @Test
+    func `a fetch inside the minute is reused, and a stale one is not`() throws {
+        let root = try TestSupport.temporaryDirectory("fetch-stamp")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let store = MetadataStore(file: root + "/state.json")
+
+        // Rebasing wants a current remote, and fetching a large
+        // repository takes seconds: one rebase's fetch serves the
+        // next rebase started right after it, and nothing older.
+        store.update { $0.gitFetchedAt["/repositories/brew"] = Date().addingTimeInterval(-30) }
+        let recent = try #require(store.load().gitFetchedAt["/repositories/brew"])
+        #expect(Date().timeIntervalSince(recent) < SessionService.fetchInterval)
+
+        store.update { $0.gitFetchedAt["/repositories/brew"] = Date().addingTimeInterval(-90) }
+        let stale = try #require(store.load().gitFetchedAt["/repositories/brew"])
+        #expect(Date().timeIntervalSince(stale) >= SessionService.fetchInterval)
+    }
+
+    @Test
     func `decoding tolerates files written before new fields existed`() throws {
         let root = try TestSupport.temporaryDirectory("store-old")
         defer { try? FileManager.default.removeItem(atPath: root) }

--- a/Tests/AgentIDEDataTests/StackCacheIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/StackCacheIntegrationTests.swift
@@ -37,6 +37,41 @@ struct StackCacheIntegrationTests {
         #expect(second.branches == ["lower", "upper"])
     }
 
+    @Test
+    func `a fetch that moves the default branch is a stack that has changed`() async throws {
+        let world = try await World.make()
+        defer { world.tearDown() }
+        let repository = try #require(world.service.repositories().first)
+        try await Self.commit("first", in: repository.path)
+        _ = try await TestSupport.runGit(["checkout", "-b", "lower"], in: repository.path)
+        try await Self.commit("lower work", in: repository.path)
+        let worktree = Worktree(
+            repositoryName: repository.name,
+            repositoryPath: repository.path,
+            branch: "lower",
+            path: repository.path,
+        )
+
+        #expect(await world.service.stack(for: worktree).branches == ["lower"])
+
+        // Every fork point is measured against the default branch,
+        // so a fetch moving it changes what a stack is while every
+        // local branch stays exactly where it was: the fingerprint
+        // has to see the remote refs, not only the local ones.
+        let moved = try await TestSupport.runGit(["rev-parse", "lower"], in: repository.path)
+            .standardOutput
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let git = GitClient(runner: FoundationProcessRunner())
+        let before = await git.refFingerprint(worktreePath: repository.path)
+        _ = try await TestSupport.runGit(
+            ["update-ref", "refs/remotes/origin/main", moved],
+            in: repository.path,
+        )
+        let after = await git.refFingerprint(worktreePath: repository.path)
+
+        #expect(before != after)
+    }
+
     // MARK: Private
 
     /// A commit of its own, so this suite needs nothing from the

--- a/Tests/AgentIDEDataTests/StackCacheIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/StackCacheIntegrationTests.swift
@@ -1,0 +1,50 @@
+@testable import AgentIDEData
+import AgentIDEDomain
+import Foundation
+import Testing
+
+/// Deriving a stack is thirty git processes, so the answer is kept
+/// against where every branch points: these pin when that answer is
+/// reused and when it is worked out again.
+struct StackCacheIntegrationTests {
+    // MARK: Internal
+
+    @Test
+    func `a stack is derived again only when a branch has moved`() async throws {
+        let world = try await World.make()
+        defer { world.tearDown() }
+        let repository = try #require(world.service.repositories().first)
+        try await Self.commit("first", in: repository.path)
+        _ = try await TestSupport.runGit(["checkout", "-b", "lower"], in: repository.path)
+        try await Self.commit("lower work", in: repository.path)
+        let worktree = Worktree(
+            repositoryName: repository.name,
+            repositoryPath: repository.path,
+            branch: "lower",
+            path: repository.path,
+        )
+
+        let first = await world.service.stack(for: worktree)
+        // Nothing moved: the same answer, without asking git about
+        // every branch's fork point a second time.
+        #expect(await world.service.stack(for: worktree) == first)
+
+        _ = try await TestSupport.runGit(["checkout", "-b", "upper"], in: repository.path)
+        try await Self.commit("upper work", in: repository.path)
+
+        // A branch that has moved is a stack that has changed.
+        let second = await world.service.stack(for: worktree)
+        #expect(second.branches == ["lower", "upper"])
+    }
+
+    // MARK: Private
+
+    /// A commit of its own, so this suite needs nothing from the
+    /// derivation's.
+    private static func commit(_ message: String, in path: String) async throws {
+        let file = path + "/" + message.replacing(" ", with: "_") + ".txt"
+        try message.write(toFile: file, atomically: true, encoding: .utf8)
+        _ = try await TestSupport.runGit(["add", "."], in: path)
+        _ = try await TestSupport.runGit(["commit", "-m", message], in: path)
+    }
+}

--- a/Tests/PRFeatureTests/PullRequestStackTests.swift
+++ b/Tests/PRFeatureTests/PullRequestStackTests.swift
@@ -183,6 +183,31 @@ struct PullRequestStackTests {
     }
 
     @Test
+    func `rebasing one entry carries the branches above it`() async {
+        let fixtures = PullRequestsModelTests()
+        let model = fixtures.makeModel(items: [fixtures.item(branch: "feature", ahead: 1)])
+        model.fetchCurrentBranch = { _ in "upper" }
+        model.stacking.fetch = { _ in
+            BranchStack(base: "main", branches: ["lower", "upper"], checkedOut: "upper")
+        }
+        let done = Mutex([String]())
+        model.performRebase = { _ in done.withLock { $0.append("rebase") } }
+        model.stacking.restack = { _ in
+            done.withLock { $0.append("restack") }
+            return ["upper"]
+        }
+        await model.reload()
+
+        #expect(await model.rebaseSigned())
+
+        // Left where they were, the branches above fork from the
+        // default branch instead of from the one that moved, and the
+        // stack stops being one: the tab then lost the entry that
+        // had just moved and showed whatever was checked out.
+        #expect(done.withLock { $0 } == ["rebase", "restack"])
+    }
+
+    @Test
     func `the listed branch's span is its own, stacked or not`() async {
         let fixtures = PullRequestsModelTests()
         let model = fixtures.makeModel(items: [fixtures.item(branch: "feature", ahead: 1)])

--- a/Tests/PRFeatureTests/PullRequestStackTests.swift
+++ b/Tests/PRFeatureTests/PullRequestStackTests.swift
@@ -159,6 +159,30 @@ struct PullRequestStackTests {
     }
 
     @Test
+    func `the stack refuses to push what no push would take`() async {
+        let fixtures = PullRequestsModelTests()
+        let model = fixtures.makeModel(items: [fixtures.item(branch: "feature", ahead: 1)])
+        model.fetchCurrentBranch = { _ in "upper" }
+        model.stacking.fetch = { _ in
+            BranchStack(base: "main", branches: ["lower", "upper"], checkedOut: "upper")
+        }
+        model.stacking.unpushed = { _ in ["lower", "upper"] }
+        model.stacking.unsigned = { _ in ["lower"] }
+        await model.reload()
+
+        // A branch's own Push dims until its tip is signed, since
+        // the hook turns unsigned commits away; the stack's did not,
+        // and pushed until the first refusal.
+        #expect(model.canPushStack == false)
+        #expect(model.pushStackHelp.contains("not GPG signed"))
+
+        model.stacking.unsigned = { _ in [] }
+        await model.loadStack()
+
+        #expect(model.canPushStack)
+    }
+
+    @Test
     func `the listed branch's span is its own, stacked or not`() async {
         let fixtures = PullRequestsModelTests()
         let model = fixtures.makeModel(items: [fixtures.item(branch: "feature", ahead: 1)])


### PR DESCRIPTION
- panes retain mounting when other worktrees appear, avoiding removal and ensuring click detection on the correct pane, including terminal behavior with Option-drag  
- every rebase now triggers a fetch before operation, with a one-minute cooldown to prevent redundant network calls, unifying fetch logic across rebase, merge cleanup, and explicit commands  
- stack buttons now mirror branch etiquette, rejecting unsigned pushes, dimming branch names, logging sidebar updates, and properly handling restack hover actions  
- entry commit counts reflect its own base and push state, with push buttons showing accurate local history, and GitHub checks re-evaluated a minute later for consistency  
- form maintains all inputs until a pull request is displayed, caching stack data via a single `for-each-ref` lookup to reduce process overhead and eliminate blank fields  
- branch information is now read directly from the worktree’s gitdir file, replacing slow symbolic-ref polling and ensuring correct handling of detached heads  
- branches above a rebase entry are now preserved and moved together, aligning with restack behavior and maintaining stack integrity