### PR TITLE
Let the centre pane host the editor

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,8 +9,13 @@ analyzer_rules:
   # positives; periphery handles dead-code detection instead.
   - unused_import
 disabled_rules:
-  # Conflicts with opening_brace and SwiftFormat's brace style.
+  # Conflicts with SwiftFormat's brace style, which keeps braces on
+  # the declaration line except after multiline conditions.
   - contrasted_opening_brace
+  # Conflicts with SwiftFormat 0.63's wrapMultilineStatementBraces,
+  # which wraps the brace after a multiline condition onto its own
+  # line; SwiftFormat owns brace placement.
+  - opening_brace
   # Conflicts with redundant_type_annotation.
   - explicit_type_interface
   # Conflict with SwiftFormat's redundantInternal rule.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -473,11 +473,32 @@ page resumes any past conversation into a fresh worktree.
 7. Read-only text is never `.disabled`, which takes selection with
    editing: the binding drops writes and the view dims.
 
+The **editor** is one `EditorPane` implementation filling two slots:
+the utility pane's Editor tab and, when chosen, the centre pane. A
+directory of your own is pinned to the centre slot; a worktree or
+repository page opens it from an Editor button on its conversations
+view, and the primary pane's branch order is what guarantees a live
+session always outranks the centre editor, so one can never cover the
+other. Each slot persists its own finder and open file under
+role-suffixed defaults keys; open-file and finder-focus requests
+travel the shared keys and the window routes each to the preferred
+slot: the side editor unless the centre editor is on screen, and
+always the slot already holding the requested file, so one file never
+opens in both. A move button on the open file sends it to the other
+slot, and a session appearing in a worktree whose centre held the
+editor (`agentide new`, a phone, a resume) moves the open file to the
+side editor. Buffers survive every such displacement because an editor
+saves on its way off screen; the Close button is the one deliberate
+discard, and a file a command waits on is never written behind its
+back. The two slots mounting together share one ripgrep file listing
+per worktree (`FileListings`), joining a run in flight rather than
+spawning a second.
+
 The **editor shim** (`bin/agentide`, on every shell pane's `PATH` as
 `EDITOR`, `VISUAL` and `GIT_EDITOR` with `--wait`) spools one JSON
 request per file into `AGENTIDE_EDITS` (or `~/.agentide/edits`),
 written aside and renamed into place; the window watches the spool with
-a dispatch source, opens the file in the utility pane's editor and
+a dispatch source, opens the file in the preferred editor slot and
 writes `.open`, then `.done` with the exit status the shim takes (zero
 saved, non-zero cancelled, which aborts a rebase). A request whose
 process has gone is swept. Nothing inside the sandbox can reach the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -587,10 +587,17 @@ selects the worktree holding it, and `agentide new` starts a session.
   mergeability alone offered Merge on a branch whose policy still
   wanted a review, and `gh` refused it.
 - **Last mile buttons**: copy unresolved review threads grouped per
-  file; one failing-checks button that copies the tail of every failing
-  run's `gh run view --log-failed` condensed (job and step named once
-  in a heading, timestamps and colour stripped), Cmd opening the check
-  in the browser and Shift in the Browser tab.
+  file, dimmed until one is unresolved (the count comes from the
+  threads the conversation pane has read, since no listing query
+  carries it); one failing-checks button, dimmed until the rollup is
+  red,
+  that copies the tail of every failing run's `gh run view
+  --log-failed` condensed (job and step named once in a heading,
+  timestamps and colour stripped), Cmd opening the check in the
+  browser and Shift in the Browser tab. A run still in progress has
+  no whole-run log, so its already-failed jobs answer with their own
+  (`--json jobs`, then `--job <id> --log-failed` each) rather than
+  failing while the rest of the run decides.
 - **Cleanup after merge** runs from the Merge button, the context menu
   and the poll (only on an observed open-to-merged transition, never a
   missing pull request) through one path: `git branch -d` refuses

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -546,7 +546,12 @@ selects the worktree holding it, and `agentide new` starts a session.
 - **Signing.** Settings' Require signed commits (default on) makes Push
   wait for the tip to verify and rebases sign (`--force-rebase
   --gpg-sign` after a fetch); off, nothing signs or checks and nothing
-  passes `--no-gpg-sign`. The signed rebase picks the branch's own
+  passes `--no-gpg-sign`. Verification is proof, never trust: Push
+  dims until the current tip has been read as signed, fresh worktree
+  counts re-read it (an agent's commits arrive between reloads), and
+  the click reads it once more, declining in the footer with Rebase
+  relit to sign; the service's own refusal stays as the backstop no
+  user path reaches. The signed rebase picks the branch's own
   origin ref when it is still an ancestor and every commit unique to
   the branch verifies, else origin/HEAD. The ancestor test keeps an
   amended branch out of that path (its pushed commit is a stale twin,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -426,9 +426,13 @@ page resumes any past conversation into a fresh worktree.
   needed, each with its own toggle and chime (any audio file, played
   through `AudioServicesPlayAlertSound` so alert volume and the
   accessibility flash apply; its completion handler must be formed in a
-  nonisolated context or the executor check traps). An exit posts
-  nothing. The Dock badge counts worktrees needing attention, each
-  contribution behind a toggle.
+  nonisolated context or the executor check traps). A chime sleep
+  interrupted mid-play loses its completion and the audio daemon
+  replays it in a loop after wake, so wake disposes every sound whose
+  completion never ran; whoever removes a sound from that registry
+  owns its disposal, so a drain and a late completion never dispose
+  one twice. An exit posts nothing. The Dock badge counts worktrees
+  needing attention, each contribution behind a toggle.
 - **Git reads are driven by the file system.** One FSEvents stream
   over the repository and worktree roots (`WorkspaceWatcher`) remembers
   what changed, and a reading asks git only about repositories

--- a/App/AgentIDEShortcuts.swift
+++ b/App/AgentIDEShortcuts.swift
@@ -337,7 +337,7 @@ nonisolated struct WhatNeedsMeIntent: AppIntent {
             return .result(value: [], dialog: "Nothing needs you.")
         }
 
-        let spoken = needing.map { $0.repository + " " + $0.branch + ", " + $0.state }.joined(separator: "; ")
+        let spoken = needing.lazy.map { $0.repository + " " + $0.branch + ", " + $0.state }.joined(separator: "; ")
         return .result(value: needing, dialog: "\(needing.count) need you: \(spoken).")
     }
 }

--- a/App/AppCommands.swift
+++ b/App/AppCommands.swift
@@ -132,10 +132,10 @@ struct AppCommands: Commands {
         utilityTab = tab.rawValue
     }
 
-    /// Jumps to the editor tab's finder in the chosen mode; the pane
-    /// consumes the focus request once it is on screen.
+    /// Asks for an editor finder in the chosen mode; the window
+    /// routes the request to the centre or side editor, reveals it
+    /// and its pane consumes the focus once on screen.
     private func openFinder(searchingContents: Bool) {
-        show(.editor)
         finderSearchesContents = searchingContents
         finderFocusRequest += 1
     }

--- a/App/ErrorsPane.swift
+++ b/App/ErrorsPane.swift
@@ -107,6 +107,7 @@ struct ErrorsPane: View {
 
     private func copyAll() {
         let text = log.entries
+            .lazy
             .map { $0.date.formatted(.dateTime.hour().minute().second()) + " " + $0.message }
             .joined(separator: "\n\n")
         NSPasteboard.general.clearContents()

--- a/App/RootView+Detail.swift
+++ b/App/RootView+Detail.swift
@@ -1,0 +1,88 @@
+import AgentIDEDomain
+import DashboardFeature
+import SwiftUI
+
+/// The detail column's composition: the covering pages, the split
+/// and the utility pane. Split from the view body's file for length.
+extension RootView {
+    /// The middle pages, never sheets, cover the primary pane
+    /// rather than replacing it: unmounting takes the panes with it,
+    /// and a pane can hold a running agent or shell, which only
+    /// destroying its worktree should end. They cover that pane
+    /// alone, so the utility pane stays where it was: the window
+    /// keeps one shape whatever it is showing.
+    var detail: some View {
+        ZStack {
+            if let item = dependencies.dashboard.selection {
+                split(for: item)
+            } else {
+                unselectedSplit
+            }
+        }
+    }
+
+    @ViewBuilder var coveringPage: some View {
+        if dependencies.dashboard.showsNewSession {
+            NewSessionPane(model: dependencies.dashboard)
+        } else if dependencies.dashboard.showsRepositoryFinder {
+            RepositoryFinderPane(model: dependencies.dashboard)
+        }
+    }
+
+    /// Narrows the panes to what the window can hold. The widths
+    /// are written back, so the dividers keep dragging from where
+    /// the panes actually are.
+    func fitPanes(to width: CGFloat) {
+        currentWindowWidth = width
+        let layout = PaneLayout(
+            width: width,
+            sidebar: sidebarWidth,
+            utility: utilityPaneWidth,
+            showsUtility: showsUtilityPane,
+        )
+        if layout.sidebar != sidebarWidth {
+            sidebarWidth = layout.sidebar
+        }
+        if layout.utility != utilityPaneWidth {
+            utilityPaneWidth = layout.utility
+        }
+    }
+
+    // MARK: Private
+
+    private func split(for item: WorktreeItem) -> some View {
+        HStack(spacing: 0) {
+            primaryColumn(for: item)
+            if showsUtility {
+                PaneDivider(width: $utilityPaneWidth, range: PaneLayout.utilityRange, controlsLeadingPane: false)
+                    .ignoresSafeArea(.container, edges: .top)
+                utilityPane(for: item)
+                    .frame(width: utilityPaneWidth)
+                    .frame(maxHeight: .infinity)
+                    .ignoresSafeArea(.container, edges: .top)
+            }
+        }
+        .ignoresSafeArea(.container, edges: .top)
+    }
+
+    /// The utility pane: the shared tab header over the content, so
+    /// the current tab is always visible whichever tab shows.
+    /// Restores the worktree's remembered tab whenever the selection
+    /// changes, so each worktree keeps its own pane.
+    private func utilityPane(for item: WorktreeItem) -> some View {
+        VStack(spacing: 0) {
+            utilityHeader(for: item)
+            Divider()
+            utilityContent(for: item)
+        }
+        .task(id: item.worktree.path) {
+            // A stale conversation focus must not survive switching
+            // to another sidebar item.
+            conversationWorktree = nil
+            utilityTabName = tabMemory[item.worktree.path] ?? utilityTabName
+        }
+        .onChange(of: utilityTabName) {
+            tabMemory[item.worktree.path] = utilityTabName
+        }
+    }
+}

--- a/App/RootView+EditorRouting.swift
+++ b/App/RootView+EditorRouting.swift
@@ -1,0 +1,157 @@
+import AgentIDEDomain
+import DashboardFeature
+import Foundation
+import ReviewFeature
+
+// MARK: - Editor slot routing
+
+/// Where editor requests land. One `EditorPane` implementation fills
+/// two slots, the centre pane and the utility pane's Editor tab;
+/// openers write untargeted keys and the window, which knows the
+/// selection and what its centre pane shows, routes each request to
+/// the slot that should take it.
+extension RootView {
+    /// Whether the item's centre pane could be an editor: nothing
+    /// session-shaped holds it. A live session always says no, which
+    /// is what keeps an editor from ever covering one.
+    func centreCanShowEditor(for item: WorktreeItem) -> Bool {
+        item.worktree.isHostDirectory
+            || (item.isPlaceholder == false
+                && resumingWorktree != item.worktree.path
+                && dependencies.dashboard.isAwaitingSession(item) == false
+                && item.session == nil
+                && startingSession != item.worktree.path)
+    }
+
+    /// Whether the item's centre pane is an editor right now: a
+    /// directory of your own always, a worktree or repository page
+    /// when it chose the editor and no session outranks it.
+    func centreShowsEditor(for item: WorktreeItem) -> Bool {
+        item.worktree.isHostDirectory
+            || (centreEditorPaths.contains(item.worktree.path) && centreCanShowEditor(for: item))
+    }
+
+    /// Sets a worktree's centre pane to its editor or back to its
+    /// conversations.
+    func setCentreEditor(_ shows: Bool, at path: String) {
+        if shows {
+            centreEditorPaths.insert(path)
+        } else {
+            centreEditorPaths.remove(path)
+        }
+    }
+
+    /// An opener wrote the shared open-file keys: copy them to the
+    /// slot that should show the file and reveal it.
+    func routeOpenFileRequest() {
+        let defaults = UserDefaults.standard
+        let file = defaults.string(forKey: "editorFilePath") ?? ""
+        let worktree = defaults.string(forKey: "editorFileWorktree") ?? ""
+        guard file.isEmpty == false, worktree.isEmpty == false else {
+            return
+        }
+
+        let role = preferredEditorRole(file: file, worktreePath: worktree)
+        defaults.set(file, forKey: role.key("editorFilePath"))
+        defaults.set(defaults.integer(forKey: "editorFileLine"), forKey: role.key("editorFileLine"))
+        defaults.set(worktree, forKey: role.key("editorFileWorktree"))
+        bump(role.key("editorFileRequest"))
+        revealEditor(role)
+    }
+
+    /// A finder menu item asked for focus: point the preferred
+    /// slot's finder at the asked-for mode and reveal it.
+    func routeFinderFocusRequest() {
+        // The launch clears the counter; only real requests route.
+        guard finderFocusRequest > 0 else {
+            return
+        }
+
+        let defaults = UserDefaults.standard
+        let role = preferredEditorRole(file: nil, worktreePath: nil)
+        defaults.set(defaults.bool(forKey: "finderSearchesContents"), forKey: role.key("finderSearchesContents"))
+        bump(role.key("finderFocusRequest"))
+        revealEditor(role)
+    }
+
+    /// Lands a file moved from one editor slot in the other,
+    /// revealing it; moving to the centre opens the centre editor.
+    func receiveMoved(file: String, line: Int?, at worktreePath: String, into role: EditorPane.Role) {
+        let defaults = UserDefaults.standard
+        defaults.set(file, forKey: role.key("editorFilePath"))
+        defaults.set(line ?? 0, forKey: role.key("editorFileLine"))
+        defaults.set(worktreePath, forKey: role.key("editorFileWorktree"))
+        bump(role.key("editorFileRequest"))
+        if role == .centre {
+            setCentreEditor(true, at: worktreePath)
+        } else {
+            revealEditor(.utility)
+        }
+    }
+
+    /// A session appeared in a worktree whose centre pane was the
+    /// editor: the session wins the centre, so the slot closes and
+    /// its open file moves to the side editor. Typing survives
+    /// because an editor saves on its way off screen.
+    func displaceCentreEditors(nowRunning: Set<String>) {
+        let defaults = UserDefaults.standard
+        let centre = EditorPane.Role.centre
+        for path in nowRunning where centreEditorPaths.contains(path) {
+            setCentreEditor(false, at: path)
+            guard defaults.string(forKey: centre.key("editorFileWorktree")) == path,
+                  let file = defaults.string(forKey: centre.key("editorFilePath")), file.isEmpty == false
+            else {
+                continue
+            }
+
+            defaults.set("", forKey: centre.key("editorFilePath"))
+            receiveMoved(
+                file: file,
+                line: defaults.integer(forKey: centre.key("editorFileLine")),
+                at: path,
+                into: .utility,
+            )
+        }
+    }
+
+    // MARK: Private
+
+    /// The slot a request lands in: the side editor unless the
+    /// centre pane is an editor, which takes it, and always the slot
+    /// already holding the requested file, so one file never opens
+    /// twice. Roles are tried centre first, matching what is on
+    /// screen.
+    private func preferredEditorRole(file: String?, worktreePath: String?) -> EditorPane.Role {
+        let defaults = UserDefaults.standard
+        let centreVisible = dependencies.dashboard.selection.map { centreShowsEditor(for: $0) } ?? false
+        if let file, file.isEmpty == false, let worktreePath {
+            for role in EditorPane.Role.allCases
+                where defaults.string(forKey: role.key("editorFilePath")) == file
+                && defaults.string(forKey: role.key("editorFileWorktree")) == worktreePath {
+                // A file held by a centre slot that is not on screen
+                // must not route into the void.
+                if role == .utility || centreVisible {
+                    return role
+                }
+            }
+        }
+        return centreVisible ? .centre : .utility
+    }
+
+    /// Shows the slot a request routed to: the utility pane and its
+    /// Editor tab for the side slot; the centre slot is only ever
+    /// preferred while already on screen.
+    private func revealEditor(_ role: EditorPane.Role) {
+        guard role == .utility else {
+            return
+        }
+
+        showsUtilityPane = true
+        utilityTabName = UtilityTab.editor.rawValue
+    }
+
+    /// Increments a storage-bus counter the slot's pane observes.
+    private func bump(_ key: String) {
+        UserDefaults.standard.set(UserDefaults.standard.integer(forKey: key) + 1, forKey: key)
+    }
+}

--- a/App/RootView+EditorRouting.swift
+++ b/App/RootView+EditorRouting.swift
@@ -31,6 +31,18 @@ extension RootView {
             || (centreEditorPaths.contains(item.worktree.path) && centreCanShowEditor(for: item))
     }
 
+    /// Whether the worktree at a path shows its centre editor, for
+    /// the waiting-edit takeover, which must leave the utility pane
+    /// alone when the centre slot will show the file.
+    func prefersCentreEditor(at path: String) -> Bool {
+        let items = dependencies.dashboard.groups.flatMap(\.items)
+        guard let item = items.first(where: { $0.worktree.path == path }) else {
+            return false
+        }
+
+        return centreShowsEditor(for: item)
+    }
+
     /// Sets a worktree's centre pane to its editor or back to its
     /// conversations.
     func setCentreEditor(_ shows: Bool, at path: String) {
@@ -52,6 +64,15 @@ extension RootView {
         }
 
         let role = preferredEditorRole(file: file, worktreePath: worktree)
+        // An off-screen centre slot still remembering this file
+        // would reopen it beside the routed copy when it next
+        // shows; the file lives in one slot only.
+        let other = role.other
+        if defaults.string(forKey: other.key("editorFilePath")) == file,
+           defaults.string(forKey: other.key("editorFileWorktree")) == worktree
+        {
+            defaults.set("", forKey: other.key("editorFilePath"))
+        }
         defaults.set(file, forKey: role.key("editorFilePath"))
         defaults.set(defaults.integer(forKey: "editorFileLine"), forKey: role.key("editorFileLine"))
         defaults.set(worktree, forKey: role.key("editorFileWorktree"))
@@ -127,7 +148,8 @@ extension RootView {
         if let file, file.isEmpty == false, let worktreePath {
             for role in EditorPane.Role.allCases
                 where defaults.string(forKey: role.key("editorFilePath")) == file
-                && defaults.string(forKey: role.key("editorFileWorktree")) == worktreePath {
+                && defaults.string(forKey: role.key("editorFileWorktree")) == worktreePath
+            {
                 // A file held by a centre slot that is not on screen
                 // must not route into the void.
                 if role == .utility || centreVisible {

--- a/App/RootView+Panes.swift
+++ b/App/RootView+Panes.swift
@@ -22,15 +22,15 @@ extension RootView {
 
     /// One conversations UI everywhere: a live session shows its
     /// terminal; anything else shows the conversation list, scoped
-    /// to the worktree or covering the whole repository on its page;
-    /// a worktree with nothing to list offers the new session form.
+    /// to the worktree or covering the whole repository on its page,
+    /// or the centre editor when the worktree chose it; a worktree
+    /// with nothing to list offers the new session form.
     @ViewBuilder
     func primary(for item: WorktreeItem) -> some View {
         if item.worktree.isHostDirectory {
-            // The editor takes the pane an agent would have, and
-            // leaves the utility pane, so it is one editor with one
-            // set of shortcuts wherever it shows.
-            editorPane(for: item)
+            // The editor takes the pane an agent would have: a
+            // directory of your own is pinned to the centre slot.
+            editorPane(for: item, role: .centre)
         } else if item.isPlaceholder {
             // The row exists before the worktree does.
             LaunchProgressView(
@@ -58,6 +58,10 @@ extension RootView {
                 .dropDestination(for: URL.self) { urls, _ in
                     _ = dropFiles(urls, into: session.name)
                 }
+        } else if centreShowsEditor(for: item) {
+            // Chosen from the conversations page; the branches above
+            // are why a live session can never sit underneath it.
+            centreEditor(for: item)
         } else if item.worktree.path == item.worktree.repositoryPath, startingSession != item.worktree.path {
             repositoryConversations(for: item)
         } else if item.pastSessions.isEmpty == false, startingSession != item.worktree.path {
@@ -68,9 +72,38 @@ extension RootView {
                 model: dependencies.dashboard,
                 canResume: dependencies.service.hasRecordedSession(worktreePath: item.worktree.path),
                 onShowConversations: showConversationsAction(for: item),
+                // The form marker would otherwise outrank the editor
+                // and the click would change nothing on screen.
+                onOpenEditor: {
+                    startingSession = nil
+                    setCentreEditor(true, at: item.worktree.path)
+                },
                 onResume: { await resumeLatest(in: item) },
                 onStarted: { await sessionStarted(in: item.worktree.path) },
             )
+        }
+    }
+
+    /// The centre editor a worktree or repository page chose, under
+    /// a header whose button goes back to the conversations it
+    /// replaced; the header also keeps the pane's controls out of
+    /// the titlebar band, the way the conversations pages inset
+    /// theirs.
+    func centreEditor(for item: WorktreeItem) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Editor")
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Button("Conversations") { setCentreEditor(false, at: item.worktree.path) }
+                    .controlSize(.small)
+                    .hoverHelp("Back to the conversations this pane was showing")
+            }
+            .padding(.horizontal, Self.stripSpacing)
+            .padding(.top, Self.toggleRowHeight)
+            .padding(.bottom, Self.stripSpacing)
+            Divider()
+            editorPane(for: item, role: .centre)
         }
     }
 

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -43,7 +43,7 @@ extension RootView {
             // beside them can never be squeezed out.
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: Self.stripSpacing) {
-                    UtilityTabStrip(hiding: item.worktree.isHostDirectory ? [.editor] : [])
+                    UtilityTabStrip()
                 }
             }
             Spacer(minLength: 0)
@@ -86,6 +86,7 @@ extension RootView {
             progress: dependencies.dashboard.launchProgress,
             onWorktreeFocus: { focusConversation(at: $0) },
             onNewSession: { startingSession = item.worktree.path },
+            onOpenEditor: { setCentreEditor(true, at: item.worktree.path) },
             onResumed: { await dependencies.dashboard.refresh() },
         )
         .padding(.top, Self.toggleRowHeight)
@@ -100,6 +101,7 @@ extension RootView {
             worktreePath: item.worktree.path,
             progress: dependencies.dashboard.launchProgress,
             onNewSession: { startingSession = item.worktree.path },
+            onOpenEditor: { setCentreEditor(true, at: item.worktree.path) },
             onResumed: { await sessionStarted(in: item.worktree.path) },
         )
         .padding(.top, Self.toggleRowHeight)

--- a/App/RootView+UtilityTabs.swift
+++ b/App/RootView+UtilityTabs.swift
@@ -51,16 +51,26 @@ extension RootView {
         )
     }
 
-    /// The one editor, wherever it shows: the utility pane for a
-    /// worktree, the primary pane for a directory of your own.
-    func editorPane(for item: WorktreeItem) -> EditorPane {
-        EditorPane(
-            worktreePath: item.worktree.path,
+    /// The one editor implementation, filling whichever slot asked:
+    /// the utility pane's Editor tab or the centre pane. The file a
+    /// command waits on goes only to the preferred slot, so it can
+    /// never take over both, and the move button is offered only
+    /// while the other slot could take the file.
+    func editorPane(for item: WorktreeItem, role: EditorPane.Role) -> EditorPane {
+        let path = item.worktree.path
+        let prefersCentre = centreShowsEditor(for: item)
+        let canMove = role == .centre || centreCanShowEditor(for: item)
+        return EditorPane(
+            worktreePath: path,
             service: dependencies.service,
+            role: role,
+            onMoveFile: canMove
+                ? { file, line in receiveMoved(file: file, line: line, at: path, into: role.other) }
+                : nil,
             // The closure stays a non-final argument: the formatter
             // rewrites a trailing one after a multiline call.
             onFinishedWaiting: { finishedWaitingEdit() },
-            waitingEdit: waitingEdit(in: item.worktree.path),
+            waitingEdit: (role == .centre) == prefersCentre ? waitingEdit(in: path) : nil,
         )
     }
 
@@ -81,15 +91,11 @@ extension RootView {
     /// The non-terminal utility tabs' content.
     func switchedUtility(for item: WorktreeItem, conversationPath: String?) -> some View {
         let target = reviewTarget(for: item, conversationPath: conversationPath)
-        // A directory of your own edits in the primary pane, so a
-        // request for the editor here, from opening a file in the
-        // diff or from the tab it was last on, shows the diff
-        // instead of a second editor.
         // Review, the editor and the pull requests stay mounted and
         // hide, rather than being rebuilt on every tab switch: each
         // costs a git or GitHub read to come back, and flipping
         // between them showed a loading state every time.
-        let shown = utilityTab == .editor && item.worktree.isHostDirectory ? UtilityTab.review : utilityTab
+        let shown = utilityTab
         // Top-aligned, as each of these was before they shared a
         // stack: a pane with nothing in it belongs at the top of the
         // pane, not floating in the middle of it.
@@ -101,7 +107,7 @@ extension RootView {
                 service: dependencies.service,
             )
             .hidden(shown != .review)
-            editorPane(for: item)
+            editorPane(for: item, role: .utility)
                 .hidden(shown != .editor)
             PullRequestsView(
                 repository: Repository(

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -1,5 +1,6 @@
 import AgentIDEDomain
 import DashboardFeature
+import ReviewFeature
 import SwiftUI
 import TerminalUI
 
@@ -83,6 +84,18 @@ struct RootView: View {
         visitedBrowsers.sorted()
     }
 
+    /// The worktrees whose centre pane is the editor rather than
+    /// conversations; internal and settable because the extension
+    /// files that route requests cannot see the view's own state.
+    /// Writing persists the set as newline-joined path lines.
+    var centreEditorPaths: Set<String> {
+        get { centreEditors }
+        nonmutating set {
+            centreEditors = newValue
+            centreEditorLines = newValue.sorted().joined(separator: "\n")
+        }
+    }
+
     /// The worktree showing its new session form rather than its
     /// conversations, which is how a worktree that already has
     /// conversations starts a fresh session; internal and settable
@@ -128,15 +141,35 @@ struct RootView: View {
         .sheet(isPresented: sessionManagerBinding) { sessionManager }
         .task {
             FlavourIcon.apply()
+            // Focus counters from the previous run must not fire on
+            // this one's first mount.
             finderFocusRequest = 0
+            for role in EditorPane.Role.allCases {
+                UserDefaults.standard.set(0, forKey: role.key("finderFocusRequest"))
+            }
             rememberedTabs = Self.decodeTabs(worktreeTabs)
+            centreEditors = Set(centreEditorLines.split(separator: "\n").map(String.init))
             await dependencies.dashboard.poll()
         }
         // A shell command waiting on an editor is stopped until this
         // window shows it the file, so it is watched for separately
         // from the dashboard's own slower poll.
         .task {
-            await waiting.watch(service: dependencies.service, dashboard: dependencies.dashboard)
+            // Bound first: the formatter rewrites a trailing closure
+            // after a multiline call.
+            let prefersCentre: @MainActor (String) -> Bool = { path in
+                let items = dependencies.dashboard.groups.flatMap(\.items)
+                guard let item = items.first(where: { $0.worktree.path == path }) else {
+                    return false
+                }
+
+                return centreShowsEditor(for: item)
+            }
+            await waiting.watch(
+                service: dependencies.service,
+                dashboard: dependencies.dashboard,
+                prefersCentreEditor: prefersCentre,
+            )
         }
         // Sleep sometimes kills the sandbox herdr server; sessions
         // running at sleep that are gone at wake resume themselves,
@@ -170,6 +203,19 @@ struct RootView: View {
         .onChange(of: dependencies.dashboard.worktreePaths) { _, paths in
             runningShells.formIntersection(paths)
             visitedBrowsers.formIntersection(paths)
+            centreEditorPaths.formIntersection(paths)
+        }
+        // Open-file and finder-focus requests land on shared keys;
+        // the window is what knows which editor slot should take
+        // each, so it routes them here.
+        .onChange(of: editorFileRequest) { routeOpenFileRequest() }
+        .onChange(of: finderFocusRequest) { routeFinderFocusRequest() }
+        // A session appearing in a worktree whose centre pane held
+        // the editor (from `agentide new`, a phone or a resume): the
+        // session always wins the centre, so the open file moves to
+        // the side editor.
+        .onChange(of: runningWorktreePaths) { _, running in
+            displaceCentreEditors(nowRunning: running)
         }
         // Reopening the app resumes the restored worktree's most
         // recent conversation: the default workflow is picking up
@@ -299,9 +345,15 @@ struct RootView: View {
     @State private var sleepInhibitor: SleepInhibitor = .init()
 
     /// Focus requests from the finder menu items, cleared at launch
-    /// so a request from the previous run cannot fire.
+    /// so a request from the previous run cannot fire; internal so
+    /// the routing extension can read the counter it consumes.
     @AppStorage("finderFocusRequest")
-    private var finderFocusRequest = 0
+    var finderFocusRequest = 0
+
+    /// Open-file requests from the openers, routed to an editor slot
+    /// by the extension file; internal for the same reason.
+    @AppStorage("editorFileRequest")
+    var editorFileRequest = 0
 
     @AppStorage("resizePanesRequest")
     private var resizePanesRequest = 0
@@ -332,6 +384,13 @@ struct RootView: View {
     @AppStorage("worktreeTabs")
     private var worktreeTabs = ""
     @State private var rememberedTabs: [String: String] = [:]
+
+    /// The worktrees showing the centre editor, persisted as path
+    /// lines so the choice survives restarts; directories of your
+    /// own are pinned to it and never recorded here.
+    @AppStorage("centreEditorWorktrees")
+    private var centreEditorLines = ""
+    @State private var centreEditors: Set<String> = []
 
     /// What the window is now, which the panes are fitted to.
     @State private var windowWidth: CGFloat = 0

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -206,6 +206,9 @@ struct RootView: View {
             sessionsBeforeSleep = runningWorktreePaths
         }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didWakeNotification)) { _ in
+            // A chime sleep interrupted mid-play loops from the
+            // audio daemon after wake until it is disposed.
+            CompletionSound.stopLingering()
             let snapshot = sessionsBeforeSleep
             sessionsBeforeSleep = []
             Task { await resumeKilled(sleepSnapshot: snapshot) }

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -39,6 +39,17 @@ struct RootView: View {
     @AppStorage("utilityPaneWidth")
     var utilityPaneWidth = 480.0
 
+    /// Focus requests from the finder menu items, cleared at launch
+    /// so a request from the previous run cannot fire; internal so
+    /// the routing extension can read the counter it consumes.
+    @AppStorage("finderFocusRequest")
+    var finderFocusRequest = 0
+
+    /// Open-file requests from the openers, routed to an editor slot
+    /// by the extension file; internal for the same reason.
+    @AppStorage("editorFileRequest")
+    var editorFileRequest = 0
+
     /// The worktree whose conversation is being resumed, so its pane
     /// shows the resume's progress rather than a terminal bound to
     /// the pane the resume is replacing; internal and settable
@@ -77,11 +88,34 @@ struct RootView: View {
     /// and the browsers already opened; internal accessors because
     /// the extension files cannot see the view's own state.
     var conversationWorktree: String? {
-        conversationWorktreePath
+        get { conversationWorktreePath }
+        nonmutating set { conversationWorktreePath = newValue }
     }
 
     var visitedBrowserPaths: [String] {
         visitedBrowsers.sorted()
+    }
+
+    /// Each worktree's last utility tab; writing persists the choice
+    /// as path-tab-name lines, so the extension file's pane can
+    /// remember without seeing the stored state.
+    var tabMemory: [String: String] {
+        get { rememberedTabs }
+        nonmutating set {
+            rememberedTabs = newValue
+            worktreeTabs = newValue
+                .map { $0.key + "\t" + $0.value }
+                .sorted()
+                .joined(separator: "\n")
+        }
+    }
+
+    /// What the window is now, which the panes are fitted to;
+    /// internal and settable so the extension file's fitting can
+    /// write it back.
+    var currentWindowWidth: CGFloat {
+        get { windowWidth }
+        nonmutating set { windowWidth = newValue }
     }
 
     /// The worktrees whose centre pane is the editor rather than
@@ -155,16 +189,10 @@ struct RootView: View {
         // window shows it the file, so it is watched for separately
         // from the dashboard's own slower poll.
         .task {
-            // Bound first: the formatter rewrites a trailing closure
-            // after a multiline call.
-            let prefersCentre: @MainActor (String) -> Bool = { path in
-                let items = dependencies.dashboard.groups.flatMap(\.items)
-                guard let item = items.first(where: { $0.worktree.path == path }) else {
-                    return false
-                }
-
-                return centreShowsEditor(for: item)
-            }
+            // Bound first: as a labelled final argument the closure
+            // trips the trailing-closure rule, and trailing it after
+            // a multiline call trips the formatter.
+            let prefersCentre: @MainActor (String) -> Bool = { prefersCentreEditor(at: $0) }
             await waiting.watch(
                 service: dependencies.service,
                 dashboard: dependencies.dashboard,
@@ -243,14 +271,6 @@ struct RootView: View {
         }
     }
 
-    @ViewBuilder var coveringPage: some View {
-        if dependencies.dashboard.showsNewSession {
-            NewSessionPane(model: dependencies.dashboard)
-        } else if dependencies.dashboard.showsRepositoryFinder {
-            RepositoryFinderPane(model: dependencies.dashboard)
-        }
-    }
-
     /// The file a command is waiting on in a worktree, which its
     /// editor pane shows instead of the finder.
     func waitingEdit(in worktreePath: String) -> ExternalEdit? {
@@ -296,25 +316,6 @@ struct RootView: View {
         runningShells.remove(path)
     }
 
-    /// Narrows the panes to what the window can hold. The widths
-    /// are written back, so the dividers keep dragging from where
-    /// the panes actually are.
-    func fitPanes(to width: CGFloat) {
-        windowWidth = width
-        let layout = PaneLayout(
-            width: width,
-            sidebar: sidebarWidth,
-            utility: utilityPaneWidth,
-            showsUtility: showsUtilityPane,
-        )
-        if layout.sidebar != sidebarWidth {
-            sidebarWidth = layout.sidebar
-        }
-        if layout.utility != utilityPaneWidth {
-            utilityPaneWidth = layout.utility
-        }
-    }
-
     // MARK: Private
 
     /// The selected conversation's worktree on the repository page,
@@ -343,17 +344,6 @@ struct RootView: View {
     /// Blocks idle sleep while agents or shells run, since sleeping
     /// mid-response cuts agents off.
     @State private var sleepInhibitor: SleepInhibitor = .init()
-
-    /// Focus requests from the finder menu items, cleared at launch
-    /// so a request from the previous run cannot fire; internal so
-    /// the routing extension can read the counter it consumes.
-    @AppStorage("finderFocusRequest")
-    var finderFocusRequest = 0
-
-    /// Open-file requests from the openers, routed to an editor slot
-    /// by the extension file; internal for the same reason.
-    @AppStorage("editorFileRequest")
-    var editorFileRequest = 0
 
     @AppStorage("resizePanesRequest")
     private var resizePanesRequest = 0
@@ -398,61 +388,5 @@ struct RootView: View {
     /// Whether anything is running that idle sleep would interrupt.
     private var hasLiveWork: Bool {
         runningShells.isEmpty == false || runningWorktreePaths.isEmpty == false
-    }
-
-    /// The middle pages, never sheets, cover the primary pane
-    /// rather than replacing it: unmounting takes the panes with it,
-    /// and a pane can hold a running agent or shell, which only
-    /// destroying its worktree should end. They cover that pane
-    /// alone, so the utility pane stays where it was: the window
-    /// keeps one shape whatever it is showing.
-    private var detail: some View {
-        ZStack {
-            if let item = dependencies.dashboard.selection {
-                split(for: item)
-            } else {
-                unselectedSplit
-            }
-        }
-    }
-
-    private func split(for item: WorktreeItem) -> some View {
-        HStack(spacing: 0) {
-            primaryColumn(for: item)
-            if showsUtility {
-                PaneDivider(width: $utilityPaneWidth, range: PaneLayout.utilityRange, controlsLeadingPane: false)
-                    .ignoresSafeArea(.container, edges: .top)
-                utilityPane(for: item)
-                    .frame(width: utilityPaneWidth)
-                    .frame(maxHeight: .infinity)
-                    .ignoresSafeArea(.container, edges: .top)
-            }
-        }
-        .ignoresSafeArea(.container, edges: .top)
-    }
-
-    /// The utility pane: the shared tab header over the content, so
-    /// the current tab is always visible whichever tab shows.
-    /// Restores the worktree's remembered tab whenever the selection
-    /// changes, so each worktree keeps its own pane.
-    private func utilityPane(for item: WorktreeItem) -> some View {
-        VStack(spacing: 0) {
-            utilityHeader(for: item)
-            Divider()
-            utilityContent(for: item)
-        }
-        .task(id: item.worktree.path) {
-            // A stale conversation focus must not survive switching
-            // to another sidebar item.
-            conversationWorktreePath = nil
-            utilityTabName = rememberedTabs[item.worktree.path] ?? utilityTabName
-        }
-        .onChange(of: utilityTabName) {
-            rememberedTabs[item.worktree.path] = utilityTabName
-            worktreeTabs = rememberedTabs
-                .map { $0.key + "\t" + $0.value }
-                .sorted()
-                .joined(separator: "\n")
-        }
     }
 }

--- a/App/SleepInhibitor.swift
+++ b/App/SleepInhibitor.swift
@@ -21,7 +21,8 @@ final class SleepInhibitor {
                 reason: "Agent sessions or shells are running",
             )
         } else if hasLiveWork == false || AppSettings.inhibitsSleep == false,
-                  let current = activity {
+                  let current = activity
+        {
             ProcessInfo.processInfo.endActivity(current)
             activity = nil
         }

--- a/App/UtilityTabStrip.swift
+++ b/App/UtilityTabStrip.swift
@@ -7,15 +7,8 @@ import TerminalUI
 struct UtilityTabStrip: View {
     // MARK: Internal
 
-    /// Tabs this worktree has no use for: a directory of your own
-    /// shows its editor in the pane the agent would have, so the
-    /// tab here would be a second copy of it.
-    var hiding: Set<UtilityTab> = []
-
     var body: some View {
-        // The errors tab hides until the first failure of the
-        // session, then sticks around even across a clear.
-        ForEach(UtilityTab.allCases.filter { hiding.contains($0) == false }, id: \.self) { tab in
+        ForEach(UtilityTab.allCases, id: \.self) { tab in
             button(tab)
         }
     }
@@ -67,8 +60,8 @@ struct UtilityTabStrip: View {
         .onHover { inside in
             hovered = inside ? tab.rawValue : (hovered == tab.rawValue ? nil : hovered)
         }
-        // Numbered from the full tab list, hidden tabs included, so
-        // the tooltip always matches the View menu's own shortcut.
+        // Numbered from the full tab list, so the tooltip always
+        // matches the View menu's own shortcut.
         .hoverHelp(tab.help, shortcut: "⌘" + String((UtilityTab.allCases.firstIndex(of: tab) ?? 0) + 1))
     }
 }

--- a/App/WaitingEdits.swift
+++ b/App/WaitingEdits.swift
@@ -34,7 +34,15 @@ final class WaitingEdits {
     /// each new request to the front and telling its shim the app
     /// has the file. Whatever the pane was showing comes back once
     /// nothing is waiting, so a rebase returns to its own shell.
-    func watch(service: SessionService, dashboard: DashboardModel) async {
+    /// `prefersCentreEditor` says whether a worktree's centre pane
+    /// is an editor, which then shows the file itself and the
+    /// utility pane is left alone.
+    func watch(
+        service: SessionService,
+        dashboard: DashboardModel,
+        prefersCentreEditor: @escaping @MainActor (String) -> Bool,
+    ) async {
+        self.prefersCentreEditor = prefersCentreEditor
         for await edits in service.pendingEdits() {
             // Only a waiting request holds a pane; the others are
             // acted on and dropped as they arrive.
@@ -76,6 +84,10 @@ final class WaitingEdits {
     /// interrupts once, and the tab to go back to afterwards.
     private var shown: String?
     private var previousTab: String?
+
+    /// Whether a worktree's centre pane is an editor, asked before
+    /// taking the utility pane over; set by `watch`.
+    private var prefersCentreEditor: @MainActor (String) -> Bool = { _ in false }
 
     /// A request nothing waits on: a directory selects its worktree
     /// or repository, a file selects the worktree holding it and
@@ -125,9 +137,16 @@ final class WaitingEdits {
         // the window really does come to the front.
         NSApp.activate()
         let items = dashboard.groups.flatMap(\.items)
-        if let item = items.first(where: { edit.belongs(toWorktree: $0.worktree.path) }) {
-            dashboard.select(item)
+        let holder = items.first { edit.belongs(toWorktree: $0.worktree.path) }
+        if let holder {
+            dashboard.select(holder)
         }
+        // A centre pane showing the editor takes the file itself;
+        // only the side editor needs the utility pane taken over.
+        if let path = (holder ?? dashboard.selection)?.worktree.path, prefersCentreEditor(path) {
+            return
+        }
+
         let defaults = UserDefaults.standard
         // A tab the user has never switched by hand is not in the
         // defaults at all, and without a name to go back to the pane

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ In workflow order; the loop from prompt to review repeats before shipping.
 - Edits files in a built-in highlighted editor, renders Markdown, and takes
   over whatever a shell command opens through the bundled `agentide`
   command (so `git rebase -i` needs no terminal editor)
+- Opens that editor beside the diff or, from any conversations page,
+  filling the centre pane, and moves the open file between the two; an
+  agent session always wins the centre back, its file stepping aside
+  saved (so editing sits beside reviewing, and never over an agent)
 - Previews web pages in an embedded browser and opens a shell running as
   your own user (so verifying behaviour never leaves the window)
 - Finds with Cmd-F everywhere and never turns quotes curly or dashes long

--- a/Sources/AgentIDEData/GitClient+Branches.swift
+++ b/Sources/AgentIDEData/GitClient+Branches.swift
@@ -117,7 +117,8 @@ public extension GitClient {
         do {
             try await git(["push"] + force + ["--set-upstream", remote, branch], in: worktreePath)
         } catch let error as CommandError
-            where error.result.standardError.contains("remote ref updated since checkout") {
+            where error.result.standardError.contains("remote ref updated since checkout")
+        {
             throw leaseRefusal(error, branch: branch, remote: remote)
         }
     }

--- a/Sources/AgentIDEData/GitClient+Diffs.swift
+++ b/Sources/AgentIDEData/GitClient+Diffs.swift
@@ -4,7 +4,11 @@ public extension GitClient {
     /// Arguments shared by every diff: `-w` drops whitespace-only
     /// changes when the review asks for it.
     private func diffOptions(ignoringWhitespace: Bool) -> [String] {
-        ignoringWhitespace ? ["-w"] : []
+        if ignoringWhitespace {
+            ["-w"]
+        } else {
+            []
+        }
     }
 
     /// The worktree's uncommitted diff against `HEAD`.

--- a/Sources/AgentIDEData/GitHubClient+Runs.swift
+++ b/Sources/AgentIDEData/GitHubClient+Runs.swift
@@ -1,7 +1,55 @@
+import Foundation
+
 /// Actions runs, split from the client body for length.
-public extension GitHubClient {
+extension GitHubClient {
     /// The failed steps' log of one Actions run, as `gh` prints it.
-    func failedRunLog(repositoryPath: String, runID: Int) async throws -> String {
-        try await gh(["run", "view", String(runID), "--log-failed"], in: repositoryPath).standardOutput
+    /// A run still in progress has no whole-run log to give, but
+    /// each job that already failed has its own, so those answer
+    /// instead of failing while the rest of the run is still
+    /// deciding; only a run with nothing failed yet keeps the
+    /// original refusal.
+    public func failedRunLog(repositoryPath: String, runID: Int) async throws -> String {
+        do {
+            return try await gh(["run", "view", String(runID), "--log-failed"], in: repositoryPath).standardOutput
+        } catch {
+            let jobs = try await gh(["run", "view", String(runID), "--json", "jobs"], in: repositoryPath)
+            let failed = Self.failedJobIDs(fromJSON: jobs.standardOutput)
+            guard failed.isEmpty == false else {
+                throw error
+            }
+
+            var logs = [String]()
+            for jobID in failed {
+                let log = try await gh(["run", "view", "--job", String(jobID), "--log-failed"], in: repositoryPath)
+                logs.append(log.standardOutput.trimmingCharacters(in: .newlines))
+            }
+            return logs.joined(separator: "\n")
+        }
+    }
+
+    /// The ids of the jobs a `--json jobs` listing says failed,
+    /// separated for tests.
+    static func failedJobIDs(fromJSON json: String) -> [Int] {
+        guard let data = json.data(using: .utf8),
+              let run = try? JSONDecoder().decode(RunJobs.self, from: data)
+        else {
+            return []
+        }
+
+        return run.jobs
+            .filter { ($0.conclusion ?? "").uppercased() == "FAILURE" }
+            .map(\.databaseId) // swiftformat:disable:this acronyms
+    }
+
+    /// The slice of `gh run view --json jobs` the fallback reads.
+    private struct RunJobs: Decodable {
+        let jobs: [RunJob]
+    }
+
+    /// One job of a run; beside its listing rather than nested in
+    /// it, since types nest at most one level deep.
+    private struct RunJob: Decodable {
+        let databaseId: Int // swiftformat:disable:this acronyms
+        let conclusion: String?
     }
 }

--- a/Sources/AgentIDEData/GitHubClient.swift
+++ b/Sources/AgentIDEData/GitHubClient.swift
@@ -45,6 +45,7 @@ public struct GitHubClient: Sendable {
     /// without one.
     public static func pullRequestTemplate(in worktreePath: String) -> String? {
         templatePaths
+            .lazy
             .map { worktreePath + "/" + $0 }
             .first { FileManager.default.fileExists(atPath: $0) }
             .flatMap { try? String(contentsOfFile: $0, encoding: .utf8) }

--- a/Sources/AgentIDEData/HerdrTerminalChannel.swift
+++ b/Sources/AgentIDEData/HerdrTerminalChannel.swift
@@ -104,6 +104,7 @@ public actor HerdrTerminalChannel {
         // wedged server, whose state and age then matter most.
         pids += Self.outputLines("/usr/bin/pgrep", ["-x", "herdr"]).filter { pids.contains($0) == false }
         return Self.outputLines("/bin/ps", ["-o", "pid=,stat=,etime=,ucomm=", "-p", pids.joined(separator: ",")])
+            .lazy
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .joined(separator: " | ")
     }

--- a/Sources/AgentIDEData/SessionService+PullRequests.swift
+++ b/Sources/AgentIDEData/SessionService+PullRequests.swift
@@ -72,7 +72,8 @@ public extension SessionService {
     /// signing path.
     func push(worktree: Worktree) async throws -> PushDestination {
         if AppSettings.requiresSignedCommits,
-           await git.isCommitSigned(worktreePath: worktree.path, ref: worktree.branch) == false {
+           await git.isCommitSigned(worktreePath: worktree.path, ref: worktree.branch) == false
+        {
             throw SessionServiceError(
                 "The tip commit is not GPG signed; Rebase on origin signs the branch before pushing.",
             )

--- a/Sources/AgentIDEData/SessionService+Sources.swift
+++ b/Sources/AgentIDEData/SessionService+Sources.swift
@@ -1,5 +1,6 @@
 import AgentIDEDomain
 import Foundation
+import Synchronization
 
 // MARK: - AgentLaunchOptions
 
@@ -29,6 +30,15 @@ struct WorktreeSlot {
     let repository: Repository
     let branch: String
     let path: String
+}
+
+// MARK: - FileListings
+
+/// The file listings in flight, one per worktree at a time, so two
+/// editor panes mounting together share a single ripgrep run. A
+/// finished listing leaves at once; a later ask reads afresh.
+final class FileListings: Sendable {
+    let running = Mutex<[String: Task<[String], Never>]>([:])
 }
 
 // MARK: - Prompt sources and search
@@ -286,8 +296,28 @@ public extension SessionService {
     }
 
     /// The worktree's tracked and untracked files, gitignore aware,
-    /// for the fuzzy finder.
+    /// for the fuzzy finder. The centre and side editors mount
+    /// together, so a caller joins a listing already running for the
+    /// worktree rather than spawning a second ripgrep.
     func listFiles(worktreePath: String) async -> [String] {
+        let (listing, started) = fileListings.running.withLock { listings in
+            if let joined = listings[worktreePath] {
+                return (joined, false)
+            }
+
+            let listing = Task { await readFileList(worktreePath: worktreePath) }
+            listings[worktreePath] = listing
+            return (listing, true)
+        }
+        let files = await listing.value
+        if started {
+            fileListings.running.withLock { $0[worktreePath] = nil }
+        }
+        return files
+    }
+
+    /// One ripgrep listing of a worktree's files.
+    private func readFileList(worktreePath: String) async -> [String] {
         let result = try? await processes.run(
             ["rg", "--files", "--sort", "path"],
             workingDirectory: worktreePath,

--- a/Sources/AgentIDEData/SessionService+Sources.swift
+++ b/Sources/AgentIDEData/SessionService+Sources.swift
@@ -38,7 +38,15 @@ struct WorktreeSlot {
 /// editor panes mounting together share a single ripgrep run. A
 /// finished listing leaves at once; a later ask reads afresh.
 final class FileListings: Sendable {
-    let running = Mutex<[String: Task<[String], Never>]>([:])
+    // MARK: Lifecycle
+
+    deinit {
+        // Nothing to clean up: tasks remove themselves.
+    }
+
+    // MARK: Internal
+
+    let running: Mutex<[String: Task<[String], Never>]> = .init([:])
 }
 
 // MARK: - Prompt sources and search
@@ -298,22 +306,25 @@ public extension SessionService {
     /// The worktree's tracked and untracked files, gitignore aware,
     /// for the fuzzy finder. The centre and side editors mount
     /// together, so a caller joins a listing already running for the
-    /// worktree rather than spawning a second ripgrep.
+    /// worktree rather than spawning a second ripgrep. The task is
+    /// unstructured on purpose, so a joined listing never dies with
+    /// whichever pane started it, and it removes itself on
+    /// completion, so cleanup depends on no caller getting there.
     func listFiles(worktreePath: String) async -> [String] {
-        let (listing, started) = fileListings.running.withLock { listings in
+        let listing = fileListings.running.withLock { listings -> Task<[String], Never> in
             if let joined = listings[worktreePath] {
-                return (joined, false)
+                return joined
             }
 
-            let listing = Task { await readFileList(worktreePath: worktreePath) }
+            let listing = Task {
+                let files = await readFileList(worktreePath: worktreePath)
+                fileListings.running.withLock { $0[worktreePath] = nil }
+                return files
+            }
             listings[worktreePath] = listing
-            return (listing, true)
+            return listing
         }
-        let files = await listing.value
-        if started {
-            fileListings.running.withLock { $0[worktreePath] = nil }
-        }
-        return files
+        return await listing.value
     }
 
     /// One ripgrep listing of a worktree's files.

--- a/Sources/AgentIDEData/SessionService.swift
+++ b/Sources/AgentIDEData/SessionService.swift
@@ -144,6 +144,11 @@ public struct SessionService: Sendable {
     /// untouched.
     let overwriteTips: OverwriteTips = .init()
 
+    /// See `FileListings`; a default so the public init is
+    /// untouched, and a class so every copy of the service shares
+    /// one set of in-flight listings.
+    let fileListings: FileListings = .init()
+
     func runner(for agent: AgentKind) -> any AgentRunner {
         runners.first { $0.kind == agent } ?? ClaudeCodeRunner()
     }

--- a/Sources/AgentIDEData/TranscriptReader.swift
+++ b/Sources/AgentIDEData/TranscriptReader.swift
@@ -24,6 +24,7 @@ public struct TranscriptReader: Sendable {
         let names = (try? manager.contentsOfDirectory(atPath: directory)) ?? []
         return names
             .filter { $0.hasSuffix(".jsonl") }
+            .lazy
             .map { name in
                 let path = directory + "/" + name
                 return (path: path, modifiedAt: modificationDate(path))

--- a/Sources/AgentIDEDomain/PerformanceLog.swift
+++ b/Sources/AgentIDEDomain/PerformanceLog.swift
@@ -64,7 +64,8 @@ public enum PerformanceLog {
     public static var isEnabled: Bool {
         let now = ContinuousClock.now
         if let state = enabledState.withLock({ $0 }),
-           now - state.checkedAt < .seconds(enabledRecheckSeconds) {
+           now - state.checkedAt < .seconds(enabledRecheckSeconds)
+        {
             return state.value
         }
 

--- a/Sources/AgentIDEDomain/PullRequestSummary.swift
+++ b/Sources/AgentIDEDomain/PullRequestSummary.swift
@@ -112,6 +112,14 @@ public struct PullRequestSummary: Identifiable, Hashable, Sendable, Codable {
     /// the count is remembered.
     public var unresolvedComments: Int
 
+    /// Whether the checks rollup is red: something has concluded
+    /// failing, even while the rest still runs. Pending and green
+    /// rollups say no, which is what greys the failing-logs button
+    /// until there is a failure to read.
+    public var hasFailingChecks: Bool {
+        checks == "FAILURE"
+    }
+
     /// The pull request's checks page.
     public var checksPageURL: String {
         url + "/checks"
@@ -120,7 +128,11 @@ public struct PullRequestSummary: Identifiable, Hashable, Sendable, Codable {
     /// Where a click on the check state should go: the one failing
     /// run when there is exactly one, otherwise the checks page.
     public var checksClickURL: String {
-        failingCheckLinks.count == 1 ? failingCheckLinks[0] : checksPageURL
+        if failingCheckLinks.count == 1 {
+            failingCheckLinks[0]
+        } else {
+            checksPageURL
+        }
     }
 
     /// The stable identity, the pull request number.

--- a/Sources/AgentIDEDomain/ReviewThread.swift
+++ b/Sources/AgentIDEDomain/ReviewThread.swift
@@ -69,7 +69,7 @@ public struct ReviewThread: Codable, Hashable, Identifiable, Sendable {
     /// The thread as pasteable text: anchor, then each comment.
     public var asText: String {
         let anchor = path + (line.map { ":" + String($0) } ?? "")
-        let body = comments.map { $0.author + ": " + $0.body }.joined(separator: "\n")
+        let body = comments.lazy.map { $0.author + ": " + $0.body }.joined(separator: "\n")
         return anchor + "\n" + body
     }
 
@@ -85,13 +85,14 @@ public struct ReviewThread: Codable, Hashable, Identifiable, Sendable {
             }
             byPath[thread.path, default: []].append(thread)
         }
-        return order.map { path in
-            let body = (byPath[path] ?? []).map { thread in
-                let anchor = thread.line.map { ":" + String($0) + " " } ?? ""
-                return anchor + thread.comments.map { $0.author + ": " + $0.body }.joined(separator: "\n")
+        return order.lazy
+            .map { path in
+                let body = (byPath[path] ?? []).map { thread in
+                    let anchor = thread.line.map { ":" + String($0) + " " } ?? ""
+                    return anchor + thread.comments.lazy.map { $0.author + ": " + $0.body }.joined(separator: "\n")
+                }
+                return path + "\n" + body.joined(separator: "\n")
             }
-            return path + "\n" + body.joined(separator: "\n")
-        }
-        .joined(separator: "\n\n")
+            .joined(separator: "\n\n")
     }
 }

--- a/Sources/AgentIDEDomain/Whitespace.swift
+++ b/Sources/AgentIDEDomain/Whitespace.swift
@@ -5,6 +5,7 @@ public enum Whitespace {
     public static func strippingTrailingWhitespace(_ text: String) -> String {
         text
             .split(separator: "\n", omittingEmptySubsequences: false)
+            .lazy
             .map { line in
                 var trimmed = line
                 while trimmed.last == " " || trimmed.last == "\t" {

--- a/Sources/DashboardFeature/CreateSessionPane.swift
+++ b/Sources/DashboardFeature/CreateSessionPane.swift
@@ -37,31 +37,8 @@ public struct CreateSessionPane: View {
     /// pane's top like the repository page.
     public var body: some View {
         VStack(alignment: .leading, spacing: Self.spacing) {
-            HStack {
-                Text("Start an agent in \(target)")
-                    .font(.subheadline.weight(.semibold))
-                if isResuming {
-                    ProgressView().controlSize(.small)
-                }
-                Spacer()
-                if let onOpenEditor {
-                    Button("Editor", action: onOpenEditor)
-                        .controlSize(.small)
-                        .hoverHelp("Edit this worktree's files in this pane without starting an agent")
-                }
-                if let onShowConversations {
-                    Button("Conversations", action: onShowConversations)
-                        .controlSize(.small)
-                        .hoverHelp("Back to this worktree's past conversations")
-                }
-                if canResume {
-                    Button("Resume last session") { resume() }
-                        .controlSize(.small)
-                        .disabled(isResuming)
-                        .hoverHelp("Continue this worktree's most recent conversation instead of starting fresh")
-                }
-            }
-            .padding(.top, Self.headerTopPadding)
+            header
+                .padding(.top, Self.headerTopPadding)
             AgentSessionForm(
                 model: model,
                 repository: repository,
@@ -96,6 +73,35 @@ public struct CreateSessionPane: View {
 
     private var target: String {
         worktree.repositoryName + ": " + worktree.branch
+    }
+
+    /// The title and header buttons, out of the body so its closure
+    /// stays within the length limit.
+    private var header: some View {
+        HStack {
+            Text("Start an agent in \(target)")
+                .font(.subheadline.weight(.semibold))
+            if isResuming {
+                ProgressView().controlSize(.small)
+            }
+            Spacer()
+            if let onOpenEditor {
+                Button("Editor", action: onOpenEditor)
+                    .controlSize(.small)
+                    .hoverHelp("Edit this worktree's files in this pane without starting an agent")
+            }
+            if let onShowConversations {
+                Button("Conversations", action: onShowConversations)
+                    .controlSize(.small)
+                    .hoverHelp("Back to this worktree's past conversations")
+            }
+            if canResume {
+                Button("Resume last session") { resume() }
+                    .controlSize(.small)
+                    .disabled(isResuming)
+                    .hoverHelp("Continue this worktree's most recent conversation instead of starting fresh")
+            }
+        }
     }
 
     private func resume() {

--- a/Sources/DashboardFeature/CreateSessionPane.swift
+++ b/Sources/DashboardFeature/CreateSessionPane.swift
@@ -9,18 +9,21 @@ public struct CreateSessionPane: View {
 
     /// Creates the pane; `canResume` offers `onResume` for the
     /// worktree's most recent conversation, `onStarted` runs after a
-    /// successful launch and `onShowConversations`, when given, goes
-    /// back to the list this form was reached from.
+    /// successful launch, `onShowConversations`, when given, goes
+    /// back to the list this form was reached from and
+    /// `onOpenEditor` offers the centre editor in this pane's place.
     @preconcurrency
     public init(
         worktree: Worktree,
         model: DashboardModel,
         canResume: Bool,
         onShowConversations: (@MainActor @Sendable () -> Void)? = nil,
+        onOpenEditor: (@MainActor @Sendable () -> Void)? = nil,
         onResume: @escaping @MainActor () async -> Void,
         onStarted: @escaping @MainActor () async -> Void,
     ) {
         self.onShowConversations = onShowConversations
+        self.onOpenEditor = onOpenEditor
         self.worktree = worktree
         self.model = model
         self.canResume = canResume
@@ -41,6 +44,11 @@ public struct CreateSessionPane: View {
                     ProgressView().controlSize(.small)
                 }
                 Spacer()
+                if let onOpenEditor {
+                    Button("Editor", action: onOpenEditor)
+                        .controlSize(.small)
+                        .hoverHelp("Edit this worktree's files in this pane without starting an agent")
+                }
                 if let onShowConversations {
                     Button("Conversations", action: onShowConversations)
                         .controlSize(.small)
@@ -75,6 +83,7 @@ public struct CreateSessionPane: View {
     @State private var isResuming = false
 
     private let onShowConversations: (@MainActor @Sendable () -> Void)?
+    private let onOpenEditor: (@MainActor @Sendable () -> Void)?
     private let worktree: Worktree
     private let model: DashboardModel
     private let canResume: Bool

--- a/Sources/DashboardFeature/DashboardModel+Host.swift
+++ b/Sources/DashboardFeature/DashboardModel+Host.swift
@@ -23,7 +23,8 @@ public extension DashboardModel {
         )
         for index in groups.indices
             where groups[index].repository.path == repository.path
-            && groups[index].items.contains(where: { $0.worktree.path == path }) == false {
+            && groups[index].items.contains(where: { $0.worktree.path == path }) == false
+        {
             groups[index].items.append(row)
         }
         await refresh()

--- a/Sources/DashboardFeature/RepositoryFinderPane.swift
+++ b/Sources/DashboardFeature/RepositoryFinderPane.swift
@@ -55,9 +55,11 @@ public struct RepositoryFinderPane: View {
     private let model: DashboardModel
 
     private var fieldPrompt: String {
-        owner == nil
-            ? "Organisation or user; return also accepts any typed owner"
-            : "Find a repository"
+        if owner == nil {
+            "Organisation or user; return also accepts any typed owner"
+        } else {
+            "Find a repository"
+        }
     }
 
     private var results: [String] {

--- a/Sources/DashboardFeature/WorktreeRowView.swift
+++ b/Sources/DashboardFeature/WorktreeRowView.swift
@@ -2,6 +2,8 @@ import AgentIDEDomain
 import SwiftUI
 import TerminalUI
 
+// MARK: - WorktreeRowView
+
 /// One worktree row: branch, session state, commit counts against
 /// the default branch and upstream, and pull request state.
 struct WorktreeRowView: View {
@@ -31,7 +33,6 @@ struct WorktreeRowView: View {
 
     private static let unreadDotSize: CGFloat = 6
     private static let spacing: CGFloat = 4
-    private static let badgeSpacing: CGFloat = 2
     /// Sits the icon on the branch line's baseline rather than the
     /// row's very top.
     private static let iconDrop: CGFloat = 2
@@ -250,51 +251,78 @@ struct WorktreeRowView: View {
 
     @ViewBuilder private var pullRequestBadge: some View {
         if let pullRequest {
-            HStack(spacing: Self.badgeSpacing) {
-                Button {
-                    LinkOpener.open(pullRequest.url)
-                } label: {
-                    Text("#" + String(pullRequest.number))
-                }
-                .buttonStyle(.plain)
-                .hoverHelp("Open pull request #" + String(pullRequest.number)
-                    + " in the Browser tab; Cmd-click for the system browser")
-                // CI, reviews and conversations are what a pull
-                // request still needs; once it is merged or closed
-                // they are history, and the state icon says it all.
-                if pullRequest.state == "OPEN" {
-                    checksDot(for: pullRequest)
-                }
-                // Conflicts with the base branch: the one state a
-                // pull request cannot leave on its own.
-                if pullRequest.state == "OPEN", pullRequest.mergeable == "CONFLICTING",
-                   let conflict = ChecksStyle.mergeableOcticonName(for: pullRequest.mergeable) {
-                    Octicon(conflict, colour: ChecksStyle.mergeableColour(for: pullRequest.mergeable))
-                        .hoverHelp("Merge conflicts with the base branch; rebase to resolve them")
-                }
-                if let review = reviewIcon(for: pullRequest) {
-                    Octicon(review, colour: ChecksStyle.reviewColour(for: pullRequest.reviewDecision))
-                        .hoverHelp("Review: " + pullRequest.reviewDecision.lowercased())
-                }
-                if pullRequest.state == "OPEN", pullRequest.unresolvedComments > 0 {
-                    Octicon(ChecksStyle.commentOcticonName, colour: .secondary)
-                        .hoverHelp("\(pullRequest.unresolvedComments) unresolved review conversations")
-                }
-                if standing.isStacked {
-                    Octicon("octicon-stack", colour: .secondary)
-                        .hoverHelp(stackHelp)
-                    Text(String(standing.position) + "/" + String(standing.height))
-                        .hoverHelp(stackHelp)
-                }
-            }
-            // Badges keep their width: squeezed, the number and the
-            // stack marker broke into a column of digits.
-            .lineLimit(1)
-            .fixedSize()
+            PullRequestBadge(pullRequest: pullRequest, standing: standing, stackHelp: stackHelp)
         }
     }
 
-    private func checksDot(for pullRequest: PullRequestSummary) -> some View {
+    private func stateHelp(for pullRequest: PullRequestSummary) -> String {
+        if pullRequest.isQueued {
+            "In the merge queue"
+        } else if pullRequest.hasAutomerge {
+            "Set to merge automatically"
+        } else if pullRequest.isDraft {
+            "Draft pull request"
+        } else {
+            if pullRequest.state == "OPEN" {
+                "Open pull request"
+            } else {
+                pullRequest.state.capitalized + " pull request"
+            }
+        }
+    }
+}
+
+// MARK: - PullRequestBadge
+
+/// A row's pull request badges: number, CI dot, conflict, review,
+/// conversations and stack; its own view so the row's type body
+/// stays within the length limit.
+private struct PullRequestBadge: View {
+    // MARK: Internal
+
+    let pullRequest: PullRequestSummary
+    let standing: StackStanding
+    let stackHelp: String
+
+    var body: some View {
+        HStack(spacing: Self.badgeSpacing) {
+            Button {
+                LinkOpener.open(pullRequest.url)
+            } label: {
+                Text("#" + String(pullRequest.number))
+            }
+            .buttonStyle(.plain)
+            .hoverHelp("Open pull request #" + String(pullRequest.number)
+                + " in the Browser tab; Cmd-click for the system browser")
+            // CI, reviews and conversations are what a pull
+            // request still needs; once it is merged or closed
+            // they are history, and the state icon says it all.
+            if pullRequest.state == "OPEN" {
+                checksDot
+            }
+            stateBadges
+        }
+        // Badges keep their width: squeezed, the number and the
+        // stack marker broke into a column of digits.
+        .lineLimit(1)
+        .fixedSize()
+    }
+
+    // MARK: Private
+
+    private static let badgeSpacing: CGFloat = 2
+
+    /// The review badge, absent once the pull request is merged or
+    /// closed: its verdict stopped being something to act on.
+    private var reviewIcon: String? {
+        if pullRequest.state == "OPEN" {
+            ChecksStyle.reviewOcticonName(for: pullRequest.reviewDecision)
+        } else {
+            nil
+        }
+    }
+
+    private var checksDot: some View {
         Button {
             LinkOpener.open(pullRequest.checksClickURL)
         } label: {
@@ -309,21 +337,30 @@ struct WorktreeRowView: View {
         )
     }
 
-    /// The review badge, absent once the pull request is merged or
-    /// closed: its verdict stopped being something to act on.
-    private func reviewIcon(for pullRequest: PullRequestSummary) -> String? {
-        pullRequest.state == "OPEN" ? ChecksStyle.reviewOcticonName(for: pullRequest.reviewDecision) : nil
-    }
-
-    private func stateHelp(for pullRequest: PullRequestSummary) -> String {
-        if pullRequest.isQueued {
-            "In the merge queue"
-        } else if pullRequest.hasAutomerge {
-            "Set to merge automatically"
-        } else if pullRequest.isDraft {
-            "Draft pull request"
-        } else {
-            pullRequest.state == "OPEN" ? "Open pull request" : pullRequest.state.capitalized + " pull request"
+    /// The badges after the CI dot, out of the body so its closure
+    /// stays within the length limit.
+    @ViewBuilder private var stateBadges: some View {
+        // Conflicts with the base branch: the one state a pull
+        // request cannot leave on its own.
+        if pullRequest.state == "OPEN", pullRequest.mergeable == "CONFLICTING",
+           let conflict = ChecksStyle.mergeableOcticonName(for: pullRequest.mergeable)
+        {
+            Octicon(conflict, colour: ChecksStyle.mergeableColour(for: pullRequest.mergeable))
+                .hoverHelp("Merge conflicts with the base branch; rebase to resolve them")
+        }
+        if let review = reviewIcon {
+            Octicon(review, colour: ChecksStyle.reviewColour(for: pullRequest.reviewDecision))
+                .hoverHelp("Review: " + pullRequest.reviewDecision.lowercased())
+        }
+        if pullRequest.state == "OPEN", pullRequest.unresolvedComments > 0 {
+            Octicon(ChecksStyle.commentOcticonName, colour: .secondary)
+                .hoverHelp("\(pullRequest.unresolvedComments) unresolved review conversations")
+        }
+        if standing.isStacked {
+            Octicon("octicon-stack", colour: .secondary)
+                .hoverHelp(stackHelp)
+            Text(String(standing.position) + "/" + String(standing.height))
+                .hoverHelp(stackHelp)
         }
     }
 }

--- a/Sources/PRFeature/PullRequestConversationView.swift
+++ b/Sources/PRFeature/PullRequestConversationView.swift
@@ -21,6 +21,9 @@ struct PullRequestConversationPane: View {
     let onOpenChecks: @MainActor () async -> Void
     let onResolvedChanged: @MainActor () async -> Void
 
+    /// See `PullRequestConversationView.onThreadsChanged`.
+    let onThreadsChanged: @MainActor (Int) -> Void
+
     /// Toggles one label against GitHub the moment a menu item is
     /// clicked; declared before the lists so the call site's
     /// closure is never its final argument, which SwiftFormat
@@ -60,6 +63,7 @@ struct PullRequestConversationPane: View {
                 seededBody: summary.body,
                 store: store,
                 onResolvedChanged: onResolvedChanged,
+                onThreadsChanged: onThreadsChanged,
             )
         }
     }
@@ -139,6 +143,11 @@ struct PullRequestConversationView: View {
     /// refresh immediately.
     let onResolvedChanged: @MainActor () async -> Void
 
+    /// Told how many conversations are unresolved whenever the
+    /// threads change, which keeps the footer's copy button level
+    /// with the timeline.
+    let onThreadsChanged: @MainActor (Int) -> Void
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Self.eventSpacing) {
@@ -173,6 +182,9 @@ struct PullRequestConversationView: View {
             events = cached.events
             threads = cached.threads
             await refresh()
+        }
+        .onChange(of: threads) { _, threads in
+            onThreadsChanged(threads.count { $0.isResolved == false })
         }
     }
 

--- a/Sources/PRFeature/PullRequestListView.swift
+++ b/Sources/PRFeature/PullRequestListView.swift
@@ -258,20 +258,24 @@ struct PullRequestFooterView: View {
             busy: "",
             systemImage: "text.bubble",
             accessibilityLabel: "Copy unresolved comments",
+            disabled: selected.unresolvedComments == 0,
         ) {
             await model.copyUnresolvedComments(selected)
         }
-        .hoverHelp("Copy every unresolved review conversation to the clipboard")
+        .hoverHelp("Copy every unresolved review conversation to the clipboard; dimmed while none is unresolved")
         // One button for the failing checks: a click copies their
         // logs, and a modifier opens them instead, since the
         // modifier is read at the click and `LinkOpener` already
         // sends Cmd to the browser and anything else to the tab.
+        // Dimmed until the rollup is red with runs to read: pending
+        // and green have no failed log, and a red rollup whose
+        // failures are not Actions runs has none either.
         BusyButton(
             "",
             busy: "",
             systemImage: "exclamationmark.triangle",
             accessibilityLabel: "Failing checks",
-            disabled: selected.failingCheckLinks.isEmpty,
+            disabled: selected.hasFailingChecks == false || selected.failingCheckLinks.isEmpty,
         ) {
             if NSEvent.modifierFlags.isDisjoint(with: [.command, .shift]) == false {
                 model.openFailingChecks(selected)
@@ -280,8 +284,9 @@ struct PullRequestFooterView: View {
             }
         }
         .hoverHelp("Copy the last " + String(PullRequestsModel.logTailLines)
-            + " lines of every failing Actions run's log; Cmd-click opens the failing check "
-            + "in your browser, Shift-click in the Browser tab; dimmed when nothing fails")
+            + " lines of every failing Actions run's log, a run still in progress answering with its "
+            + "already-failed jobs; Cmd-click opens the failing check in your browser, Shift-click "
+            + "in the Browser tab; dimmed until a check fails")
     }
 }
 

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -51,7 +51,7 @@ extension PullRequestsModel {
 
         cacheEnriched(full)
         if selected?.number == number {
-            selected = full
+            selected = withCachedUnresolved(full)
         }
         if let index = summaries.firstIndex(where: { $0.number == number }) {
             summaries[index] = full
@@ -127,18 +127,41 @@ extension PullRequestsModel {
     /// instantly, then refreshes it; the open scope's light rows
     /// gain their status icons here.
     func select(_ summary: PullRequestSummary) {
-        selected = pullRequests.cachedSummary(repositoryPath: repository.path, number: summary.number)
-            ?? summary
+        let cached = pullRequests.cachedSummary(repositoryPath: repository.path, number: summary.number)
+        selected = withCachedUnresolved(cached ?? summary)
         Task { await loadSelectedLabels(summary.number) }
         Task {
             let full = try? await fetchSummary(summary.number)
             if let full {
                 cacheEnriched(full)
                 if selected?.number == full.number {
-                    selected = full
+                    selected = withCachedUnresolved(full)
                 }
             }
         }
+    }
+
+    /// The conversation pane counted its unresolved threads: keep
+    /// the open summary level with it, which is what enables the
+    /// footer's copy button the moment there is something to copy.
+    func updateUnresolved(_ count: Int, number: Int) {
+        guard selected?.number == number else {
+            return
+        }
+
+        selected?.unresolvedComments = count
+    }
+
+    /// A summary with its unresolved-conversation count from the
+    /// threads cache: no listing or summary query carries the count,
+    /// so what the conversation pane last cached stands in, the way
+    /// the sidebar rows count theirs.
+    private func withCachedUnresolved(_ summary: PullRequestSummary) -> PullRequestSummary {
+        let key = AppMetadata.threadsKey(repositoryPath: repository.path, number: summary.number)
+        let threads = store.load().threadsCache[key]?.threads ?? []
+        var stamped = summary
+        stamped.unresolvedComments = threads.count { $0.isResolved == false }
+        return stamped
     }
 
     /// Caches one enriched summary, so reopening the conversation

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -7,40 +7,6 @@ import TerminalUI
 /// The footer's branch actions, split from the model body for
 /// length.
 extension PullRequestsModel {
-    /// What the worktree itself says: its stack, signing, rebase
-    /// need, template and checked-out branch. Skipped when moving
-    /// between a stack's entries, which share all of it.
-    func refreshWorktreeFacts(_ worktree: Worktree) async {
-        await loadStack()
-        // Gather, then write only while still the newest read: an
-        // older reload landing stale signing facts over the rebase's
-        // fresh ones is how Push sometimes stayed locked until a
-        // second press ran a fresh read.
-        stacking.factsGeneration += 1
-        let generation = stacking.factsGeneration
-        let signed = await checkTipSigned(listedWorktree ?? worktree)
-        let need = await fetchRebaseNeed(listedWorktree ?? worktree)
-        let template = await fetchTemplate(worktree.path)
-        let live = await fetchCurrentBranch(worktree.path)
-        let labels = availableLabels.isEmpty ? await fetchLabels() : availableLabels
-        guard generation == stacking.factsGeneration else {
-            return
-        }
-
-        isTipSigned = signed
-        rebaseNeed = need
-        availableLabels = labels
-        hasTemplate = template != nil
-        originalTemplate = template ?? ""
-        if prTemplate.isEmpty {
-            prTemplate = originalTemplate
-        }
-        await prefillFromSingleCommit(worktree)
-        if let branch = live {
-            currentBranch = branch
-        }
-    }
-
     /// Refreshes one pull request's header wherever it shows, so
     /// actions like resolving conversations reflect immediately in
     /// the selected conversation and its listed row.
@@ -316,6 +282,22 @@ extension PullRequestsModel {
 
         isBranchActionRunning = true
         defer { isBranchActionRunning = false }
+        // The button dims on what the last read knew, and a tip
+        // amended since then must never reach the service's refusal
+        // as an error: the signature is read again at the click, and
+        // a failed check declines in the footer instead, with Rebase
+        // relit to sign.
+        guard await checkTipSigned(worktree) else {
+            tipSignature = .unsigned
+            rebaseNeed = await fetchRebaseNeed(worktree)
+            setStatus(
+                "Not pushed: the tip commit is unsigned.",
+                detail: "The tip commit of " + worktree.branch
+                    + " is not GPG signed; Rebase on origin signs the branch, then Push.",
+            )
+            return true
+        }
+
         do {
             let destination = try await performPush(worktree)
             pullRequests.invalidateListings(repositoryPath: repository.path)

--- a/Sources/PRFeature/PullRequestsModel+Branch.swift
+++ b/Sources/PRFeature/PullRequestsModel+Branch.swift
@@ -6,6 +6,59 @@ import AgentIDEDomain
 /// and what it moves are not always the branch the worktree holds.
 /// Split from the actions for length.
 extension PullRequestsModel {
+    /// What the worktree itself says: its stack, signing, rebase
+    /// need, template and checked-out branch. Skipped when moving
+    /// between a stack's entries, which share all of it.
+    func refreshWorktreeFacts(_ worktree: Worktree) async {
+        await loadStack()
+        // Gather, then write only while still the newest read: an
+        // older reload landing stale signing facts over the rebase's
+        // fresh ones is how Push sometimes stayed locked until a
+        // second press ran a fresh read.
+        stacking.factsGeneration += 1
+        let generation = stacking.factsGeneration
+        let signed = await checkTipSigned(listedWorktree ?? worktree)
+        let need = await fetchRebaseNeed(listedWorktree ?? worktree)
+        let template = await fetchTemplate(worktree.path)
+        let live = await fetchCurrentBranch(worktree.path)
+        let labels = availableLabels.isEmpty ? await fetchLabels() : availableLabels
+        guard generation == stacking.factsGeneration else {
+            return
+        }
+
+        tipSignature = signed ? .signed : .unsigned
+        rebaseNeed = need
+        availableLabels = labels
+        hasTemplate = template != nil
+        originalTemplate = template ?? ""
+        if prTemplate.isEmpty {
+            prTemplate = originalTemplate
+        }
+        await prefillFromSingleCommit(worktree)
+        if let branch = live {
+            currentBranch = branch
+        }
+    }
+
+    /// Fresh counts can mean fresh commits, and nobody has read the
+    /// new tip: the signing and rebase facts follow the item, so
+    /// Push can never light up on a tip the last read never saw.
+    func reverifyBranchFacts(from oldItems: [WorktreeItem]) {
+        guard let current = branchItem else {
+            return
+        }
+
+        let previous = oldItems.first { $0.worktree.path == current.worktree.path }
+        guard previous?.aheadOfUpstream != current.aheadOfUpstream
+            || previous?.isDirty != current.isDirty
+        else {
+            return
+        }
+
+        tipSignature = .unread
+        Task { await refreshWorktreeFacts(current.worktree) }
+    }
+
     /// The rebase button's label names exactly what it would do.
     var rebaseTitle: String {
         guard AppSettings.requiresSignedCommits else {
@@ -61,7 +114,7 @@ extension PullRequestsModel {
             await reload(keepingSelection: true)
             // Done means Push agrees; reporting success with the tip
             // still unsigned took a second press to notice.
-            if isTipSigned == false {
+            if tipSignature != .signed {
                 report("Rebased, but the tip still reads unsigned; check the signing key "
                     + "and hit Rebase again")
                 return false
@@ -112,12 +165,15 @@ extension PullRequestsModel {
     }
 
     /// Push makes sense with unpushed commits that this tab has not
-    /// already pushed and a GPG-signed tip; nil upstream means
-    /// nothing was ever pushed. In a stack it is the listed entry's
-    /// own commits that are counted, since the worktree's counts
-    /// describe whichever branch it has checked out.
+    /// already pushed and a tip proven GPG signed; an unread tip
+    /// dims the button rather than trusting the last answer, since
+    /// a click on unverified commits could only end in a refusal.
+    /// Nil upstream means nothing was ever pushed. In a stack it is
+    /// the listed entry's own commits that are counted, since the
+    /// worktree's counts describe whichever branch it has checked
+    /// out.
     var canPush: Bool {
-        guard branchItem != nil, isPushed == false, isTipSigned else {
+        guard branchItem != nil, isPushed == false, tipSignature == .signed else {
             return false
         }
 
@@ -142,11 +198,17 @@ extension PullRequestsModel {
         guard branchItem != nil, isPushed == false, hasUnpushedCommits else {
             return "Everything is already pushed"
         }
-        guard isTipSigned else {
-            return "The tip commit is not GPG signed; Rebase on origin signs the branch first"
-        }
 
-        return "Push this branch's unpushed commits to origin; a failure reports to the Errors tab"
+        return switch tipSignature {
+        case .unread:
+            "Checking that the tip commit is GPG signed; Push enables once it proves to be"
+
+        case .unsigned:
+            "The tip commit is not GPG signed; Rebase on origin signs the branch first"
+
+        case .signed:
+            "Push this branch's unpushed commits to origin; a failure reports to the Errors tab"
+        }
     }
 
     /// The branch item's worktree with the checked-out branch

--- a/Sources/PRFeature/PullRequestsModel+Prefill.swift
+++ b/Sources/PRFeature/PullRequestsModel+Prefill.swift
@@ -37,7 +37,7 @@ extension PullRequestsModel {
             // pull request and the rest list the body, which is what
             // Submit stack writes for a stack entry.
             let subjects = commits.map { Self.description(splitFromMessage: $0).title }
-            let rest = subjects.dropFirst().map { "- " + $0 }.joined(separator: "\n")
+            let rest = subjects.dropFirst().lazy.map { "- " + $0 }.joined(separator: "\n")
             apply(description: (Self.description(splitFromMessage: first).title, rest))
         }
     }

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -362,7 +362,8 @@ final class PullRequestsModel {
     func repaintFromCache() {
         if let selected,
            let cached = pullRequests.cachedSummary(repositoryPath: repository.path, number: selected.number),
-           cached != selected {
+           cached != selected
+        {
             self.selected = cached
         }
         summaries = summaries.map { row in

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -177,6 +177,17 @@ final class PullRequestsModel {
 
     // MARK: Internal
 
+    /// What the last read said of the tip commit's signature:
+    /// unread until the current tip has been checked. Pushing
+    /// unsigned commits is never allowed, so Push waits for proof
+    /// rather than trusting a stale answer, and dims until Rebase
+    /// on origin signs the branch.
+    enum TipSignature {
+        case unread
+        case unsigned
+        case signed
+    }
+
     let repository: Repository
     let branch: String?
 
@@ -209,10 +220,7 @@ final class PullRequestsModel {
     /// its pull request carries, counted from the branch's base.
     var commitsAboveBase = 0
 
-    /// Whether the tip commit is GPG signed, refreshed on reload;
-    /// pushing unsigned commits is never allowed, so Push dims until
-    /// Rebase on origin signs the branch.
-    var isTipSigned = true
+    var tipSignature: TipSignature = .unread
 
     /// Which pull requests the tab lists.
     var scope: PullRequestScope = .worktree
@@ -353,6 +361,7 @@ final class PullRequestsModel {
             // The sidebar's poll may have fetched a fresher summary
             // into the shared cache since these rows were painted.
             repaintFromCache()
+            reverifyBranchFacts(from: oldValue)
         }
     }
 

--- a/Sources/PRFeature/PullRequestsView.swift
+++ b/Sources/PRFeature/PullRequestsView.swift
@@ -134,7 +134,11 @@ public struct PullRequestsView: View {
     /// The worktree scope names the branch itself when the pane
     /// drives from the main checkout, where no worktree exists.
     private var worktreeScopeTitle: String {
-        isMainCheckout ? "Branch" : "Worktree"
+        if isMainCheckout {
+            "Branch"
+        } else {
+            "Worktree"
+        }
     }
 
     private var listView: some View {
@@ -163,6 +167,7 @@ public struct PullRequestsView: View {
             onCopyComments: { await model.copyUnresolvedComments(summary) },
             onOpenChecks: { model.openFailingChecks(summary) },
             onResolvedChanged: { await model.refreshSummary(summary.number) },
+            onThreadsChanged: { model.updateUnresolved($0, number: summary.number) },
             onToggleLabel: { _ = await model.toggleLabel($0) },
             labels: model.selectedLabels,
             availableLabels: model.availableLabels,

--- a/Sources/ReviewFeature/EditorPane+Role.swift
+++ b/Sources/ReviewFeature/EditorPane+Role.swift
@@ -1,0 +1,34 @@
+public extension EditorPane {
+    /// The slot an editor pane fills. Each slot keeps its own finder
+    /// and open file under key-suffixed defaults, so two mounted
+    /// editors never answer one request twice; the window routes
+    /// requests between them by these names. Split from the pane
+    /// for length.
+    enum Role: String, CaseIterable, Sendable {
+        // The case names are the persisted key suffixes (SwiftFormat
+        // strips explicit raw values); keep names stable or migrate
+        // deliberately. Centre first: a file open in both slots
+        // routes to the visible centre before the side.
+        // swiftlint:disable explicit_enum_raw_value
+        case centre
+        case utility
+
+        // MARK: Public
+
+        /// The other slot, where a moved file lands.
+        public var other: Self {
+            if self == .centre {
+                .utility
+            } else {
+                .centre
+            }
+        }
+
+        // swiftlint:enable explicit_enum_raw_value
+
+        /// The slot's defaults key for one of the shared base names.
+        public func key(_ base: String) -> String {
+            base + "." + rawValue
+        }
+    }
+}

--- a/Sources/ReviewFeature/EditorPane.swift
+++ b/Sources/ReviewFeature/EditorPane.swift
@@ -11,22 +11,61 @@ import TerminalUI
 public struct EditorPane: View {
     // MARK: Lifecycle
 
-    /// Creates the pane for a worktree. `waitingEdit` is a file some
-    /// command outside the app is blocked on, which takes the pane
-    /// over until it is dealt with.
+    /// Creates the pane for a worktree. `role` names the slot this
+    /// instance fills, whose persisted state stays its own;
+    /// `onMoveFile`, when given, offers sending the open file to the
+    /// other slot; `waitingEdit` is a file some command outside the
+    /// app is blocked on, which takes the pane over until it is
+    /// dealt with.
     public init(
         worktreePath: String,
         service: SessionService,
+        role: Role = .utility,
+        onMoveFile: ((_ file: String, _ line: Int?) -> Void)? = nil,
         onFinishedWaiting: (() -> Void)? = nil,
         waitingEdit: ExternalEdit? = nil,
     ) {
         self.worktreePath = worktreePath
         self.service = service
+        self.role = role
+        self.onMoveFile = onMoveFile
         self.waitingEdit = waitingEdit
         self.onFinishedWaiting = onFinishedWaiting
+        _query = AppStorage(wrappedValue: "", role.key("finderQuery"))
+        _searchesContents = AppStorage(wrappedValue: false, role.key("finderSearchesContents"))
+        _finderFocusRequest = AppStorage(wrappedValue: 0, role.key("finderFocusRequest"))
+        _editorFileRequest = AppStorage(wrappedValue: 0, role.key("editorFileRequest"))
+        _editorFilePath = AppStorage(wrappedValue: "", role.key("editorFilePath"))
+        _editorFileLine = AppStorage(wrappedValue: 0, role.key("editorFileLine"))
+        _editorFileWorktree = AppStorage(wrappedValue: "", role.key("editorFileWorktree"))
     }
 
     // MARK: Public
+
+    /// The slot an editor pane fills. Each slot keeps its own finder
+    /// and open file under key-suffixed defaults, so two mounted
+    /// editors never answer one request twice; the window routes
+    /// requests between them by these names.
+    public enum Role: String, CaseIterable, Sendable {
+        // The case names are the persisted key suffixes (SwiftFormat
+        // strips explicit raw values); keep names stable or migrate
+        // deliberately. Centre first: a file open in both slots
+        // routes to the visible centre before the side.
+        // swiftlint:disable explicit_enum_raw_value
+        case centre
+        case utility
+        // swiftlint:enable explicit_enum_raw_value
+
+        /// The slot's defaults key for one of the shared base names.
+        public func key(_ base: String) -> String {
+            base + "." + rawValue
+        }
+
+        /// The other slot, where a moved file lands.
+        public var other: Role {
+            self == .centre ? .utility : .centre
+        }
+    }
 
     /// The pinned finder field over results, over the embedded
     /// editor. Arrow keys move the highlight and return opens it.
@@ -88,27 +127,27 @@ public struct EditorPane: View {
     /// the finder as soon as the buttons are pressed.
     @State private var finishedEdit: String?
 
-    /// The query, mode and open file persist across restarts.
-    @AppStorage("finderQuery")
-    private var query = ""
-    @AppStorage("finderSearchesContents")
-    private var searchesContents = false
-    @AppStorage("finderFocusRequest")
-    private var finderFocusRequest = 0
-    @AppStorage("editorFileRequest")
-    private var editorFileRequest = 0
-    @AppStorage("editorFilePath")
-    private var editorFilePath = ""
-    @AppStorage("editorFileLine")
-    private var editorFileLine = 0
-    @AppStorage("editorFileWorktree")
-    private var editorFileWorktree = ""
+    /// The query, mode and open file persist across restarts, each
+    /// under the slot's own keys, set in the initialiser from the
+    /// role.
+    @AppStorage private var query: String
+    @AppStorage private var searchesContents: Bool
+    @AppStorage private var finderFocusRequest: Int
+    @AppStorage private var editorFileRequest: Int
+    @AppStorage private var editorFilePath: String
+    @AppStorage private var editorFileLine: Int
+    @AppStorage private var editorFileWorktree: String
 
     @FocusState private var finderFocused: Bool
 
     private let worktreePath: String
     private let service: SessionService
+    private let role: Role
     private let waitingEdit: ExternalEdit?
+
+    /// Sends the open file to the other slot; absent when the other
+    /// slot cannot take one right now.
+    private let onMoveFile: ((_ file: String, _ line: Int?) -> Void)?
 
     /// Told when a waiting file is dealt with, so the pane the
     /// command interrupted can come straight back.
@@ -228,11 +267,32 @@ public struct EditorPane: View {
             relativePath: result.file,
             service: service,
             jumpToLine: result.line,
+            move: paneMove(for: result),
         ) {
             target = nil
             editorFilePath = ""
         }
         .id(result.id)
+    }
+
+    /// The move-to-other-pane action for the open file, which clears
+    /// this slot before handing the file over.
+    private func paneMove(for result: Result) -> FileEditorView.PaneMove? {
+        onMoveFile.map { move in
+            // The closure stays a non-final argument: the formatter
+            // rewrites a trailing one after a multiline call.
+            FileEditorView.PaneMove(
+                action: {
+                    target = nil
+                    editorFilePath = ""
+                    move(result.file, result.line)
+                },
+                icon: role == .centre ? "arrow.right.square" : "arrow.left.square",
+                help: role == .centre
+                    ? "Save and move this file to the utility pane's editor"
+                    : "Save and move this file to the centre editor",
+            )
+        }
     }
 
     /// Opens the stored file when it belongs to this worktree; the

--- a/Sources/ReviewFeature/EditorPane.swift
+++ b/Sources/ReviewFeature/EditorPane.swift
@@ -42,31 +42,6 @@ public struct EditorPane: View {
 
     // MARK: Public
 
-    /// The slot an editor pane fills. Each slot keeps its own finder
-    /// and open file under key-suffixed defaults, so two mounted
-    /// editors never answer one request twice; the window routes
-    /// requests between them by these names.
-    public enum Role: String, CaseIterable, Sendable {
-        // The case names are the persisted key suffixes (SwiftFormat
-        // strips explicit raw values); keep names stable or migrate
-        // deliberately. Centre first: a file open in both slots
-        // routes to the visible centre before the side.
-        // swiftlint:disable explicit_enum_raw_value
-        case centre
-        case utility
-        // swiftlint:enable explicit_enum_raw_value
-
-        /// The slot's defaults key for one of the shared base names.
-        public func key(_ base: String) -> String {
-            base + "." + rawValue
-        }
-
-        /// The other slot, where a moved file lands.
-        public var other: Role {
-            self == .centre ? .utility : .centre
-        }
-    }
-
     /// The pinned finder field over results, over the embedded
     /// editor. Arrow keys move the highlight and return opens it.
     public var body: some View {
@@ -97,29 +72,16 @@ public struct EditorPane: View {
 
     // MARK: Private
 
-    /// One row of the result list: a file, or a content match with
-    /// the matched line's text.
-    private struct Result: Identifiable, Hashable {
-        let file: String
-        let line: Int?
-        var preview: String?
-
-        var id: String {
-            file + ":" + String(line ?? 0)
-        }
-    }
-
     private static let padding: CGFloat = 6
     private static let fieldTopPadding: CGFloat = 4
     private static let fileResultLimit = 12
     private static let contentQueryMinimum = 3
-    private static let resultsHeight: CGFloat = 180
     private static let fieldCornerRadius: CGFloat = 6
     private static let fieldBackgroundOpacity = 0.5
 
     @State private var files: [String] = []
-    @State private var results: [Result] = []
-    @State private var target: Result?
+    @State private var results: [FinderResult] = []
+    @State private var target: FinderResult?
     @State private var highlighted = 0
     @State private var handledFocusRequest = 0
 
@@ -157,7 +119,11 @@ public struct EditorPane: View {
     /// the answer takes a moment to reach the spool and come back,
     /// and the pane must not flash the file again in between.
     private var blockingEdit: ExternalEdit? {
-        waitingEdit?.id == finishedEdit ? nil : waitingEdit
+        if waitingEdit?.id == finishedEdit {
+            nil
+        } else {
+            waitingEdit
+        }
     }
 
     /// The finder over its results over the file being edited. Arrow
@@ -238,30 +204,10 @@ public struct EditorPane: View {
     }
 
     private var resultsList: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(spacing: 0) {
-                    ForEach(Array(results.enumerated()), id: \.element.id) { index, result in
-                        FinderResultRow(
-                            file: result.file,
-                            line: result.line,
-                            preview: result.preview,
-                            isHighlighted: index == highlighted,
-                        )
-                        .onTapGesture { pick(result) }
-                        .id(index)
-                    }
-                }
-            }
-            // Arrowing past the visible rows scrolls the highlight
-            // into view rather than moving it off screen.
-            .onChange(of: highlighted) { proxy.scrollTo(highlighted) }
-        }
-        .frame(maxHeight: Self.resultsHeight)
-        .hoverHelp("Arrows move the highlight; return or a click opens")
+        FinderResultsList(results: results, highlighted: highlighted) { pick($0) }
     }
 
-    private func editor(for result: Result) -> some View {
+    private func editor(for result: FinderResult) -> some View {
         FileEditorView(
             worktreePath: worktreePath,
             relativePath: result.file,
@@ -277,7 +223,7 @@ public struct EditorPane: View {
 
     /// The move-to-other-pane action for the open file, which clears
     /// this slot before handing the file over.
-    private func paneMove(for result: Result) -> FileEditorView.PaneMove? {
+    private func paneMove(for result: FinderResult) -> FileEditorView.PaneMove? {
         onMoveFile.map { move in
             // The closure stays a non-final argument: the formatter
             // rewrites a trailing one after a multiline call.
@@ -302,7 +248,7 @@ public struct EditorPane: View {
             return
         }
 
-        target = Result(file: editorFilePath, line: editorFileLine > 0 ? editorFileLine : nil)
+        target = FinderResult(file: editorFilePath, line: editorFileLine > 0 ? editorFileLine : nil)
     }
 
     /// Releases the command waiting on the file and returns the
@@ -341,7 +287,7 @@ public struct EditorPane: View {
 
     /// Every open routes through the opener: the Editor tab by
     /// default, the external editor on Cmd-click.
-    private func pick(_ result: Result?) {
+    private func pick(_ result: FinderResult?) {
         guard let result else {
             return
         }
@@ -355,7 +301,7 @@ public struct EditorPane: View {
         guard searchesContents else {
             let matches = FuzzyMatcher.rank(files, query: query)
                 .prefix(Self.fileResultLimit)
-                .map { Result(file: $0, line: nil) }
+                .map { FinderResult(file: $0, line: nil) }
             results = Array(matches)
             return
         }
@@ -372,7 +318,7 @@ public struct EditorPane: View {
             }
 
             results = hits.map { hit in
-                Result(
+                FinderResult(
                     file: hit.file,
                     line: hit.line,
                     preview: hit.text.trimmingCharacters(in: .whitespaces),
@@ -380,46 +326,4 @@ public struct EditorPane: View {
             }
         }
     }
-}
-
-// MARK: - FinderResultRow
-
-/// One finder result row; its own view so the pane's type body
-/// stays within the length limit.
-private struct FinderResultRow: View {
-    // MARK: Internal
-
-    let file: String
-    let line: Int?
-    let preview: String?
-    let isHighlighted: Bool
-
-    var body: some View {
-        HStack(spacing: Self.padding) {
-            Image(systemName: line == nil ? "doc.text" : "text.magnifyingglass")
-                .foregroundStyle(.secondary)
-                .accessibilityHidden(true)
-            Text(file + (line.map { ":" + String($0) } ?? ""))
-                .font(CodeStyle.font)
-                .lineLimit(1)
-            if let preview {
-                Text(preview)
-                    .font(CodeStyle.font)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, Self.padding)
-        .padding(.vertical, Self.rowVerticalPadding)
-        .background(isHighlighted ? Color.accentColor.opacity(Self.highlightOpacity) : .clear)
-        .contentShape(Rectangle())
-    }
-
-    // MARK: Private
-
-    private static let padding: CGFloat = 6
-    private static let highlightOpacity = 0.25
-    private static let rowVerticalPadding: CGFloat = 2
 }

--- a/Sources/ReviewFeature/FileEditorView.swift
+++ b/Sources/ReviewFeature/FileEditorView.swift
@@ -10,7 +10,8 @@ struct FileEditorView: View {
     // MARK: Lifecycle
 
     /// Creates an editor for a file relative to the worktree,
-    /// optionally jumping to a line. `onClose` closes an embedding
+    /// optionally jumping to a line. `move` offers sending the file
+    /// to the other editor slot; `onClose` closes an embedding
     /// owner; `showsClose: false` suits inline embeddings that have
     /// nothing to close.
     init(
@@ -19,6 +20,7 @@ struct FileEditorView: View {
         service: SessionService,
         jumpToLine: Int? = nil,
         showsClose: Bool = true,
+        move: PaneMove? = nil,
         onClose: (() -> Void)? = nil,
     ) {
         // A hostile repository could put `../` in a diff path, so a
@@ -37,6 +39,7 @@ struct FileEditorView: View {
         changedLines = { await service.changedLineNumbers(worktreePath: worktreePath, file: relativePath) }
         self.jumpToLine = jumpToLine
         self.showsClose = showsClose
+        self.move = move
         self.onClose = onClose
         onFinish = nil
     }
@@ -53,11 +56,20 @@ struct FileEditorView: View {
         changedLines = nil
         jumpToLine = nil
         showsClose = false
+        move = nil
         onClose = nil
         self.onFinish = onFinish
     }
 
     // MARK: Internal
+
+    /// Sending the open file to the other editor slot: what the
+    /// button looks like and what it runs once the file is saved.
+    struct PaneMove {
+        let action: () -> Void
+        let icon: String
+        let help: String
+    }
 
     /// The editor under its header. Save enables only with unsaved
     /// changes and reports Saved after writing; a file some command
@@ -83,6 +95,17 @@ struct FileEditorView: View {
             }
         }
         .onAppear { load() }
+        // A displaced editor keeps its typing: the pane can go off
+        // screen without a close (a worktree switch, a session
+        // appearing, a move to the other slot), and losing the
+        // buffer there would be silent. The Close button stays the
+        // one deliberate discard, and a waiting file must never be
+        // written behind its command's back.
+        .onDisappear {
+            if onFinish == nil, closedWithoutSaving == false, hasChanges {
+                save()
+            }
+        }
         // Editing again invalidates the save report, but real error
         // messages stay until resolved.
         .onChange(of: content) {
@@ -104,6 +127,10 @@ struct FileEditorView: View {
     @State private var status: String?
     @State private var rendersMarkdown = false
 
+    /// Whether Close discarded the buffer, which the disappearing
+    /// autosave must honour rather than writing it anyway.
+    @State private var closedWithoutSaving = false
+
     @Environment(\.dismiss)
     private var dismiss
 
@@ -118,6 +145,7 @@ struct FileEditorView: View {
     private let changedLines: (() async -> Set<Int>)?
     private let jumpToLine: Int?
     private let showsClose: Bool
+    private let move: PaneMove?
     private let onClose: (() -> Void)?
 
     /// Releases the command waiting on this file, saved or not.
@@ -148,6 +176,19 @@ struct FileEditorView: View {
             }
             if isMarkdown {
                 markdownToggle
+            }
+            if let move {
+                // Only a file that reached the disk moves: the other
+                // slot re-reads it from there, so moving an unsaved
+                // buffer would silently drop the typing.
+                Button("Move to other pane", systemImage: move.icon) {
+                    if hasChanges == false || save() {
+                        move.action()
+                    }
+                }
+                .labelStyle(.iconOnly)
+                .buttonStyle(.borderless)
+                .hoverHelp(move.help)
             }
             Button("Save", systemImage: "square.and.arrow.down") { save() }
                 .labelStyle(.iconOnly)
@@ -239,6 +280,7 @@ struct FileEditorView: View {
     }
 
     private func close() {
+        closedWithoutSaving = true
         if let onClose {
             onClose()
         } else {

--- a/Sources/ReviewFeature/FileEditorView.swift
+++ b/Sources/ReviewFeature/FileEditorView.swift
@@ -177,19 +177,7 @@ struct FileEditorView: View {
             if isMarkdown {
                 markdownToggle
             }
-            if let move {
-                // Only a file that reached the disk moves: the other
-                // slot re-reads it from there, so moving an unsaved
-                // buffer would silently drop the typing.
-                Button("Move to other pane", systemImage: move.icon) {
-                    if hasChanges == false || save() {
-                        move.action()
-                    }
-                }
-                .labelStyle(.iconOnly)
-                .buttonStyle(.borderless)
-                .hoverHelp(move.help)
-            }
+            moveButton
             Button("Save", systemImage: "square.and.arrow.down") { save() }
                 .labelStyle(.iconOnly)
                 .buttonStyle(.borderless)
@@ -203,6 +191,22 @@ struct FileEditorView: View {
                     .hoverHelp("Close the editor without saving")
             }
             waitingActions
+        }
+    }
+
+    /// Sends the file to the other editor slot, but only once it has
+    /// reached the disk: the other slot re-reads it from there, so
+    /// moving an unsaved buffer would silently drop the typing.
+    @ViewBuilder private var moveButton: some View {
+        if let move {
+            Button("Move to other pane", systemImage: move.icon) {
+                if hasChanges == false || save() {
+                    move.action()
+                }
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.borderless)
+            .hoverHelp(move.help)
         }
     }
 

--- a/Sources/ReviewFeature/FinderResultRow.swift
+++ b/Sources/ReviewFeature/FinderResultRow.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import TerminalUI
+
+// MARK: - FinderResultRow
+
+/// One finder result row; its own view and file so the pane stays
+/// within the length limits.
+struct FinderResultRow: View {
+    // MARK: Internal
+
+    let file: String
+    let line: Int?
+    let preview: String?
+    let isHighlighted: Bool
+
+    var body: some View {
+        HStack(spacing: Self.padding) {
+            Image(systemName: line == nil ? "doc.text" : "text.magnifyingglass")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text(file + (line.map { ":" + String($0) } ?? ""))
+                .font(CodeStyle.font)
+                .lineLimit(1)
+            if let preview {
+                Text(preview)
+                    .font(CodeStyle.font)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Self.padding)
+        .padding(.vertical, Self.rowVerticalPadding)
+        .background(isHighlighted ? Color.accentColor.opacity(Self.highlightOpacity) : .clear)
+        .contentShape(Rectangle())
+    }
+
+    // MARK: Private
+
+    private static let padding: CGFloat = 6
+    private static let highlightOpacity = 0.25
+    private static let rowVerticalPadding: CGFloat = 2
+}
+
+// MARK: - FinderResult
+
+/// One row of the result list: a file, or a content match with the
+/// matched line's text; beside the row views so the pane's type
+/// body stays within the length limit.
+struct FinderResult: Identifiable, Hashable {
+    let file: String
+    let line: Int?
+    var preview: String?
+
+    var id: String {
+        file + ":" + String(line ?? 0)
+    }
+}
+
+// MARK: - FinderResultsList
+
+/// The finder's result rows in a bounded scroll, the highlight kept
+/// on screen; its own view so the pane's type body stays within the
+/// length limit.
+struct FinderResultsList: View {
+    // MARK: Internal
+
+    let results: [FinderResult]
+    let highlighted: Int
+    let onPick: (FinderResult) -> Void
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(Array(results.enumerated()), id: \.element.id) { index, result in
+                        FinderResultRow(
+                            file: result.file,
+                            line: result.line,
+                            preview: result.preview,
+                            isHighlighted: index == highlighted,
+                        )
+                        .onTapGesture { onPick(result) }
+                        .accessibilityAddTraits(.isButton)
+                        .id(index)
+                    }
+                }
+            }
+            // Arrowing past the visible rows scrolls the highlight
+            // into view rather than moving it off screen.
+            .onChange(of: highlighted) { proxy.scrollTo(highlighted) }
+        }
+        .frame(maxHeight: Self.resultsHeight)
+        .hoverHelp("Arrows move the highlight; return or a click opens")
+    }
+
+    // MARK: Private
+
+    private static let resultsHeight: CGFloat = 180
+}

--- a/Sources/ReviewFeature/ReviewFooterView.swift
+++ b/Sources/ReviewFeature/ReviewFooterView.swift
@@ -43,7 +43,11 @@ struct ReviewFooterView: View {
 
     /// Rejoins the fields with the blank separator git expects.
     static func message(subject: String, body: String) -> String {
-        body.isEmpty ? subject : subject + "\n\n" + body
+        if body.isEmpty {
+            subject
+        } else {
+            subject + "\n\n" + body
+        }
     }
 
     // MARK: Private

--- a/Sources/ReviewFeature/ReviewModel+Find.swift
+++ b/Sources/ReviewFeature/ReviewModel+Find.swift
@@ -30,7 +30,11 @@ extension ReviewModel {
 
     /// The hunk the diff should be showing, nil when nothing matches.
     var currentFindTarget: String? {
-        findTargets.indices.contains(currentFind) ? findTargets[currentFind].id : nil
+        if findTargets.indices.contains(currentFind) {
+            findTargets[currentFind].id
+        } else {
+            nil
+        }
     }
 
     /// Whether a line has anything to highlight, so the renderer

--- a/Sources/SessionFeature/RepositorySessionsView.swift
+++ b/Sources/SessionFeature/RepositorySessionsView.swift
@@ -123,50 +123,54 @@ public struct RepositorySessionsView: View {
             )
             .font(.subheadline.weight(.semibold))
             Spacer()
-            // The editor is a sideways move rather than session
-            // work, so it comes first; then starting fresh before
-            // continuing something, in the order the two are read,
-            // with resuming the prominent one, since it is why the
-            // list is here.
-            if let onOpenEditor {
-                Button("Editor", action: onOpenEditor)
-                    .controlSize(.small)
-                    .hoverHelp(
-                        model.worktreePath == nil
-                            ? "Edit files in this repository's main checkout, in this pane"
-                            : "Edit this worktree's files in this pane; this list is a click away",
-                    )
-            }
-            if let onNewSession {
-                Button(model.worktreePath == nil ? "Start session" : "New session", action: onNewSession)
-                    .controlSize(.small)
-                    .hoverHelp(
-                        model.worktreePath == nil
-                            ? "Start an agent session on the default branch, in this checkout without a new worktree"
-                            : "Start a fresh agent session in this worktree instead of continuing one",
-                    )
-            }
-            // One resume button: in place when the conversation's
-            // worktree still exists, into a fresh worktree only when
-            // it is gone and that is all that can be done.
-            if model.selected == nil || model.selectedWorktreePath != nil {
-                Button("Resume here") { model.resumeSelectedHere(onResumed: onResumed) }
-                    .controlSize(.small)
-                    .disabled(model.selectedWorktreePath == nil)
-                    .hoverHelp("Continue the selected conversation in the worktree it ran in")
-            } else {
-                Button("Resume in new worktree") { model.resumeSelected(onResumed: onResumed) }
-                    .controlSize(.small)
-                    .hoverHelp(
-                        "This conversation's worktree is gone; continue it in a fresh worktree and branch",
-                    )
-            }
+            headerButtons
         }
         // The embedding pane owns the top inset; only a hairline of
         // breathing room is added here.
         .padding(.horizontal, Self.padding)
         .padding(.top, Self.headerBottomPadding)
         .padding(.bottom, Self.headerBottomPadding)
+    }
+
+    /// The editor is a sideways move rather than session work, so it
+    /// comes first; then starting fresh before continuing something,
+    /// in the order the two are read, with resuming the prominent
+    /// one, since it is why the list is here. Out of the header so
+    /// its closure stays within the length limit.
+    @ViewBuilder private var headerButtons: some View {
+        if let onOpenEditor {
+            Button("Editor", action: onOpenEditor)
+                .controlSize(.small)
+                .hoverHelp(
+                    model.worktreePath == nil
+                        ? "Edit files in this repository's main checkout, in this pane"
+                        : "Edit this worktree's files in this pane; this list is a click away",
+                )
+        }
+        if let onNewSession {
+            Button(model.worktreePath == nil ? "Start session" : "New session", action: onNewSession)
+                .controlSize(.small)
+                .hoverHelp(
+                    model.worktreePath == nil
+                        ? "Start an agent session on the default branch, in this checkout without a new worktree"
+                        : "Start a fresh agent session in this worktree instead of continuing one",
+                )
+        }
+        // One resume button: in place when the conversation's
+        // worktree still exists, into a fresh worktree only when
+        // it is gone and that is all that can be done.
+        if model.selected == nil || model.selectedWorktreePath != nil {
+            Button("Resume here") { model.resumeSelectedHere(onResumed: onResumed) }
+                .controlSize(.small)
+                .disabled(model.selectedWorktreePath == nil)
+                .hoverHelp("Continue the selected conversation in the worktree it ran in")
+        } else {
+            Button("Resume in new worktree") { model.resumeSelected(onResumed: onResumed) }
+                .controlSize(.small)
+                .hoverHelp(
+                    "This conversation's worktree is gone; continue it in a fresh worktree and branch",
+                )
+        }
     }
 
     private var list: some View {

--- a/Sources/SessionFeature/RepositorySessionsView.swift
+++ b/Sources/SessionFeature/RepositorySessionsView.swift
@@ -15,9 +15,10 @@ public struct RepositorySessionsView: View {
     /// worktree,
     /// `onResumed` runs after a resume launches and
     /// `onWorktreeFocus` reports the selected conversation's still
-    /// existing worktree, so other panes can follow along, and
+    /// existing worktree, so other panes can follow along,
     /// `onNewSession`, when given, offers a fresh session in the
-    /// worktree the list is scoped to.
+    /// worktree the list is scoped to and `onOpenEditor` offers the
+    /// centre editor in this pane's place.
     @preconcurrency
     public init(
         repository: Repository,
@@ -26,10 +27,12 @@ public struct RepositorySessionsView: View {
         progress: LaunchProgress? = nil,
         onWorktreeFocus: (@MainActor (String?) -> Void)? = nil,
         onNewSession: (@MainActor () -> Void)? = nil,
+        onOpenEditor: (@MainActor () -> Void)? = nil,
         onResumed: @escaping @MainActor () async -> Void,
     ) {
         self.onWorktreeFocus = onWorktreeFocus
         self.onNewSession = onNewSession
+        self.onOpenEditor = onOpenEditor
         self.onResumed = onResumed
         self.progress = progress
         identity = repository.id + "#" + (worktreePath ?? "")
@@ -107,6 +110,7 @@ public struct RepositorySessionsView: View {
     private let progress: LaunchProgress?
     private let onWorktreeFocus: (@MainActor (String?) -> Void)?
     private let onNewSession: (@MainActor () -> Void)?
+    private let onOpenEditor: (@MainActor () -> Void)?
     private let onResumed: @MainActor () async -> Void
     private let makeModel: () -> RepositorySessionsModel
 
@@ -119,9 +123,20 @@ public struct RepositorySessionsView: View {
             )
             .font(.subheadline.weight(.semibold))
             Spacer()
-            // Starting fresh comes before continuing something, in
-            // the order the two are read; resuming stays the
-            // prominent one, since it is why the list is here.
+            // The editor is a sideways move rather than session
+            // work, so it comes first; then starting fresh before
+            // continuing something, in the order the two are read,
+            // with resuming the prominent one, since it is why the
+            // list is here.
+            if let onOpenEditor {
+                Button("Editor", action: onOpenEditor)
+                    .controlSize(.small)
+                    .hoverHelp(
+                        model.worktreePath == nil
+                            ? "Edit files in this repository's main checkout, in this pane"
+                            : "Edit this worktree's files in this pane; this list is a click away",
+                    )
+            }
             if let onNewSession {
                 Button(model.worktreePath == nil ? "Start session" : "New session", action: onNewSession)
                     .controlSize(.small)

--- a/Sources/TerminalUI/BranchStackStrip.swift
+++ b/Sources/TerminalUI/BranchStackStrip.swift
@@ -84,8 +84,10 @@ public struct BranchStackStrip: View {
     }
 
     private func help(for branch: String) -> String {
-        branch == stack.checkedOut
-            ? "The branch this worktree holds; its diff is the one you can change"
-            : "Show this branch's own changes; checking it out is a separate step"
+        if branch == stack.checkedOut {
+            "The branch this worktree holds; its diff is the one you can change"
+        } else {
+            "Show this branch's own changes; checking it out is a separate step"
+        }
     }
 }

--- a/Sources/TerminalUI/ChecksStyle.swift
+++ b/Sources/TerminalUI/ChecksStyle.swift
@@ -133,7 +133,11 @@ public nonisolated enum ChecksStyle {
 
     /// The colour for a mergeability verdict.
     public static func mergeableColour(for mergeable: String) -> Color {
-        mergeable == "MERGEABLE" ? .green : .red
+        if mergeable == "MERGEABLE" {
+            .green
+        } else {
+            .red
+        }
     }
 
     /// A short display name for a GitHub login: the code review bot

--- a/Sources/TerminalUI/CompletionSound.swift
+++ b/Sources/TerminalUI/CompletionSound.swift
@@ -1,5 +1,6 @@
 import AppKit
 import AudioToolbox
+import Synchronization
 import UniformTypeIdentifiers
 
 /// The chime played when an agent finishes its work, stored on the
@@ -60,10 +61,33 @@ public enum CompletionSound {
             return
         }
 
+        lingering.withLock { _ = $0.insert(sound) }
         AudioServicesPlayAlertSoundWithCompletion(sound, Self.disposal(of: sound))
     }
 
+    /// Disposes every sound whose completion never ran, called on
+    /// wake: sleep can interrupt an alert mid-play and swallow its
+    /// completion, and the audio daemon then replays the undisposed
+    /// sound in a loop until something disposes it (playing any
+    /// other alert did too, which is why a Settings preview used to
+    /// stop the noise).
+    public static func stopLingering() {
+        let stuck = lingering.withLock { sounds in
+            let all = sounds
+            sounds = []
+            return all
+        }
+        for sound in stuck {
+            AudioServicesDisposeSystemSoundID(sound)
+        }
+    }
+
     // MARK: Internal
+
+    /// The sounds playing right now, each removed by whoever
+    /// disposes it, so a drain and a late completion can never
+    /// dispose one sound twice.
+    nonisolated static let lingering: Mutex<Set<SystemSoundID>> = .init([])
 
     /// Whether a file name carries an audio type playback accepts.
     static func isPlayable(_ name: String) -> Bool {
@@ -82,8 +106,16 @@ public enum CompletionSound {
     /// The completion runs on the sound service's own queue, so it
     /// must not be a main-actor closure: the runtime's executor
     /// check traps there. Formed in a nonisolated context it stays
-    /// free of any actor.
+    /// free of any actor. Only the closure that still finds its
+    /// sound registered disposes it; a wake drain may have got
+    /// there first.
     private nonisolated static func disposal(of sound: SystemSoundID) -> @Sendable () -> Void {
-        { AudioServicesDisposeSystemSoundID(sound) }
+        {
+            guard lingering.withLock({ $0.remove(sound) != nil }) else {
+                return
+            }
+
+            AudioServicesDisposeSystemSoundID(sound)
+        }
     }
 }

--- a/Sources/TerminalUI/HighlightedLine.swift
+++ b/Sources/TerminalUI/HighlightedLine.swift
@@ -8,6 +8,7 @@ public enum HighlightedLine {
     /// Unknown languages come back plain.
     public static func text(line: String, language: SyntaxLanguage?) -> Text {
         CodeHighlighter.tokens(for: line, language: language)
+            .lazy
             .map { token in Text(token.text).foregroundStyle(colour(for: token.kind)) }
             .reduce(Text("")) { Text("\($0)\($1)") }
     }

--- a/Sources/TerminalUI/LinkOpener.swift
+++ b/Sources/TerminalUI/LinkOpener.swift
@@ -123,10 +123,12 @@ public enum LinkOpener {
 
 // MARK: - FileOpener
 
-/// Opens files: in the Editor tab by default, in an external editor
-/// when the command key is held. The external command comes from the
-/// `externalEditorCommand` default (space-separated argv), falling
-/// back to the system's default application.
+/// Opens files: in the built-in editor by default, in an external
+/// editor when the command key is held. The built-in request lands
+/// on the shared keys; the window routes it to the centre or side
+/// editor and reveals whichever it picked. The external command
+/// comes from the `externalEditorCommand` default (space-separated
+/// argv), falling back to the system's default application.
 public enum FileOpener {
     // MARK: Public
 
@@ -141,7 +143,6 @@ public enum FileOpener {
         defaults.set(line ?? 0, forKey: "editorFileLine")
         defaults.set(worktreePath, forKey: "editorFileWorktree")
         defaults.set(defaults.integer(forKey: "editorFileRequest") + 1, forKey: "editorFileRequest")
-        defaults.set(UtilityTabTarget.editor, forKey: UtilityTabTarget.key)
     }
 
     /// Routes a worktree-relative file by the command key. Paths
@@ -159,7 +160,6 @@ public enum FileOpener {
             defaults.set(line ?? 0, forKey: "editorFileLine")
             defaults.set(worktreePath, forKey: "editorFileWorktree")
             defaults.set(defaults.integer(forKey: "editorFileRequest") + 1, forKey: "editorFileRequest")
-            defaults.set(UtilityTabTarget.editor, forKey: UtilityTabTarget.key)
             return
         }
 

--- a/Sources/TerminalUI/PaneTerminalView.swift
+++ b/Sources/TerminalUI/PaneTerminalView.swift
@@ -86,7 +86,8 @@ final class PaneTerminalView: LocalProcessTerminalView {
         }
 
         if bracketsPastes, getTerminal().bracketedPasteMode == false,
-           let text = NSPasteboard.general.string(forType: .string) {
+           let text = NSPasteboard.general.string(forType: .string)
+        {
             // Three sends, gathered into one write by the coordinator,
             // so the agent sees one paste and draws one.
             send(data: Self.bracketedPasteStart[...])

--- a/Tests/AgentIDEDataTests/FileListingTests.swift
+++ b/Tests/AgentIDEDataTests/FileListingTests.swift
@@ -1,0 +1,81 @@
+import AgentIDEData
+import AgentIDEDomain
+import Foundation
+import Synchronization
+import Testing
+
+// MARK: - FileListingTests
+
+/// The fuzzy finder's file listing, whose concurrent callers must
+/// share one ripgrep run: the centre and side editors mount
+/// together.
+struct FileListingTests {
+    @Test
+    func `concurrent file listings share one ripgrep run`() async throws {
+        let world = try await World.make()
+        defer { world.tearDown() }
+        let runner = SlowCountingRunner(standardOutput: "one.swift\ntwo.swift\n")
+        let service = SessionService(
+            paths: world.paths,
+            git: GitClient(runner: runner),
+            herdr: world.herdr,
+            github: GitHubClient(runner: runner),
+            transcripts: TranscriptReader(),
+            spool: EventSpool(directory: world.paths.eventsDirectory),
+            store: MetadataStore(file: world.paths.metadataFile),
+            runners: [],
+            processes: runner,
+        )
+
+        async let first = service.listFiles(worktreePath: world.repository.path)
+        async let second = service.listFiles(worktreePath: world.repository.path)
+        let listings = await [first, second]
+        #expect(listings[0] == ["one.swift", "two.swift"])
+        #expect(listings[1] == listings[0])
+        #expect(runner.runCount == 1)
+
+        // A listing after the shared one finished reads afresh.
+        _ = await service.listFiles(worktreePath: world.repository.path)
+        #expect(runner.runCount == 2)
+    }
+}
+
+// MARK: - SlowCountingRunner
+
+/// Answers fixed output slowly enough that concurrent callers
+/// overlap, counting how many commands actually ran.
+private final class SlowCountingRunner: ProcessRunner, Sendable {
+    // MARK: Lifecycle
+
+    init(standardOutput: String) {
+        self.standardOutput = standardOutput
+    }
+
+    deinit {
+        // Nothing to clean up.
+    }
+
+    // MARK: Internal
+
+    var runCount: Int {
+        count.withLock { $0 }
+    }
+
+    func run(
+        _: [String],
+        workingDirectory _: String?,
+        environment _: [String: String],
+    ) async throws -> ProcessResult {
+        count.withLock { $0 += 1 }
+        try await Task.sleep(for: .milliseconds(Self.stallMilliseconds))
+        return ProcessResult(status: 0, standardOutput: standardOutput, standardError: "")
+    }
+
+    // MARK: Private
+
+    /// Long enough that both callers overlap on any scheduler.
+    private static let stallMilliseconds = 200
+
+    private let count: Mutex<Int> = .init(0)
+    private let standardOutput: String
+}

--- a/Tests/AgentIDEDataTests/GitClientIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/GitClientIntegrationTests.swift
@@ -101,7 +101,7 @@ struct GitClientIntegrationTests {
         defer { try? FileManager.default.removeItem(atPath: root) }
         let repoPath = root + "/repo"
         try await TestSupport.makeRepository(at: repoPath)
-        let base = (1 ... 40).map { "line\($0)" }.joined(separator: "\n") + "\n"
+        let base = (1 ... 40).lazy.map { "line\($0)" }.joined(separator: "\n") + "\n"
         try base.write(toFile: repoPath + "/f.txt", atomically: true, encoding: .utf8)
         try await TestSupport.runGit(["add", "-A"], in: repoPath)
         try await TestSupport.runGit(["commit", "-q", "-m", "Base"], in: repoPath)
@@ -135,7 +135,7 @@ struct GitClientIntegrationTests {
         defer { try? FileManager.default.removeItem(atPath: root) }
         let repoPath = root + "/repo"
         try await TestSupport.makeRepository(at: repoPath)
-        let base = (1 ... 40).map { "line\($0)" }.joined(separator: "\n") + "\n"
+        let base = (1 ... 40).lazy.map { "line\($0)" }.joined(separator: "\n") + "\n"
         try base.write(toFile: repoPath + "/f.txt", atomically: true, encoding: .utf8)
         try await TestSupport.runGit(["add", "-A"], in: repoPath)
         try await TestSupport.runGit(["commit", "-q", "-m", "Base"], in: repoPath)

--- a/Tests/AgentIDEDataTests/GitHubClientTests.swift
+++ b/Tests/AgentIDEDataTests/GitHubClientTests.swift
@@ -2,6 +2,8 @@
 import AgentIDEDomain
 import Testing
 
+// MARK: - GitHubClientTests
+
 /// Exercises the pure parsing and prompt composition around `gh`.
 struct GitHubClientTests {
     @Test
@@ -192,4 +194,85 @@ struct GitHubClientTests {
         #expect(models.contains("gpt-5.5"))
         #expect(models.contains("Available") == false)
     }
+
+    @Test
+    func `failed job ids parse from a run's jobs listing`() {
+        let json = """
+        {"jobs": [
+          {"databaseId": 11, "conclusion": "failure"},
+          {"databaseId": 12, "conclusion": null},
+          {"databaseId": 13, "conclusion": "success"}
+        ]}
+        """
+        #expect(GitHubClient.failedJobIDs(fromJSON: json) == [11])
+        #expect(GitHubClient.failedJobIDs(fromJSON: "").isEmpty)
+    }
+
+    @Test
+    func `failing logs fall back to failed jobs while a run runs`() async throws {
+        let jobs = #"{"jobs": [{"databaseId": 11, "conclusion": "failure"}, {"databaseId": 12, "conclusion": null}]}"#
+        let runner = ScriptedGitHubRunner(answers: [
+            "gh run view 9 --log-failed": .failure("run 9 is still in progress"),
+            "gh run view 9 --json jobs": .success(jobs),
+            "gh run view --job 11 --log-failed": .success("job\tstep\tline\n"),
+        ])
+        let log = try await GitHubClient(runner: runner).failedRunLog(repositoryPath: "/repo", runID: 9)
+        #expect(log == "job\tstep\tline")
+    }
+
+    @Test
+    func `a run in progress with no failed job keeps its own error`() async {
+        let runner = ScriptedGitHubRunner(answers: [
+            "gh run view 9 --log-failed": .failure("run 9 is still in progress"),
+            "gh run view 9 --json jobs": .success(#"{"jobs": [{"databaseId": 12, "conclusion": null}]}"#),
+        ])
+        await #expect(throws: Error.self) {
+            try await GitHubClient(runner: runner).failedRunLog(repositoryPath: "/repo", runID: 9)
+        }
+    }
+}
+
+// MARK: - ScriptedGitHubRunner
+
+/// Answers each expected command from a script; anything unexpected
+/// fails, naming itself.
+private final class ScriptedGitHubRunner: ProcessRunner, Sendable {
+    // MARK: Lifecycle
+
+    init(answers: [String: Answer]) {
+        self.answers = answers
+    }
+
+    deinit {
+        // Nothing to clean up.
+    }
+
+    // MARK: Internal
+
+    enum Answer {
+        case success(String)
+        case failure(String)
+    }
+
+    func run(
+        _ arguments: [String],
+        workingDirectory _: String?,
+        environment _: [String: String],
+    ) -> ProcessResult {
+        let command = arguments.joined(separator: " ")
+        return switch answers[command] {
+        case let .success(output):
+            ProcessResult(status: 0, standardOutput: output, standardError: "")
+
+        case let .failure(message):
+            ProcessResult(status: 1, standardOutput: "", standardError: message)
+
+        case nil:
+            ProcessResult(status: 1, standardOutput: "", standardError: "unscripted command: " + command)
+        }
+    }
+
+    // MARK: Private
+
+    private let answers: [String: Answer]
 }

--- a/Tests/AgentIDEDataTests/HerdrLargeInputIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/HerdrLargeInputIntegrationTests.swift
@@ -30,6 +30,7 @@ struct HerdrLargeInputIntegrationTests {
 
         // Numbered lines, so whatever survives says which part did.
         let text = (1 ... 4_000)
+            .lazy
             .map { String(format: "line %04d ends here and this pads it out", $0) }
             .joined(separator: "\n") + "\n"
         let watchdog = Task {

--- a/Tests/AgentIDEDataTests/HerdrSlowReaderIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/HerdrSlowReaderIntegrationTests.swift
@@ -44,6 +44,7 @@ struct HerdrSlowReaderIntegrationTests {
         channel.send(HerdrTerminal.resizeCommand(columns: 80, rows: 24))
 
         let text = (1 ... 1_500)
+            .lazy
             .map { String(format: "line %04d ends here and this pads it out", $0) }
             .joined(separator: "\n") + "\n"
         let watchdog = Task {

--- a/Tests/AgentIDEDataTests/SessionServiceIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/SessionServiceIntegrationTests.swift
@@ -1,7 +1,6 @@
 import AgentIDEData
 import AgentIDEDomain
 import Foundation
-import Synchronization
 import Testing
 
 // MARK: - PromptCaptureRunner
@@ -296,72 +295,6 @@ struct SessionServiceIntegrationTests {
         #expect(files.contains("deep/nested.swift"))
         #expect(files.contains("README.md"))
     }
-
-    @Test
-    func `concurrent file listings share one ripgrep run`() async throws {
-        let world = try await World.make()
-        defer { world.tearDown() }
-        let runner = SlowCountingRunner(standardOutput: "one.swift\ntwo.swift\n")
-        let service = SessionService(
-            paths: world.paths,
-            git: GitClient(runner: runner),
-            herdr: world.herdr,
-            github: GitHubClient(runner: runner),
-            transcripts: TranscriptReader(),
-            spool: EventSpool(directory: world.paths.eventsDirectory),
-            store: MetadataStore(file: world.paths.metadataFile),
-            runners: [],
-            processes: runner,
-        )
-
-        async let first = service.listFiles(worktreePath: world.repository.path)
-        async let second = service.listFiles(worktreePath: world.repository.path)
-        let listings = await [first, second]
-        #expect(listings[0] == ["one.swift", "two.swift"])
-        #expect(listings[1] == listings[0])
-        #expect(runner.runCount == 1)
-
-        // A listing after the shared one finished reads afresh.
-        _ = await service.listFiles(worktreePath: world.repository.path)
-        #expect(runner.runCount == 2)
-    }
-}
-
-// MARK: - SlowCountingRunner
-
-/// Answers fixed output slowly enough that concurrent callers
-/// overlap, counting how many commands actually ran.
-private final class SlowCountingRunner: ProcessRunner, Sendable {
-    // MARK: Lifecycle
-
-    init(standardOutput: String) {
-        self.standardOutput = standardOutput
-    }
-
-    deinit {
-        // Nothing to clean up.
-    }
-
-    // MARK: Internal
-
-    var runCount: Int {
-        count.withLock { $0 }
-    }
-
-    func run(
-        _: [String],
-        workingDirectory _: String?,
-        environment _: [String: String],
-    ) async throws -> ProcessResult {
-        count.withLock { $0 += 1 }
-        try await Task.sleep(for: .milliseconds(200))
-        return ProcessResult(status: 0, standardOutput: standardOutput, standardError: "")
-    }
-
-    // MARK: Private
-
-    private let count = Mutex(0)
-    private let standardOutput: String
 }
 
 // MARK: - RepositoryPageIntegrationTests

--- a/Tests/AgentIDEDataTests/SessionServiceIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/SessionServiceIntegrationTests.swift
@@ -1,6 +1,7 @@
 import AgentIDEData
 import AgentIDEDomain
 import Foundation
+import Synchronization
 import Testing
 
 // MARK: - PromptCaptureRunner
@@ -295,6 +296,72 @@ struct SessionServiceIntegrationTests {
         #expect(files.contains("deep/nested.swift"))
         #expect(files.contains("README.md"))
     }
+
+    @Test
+    func `concurrent file listings share one ripgrep run`() async throws {
+        let world = try await World.make()
+        defer { world.tearDown() }
+        let runner = SlowCountingRunner(standardOutput: "one.swift\ntwo.swift\n")
+        let service = SessionService(
+            paths: world.paths,
+            git: GitClient(runner: runner),
+            herdr: world.herdr,
+            github: GitHubClient(runner: runner),
+            transcripts: TranscriptReader(),
+            spool: EventSpool(directory: world.paths.eventsDirectory),
+            store: MetadataStore(file: world.paths.metadataFile),
+            runners: [],
+            processes: runner,
+        )
+
+        async let first = service.listFiles(worktreePath: world.repository.path)
+        async let second = service.listFiles(worktreePath: world.repository.path)
+        let listings = await [first, second]
+        #expect(listings[0] == ["one.swift", "two.swift"])
+        #expect(listings[1] == listings[0])
+        #expect(runner.runCount == 1)
+
+        // A listing after the shared one finished reads afresh.
+        _ = await service.listFiles(worktreePath: world.repository.path)
+        #expect(runner.runCount == 2)
+    }
+}
+
+// MARK: - SlowCountingRunner
+
+/// Answers fixed output slowly enough that concurrent callers
+/// overlap, counting how many commands actually ran.
+private final class SlowCountingRunner: ProcessRunner, Sendable {
+    // MARK: Lifecycle
+
+    init(standardOutput: String) {
+        self.standardOutput = standardOutput
+    }
+
+    deinit {
+        // Nothing to clean up.
+    }
+
+    // MARK: Internal
+
+    var runCount: Int {
+        count.withLock { $0 }
+    }
+
+    func run(
+        _: [String],
+        workingDirectory _: String?,
+        environment _: [String: String],
+    ) async throws -> ProcessResult {
+        count.withLock { $0 += 1 }
+        try await Task.sleep(for: .milliseconds(200))
+        return ProcessResult(status: 0, standardOutput: standardOutput, standardError: "")
+    }
+
+    // MARK: Private
+
+    private let count = Mutex(0)
+    private let standardOutput: String
 }
 
 // MARK: - RepositoryPageIntegrationTests

--- a/Tests/AgentIDEDomainTests/PerformanceLogTests.swift
+++ b/Tests/AgentIDEDomainTests/PerformanceLogTests.swift
@@ -14,7 +14,7 @@ struct PerformanceLogTests {
 
     @Test
     func `trimming keeps the newest whole lines that fit`() {
-        let text = (1 ... 10).map { "line-" + String($0) }.joined(separator: "\n") + "\n"
+        let text = (1 ... 10).lazy.map { "line-" + String($0) }.joined(separator: "\n") + "\n"
 
         // Each line is seven bytes and a newline: a budget of
         // twenty-four holds three of them, newest last.

--- a/Tests/PRFeatureTests/PullRequestsModelTests+Push.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests+Push.swift
@@ -1,0 +1,120 @@
+import AgentIDEData
+import AgentIDEDomain
+import Foundation
+@testable import PRFeature
+import Testing
+
+/// Push's availability and refusals: unpushed counts, the tip's
+/// signature proven before the button lights, and a push that can
+/// never error on an unsigned tip; split from the model tests for
+/// length.
+extension PullRequestsModelTests {
+    @Test
+    func `push needs unpushed commits and the form needs no open pull request`() async {
+        let pushed = makeModel(items: [item(branch: "feature", ahead: 0)])
+        await pushed.reload()
+        #expect(pushed.canPush == false)
+        #expect(pushed.needsCreateForm)
+
+        let ahead = makeModel(items: [item(branch: "feature", ahead: 2)])
+        await ahead.reload()
+        #expect(ahead.canPush)
+
+        let unpushed = makeModel(items: [item(branch: "feature", ahead: nil)])
+        await unpushed.reload()
+        #expect(unpushed.canPush)
+
+        let open = makeModel(items: [item(branch: "feature", ahead: 1)])
+        open.fetchList = { _, _ in [summary(7, head: "feature")] }
+        await open.reload()
+        #expect(open.needsCreateForm == false)
+
+        let merged = makeModel(items: [item(branch: "feature", ahead: 1)])
+        merged.fetchList = { _, _ in [summary(7, head: "feature", state: "MERGED")] }
+        await merged.reload()
+        #expect(merged.needsCreateForm)
+
+        let elsewhere = makeModel()
+        #expect(elsewhere.canPush == false)
+        #expect(elsewhere.needsCreateForm == false)
+    }
+
+    @Test
+    func `pushing dims the button until new commits arrive`() async {
+        let model = makeModel(items: [item(branch: "feature", ahead: 2)])
+        await model.reload()
+        #expect(model.canPush)
+
+        #expect(await model.push())
+        #expect(model.isPushed)
+        #expect(model.canPush == false)
+        #expect(model.status == "Pushed.")
+
+        // Fresh counts can mean fresh commits nobody has verified:
+        // Push waits for the signature read the change kicked off.
+        model.items = [item(branch: "feature", ahead: 1)]
+        #expect(model.canPush == false)
+        await model.reload()
+        #expect(model.canPush)
+    }
+
+    @Test
+    func `push waits until the tip's signature is verified`() async {
+        let model = makeModel(items: [item(branch: "feature", ahead: 2)])
+        #expect(model.canPush == false)
+        #expect(model.pushHelp.contains("Checking"))
+        await model.reload()
+        #expect(model.canPush)
+    }
+
+    @Test
+    func `a tip that lost its signature never errors the push`() async {
+        let model = makeModel(items: [item(branch: "feature", ahead: 2)])
+        await model.reload()
+        #expect(model.canPush)
+
+        // Amended outside the app between the last read and the
+        // click: the push re-reads the signature, declines quietly
+        // and never reaches the remote.
+        model.checkTipSigned = { _ in false }
+        var pushed = false
+        model.performPush = { _ in
+            pushed = true
+            return .origin
+        }
+        #expect(await model.push())
+        #expect(pushed == false)
+        #expect(model.canPush == false)
+        #expect(model.status?.contains("unsigned") == true)
+    }
+
+    @Test
+    func `an unsigned tip dims Push and explains itself`() async {
+        let model = makeModel(items: [item(branch: "feature", ahead: 2)])
+        model.checkTipSigned = { _ in false }
+        await model.reload()
+        #expect(model.canPush == false)
+        #expect(model.pushHelp.contains("not GPG signed"))
+
+        model.checkTipSigned = { _ in true }
+        await model.reload()
+        #expect(model.canPush)
+    }
+
+    @Test
+    func `an unsigned tip with nothing to push reads as pushed`() async {
+        let model = makeModel(items: [item(branch: "feature", ahead: 0)])
+        model.checkTipSigned = { _ in false }
+        await model.reload()
+        #expect(model.pushHelp.contains("already pushed"))
+    }
+
+    @Test
+    func `a failed push reports rather than dimming`() async {
+        let model = makeModel(items: [item(branch: "feature", ahead: 2)])
+        await model.reload()
+        model.performPush = { _ in throw CocoaError(.fileNoSuchFile) }
+        #expect(await model.push() == false)
+        #expect(model.canPush)
+    }
+}

--- a/Tests/PRFeatureTests/PullRequestsModelTests.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests.swift
@@ -25,34 +25,6 @@ struct PullRequestsModelTests {
     }
 
     @Test
-    func `push needs unpushed commits and the form needs no open pull request`() async {
-        let pushed = makeModel(items: [item(branch: "feature", ahead: 0)])
-        await pushed.reload()
-        #expect(pushed.canPush == false)
-        #expect(pushed.needsCreateForm)
-
-        let ahead = makeModel(items: [item(branch: "feature", ahead: 2)])
-        #expect(ahead.canPush)
-
-        let unpushed = makeModel(items: [item(branch: "feature", ahead: nil)])
-        #expect(unpushed.canPush)
-
-        let open = makeModel(items: [item(branch: "feature", ahead: 1)])
-        open.fetchList = { _, _ in [summary(7, head: "feature")] }
-        await open.reload()
-        #expect(open.needsCreateForm == false)
-
-        let merged = makeModel(items: [item(branch: "feature", ahead: 1)])
-        merged.fetchList = { _, _ in [summary(7, head: "feature", state: "MERGED")] }
-        await merged.reload()
-        #expect(merged.needsCreateForm)
-
-        let elsewhere = makeModel()
-        #expect(elsewhere.canPush == false)
-        #expect(elsewhere.needsCreateForm == false)
-    }
-
-    @Test
     func `reload keeps the selection and opens single results directly`() async {
         let model = makeModel()
         model.fetchList = { _, _ in [summary(1, head: "one"), summary(2, head: "two")] }
@@ -133,33 +105,6 @@ struct PullRequestsModelTests {
     }
 
     @Test
-    func `pushing dims the button until new commits arrive`() async {
-        let model = makeModel(items: [item(branch: "feature", ahead: 2)])
-        #expect(model.canPush)
-
-        #expect(await model.push())
-        #expect(model.isPushed)
-        #expect(model.canPush == false)
-        #expect(model.status == "Pushed.")
-
-        model.items = [item(branch: "feature", ahead: 1)]
-        #expect(model.canPush)
-    }
-
-    @Test
-    func `an unsigned tip dims Push and explains itself`() async {
-        let model = makeModel(items: [item(branch: "feature", ahead: 2)])
-        model.checkTipSigned = { _ in false }
-        await model.reload()
-        #expect(model.canPush == false)
-        #expect(model.pushHelp.contains("not GPG signed"))
-
-        model.checkTipSigned = { _ in true }
-        await model.reload()
-        #expect(model.canPush)
-    }
-
-    @Test
     func `a fresh reload fetches exactly once`() async {
         let model = makeModel()
         var fetches = 0
@@ -174,22 +119,6 @@ struct PullRequestsModelTests {
             await Task.yield()
         }
         #expect(fetches == 1)
-    }
-
-    @Test
-    func `an unsigned tip with nothing to push reads as pushed`() async {
-        let model = makeModel(items: [item(branch: "feature", ahead: 0)])
-        model.checkTipSigned = { _ in false }
-        await model.reload()
-        #expect(model.pushHelp.contains("already pushed"))
-    }
-
-    @Test
-    func `a failed push reports rather than dimming`() async {
-        let model = makeModel(items: [item(branch: "feature", ahead: 2)])
-        model.performPush = { _ in throw CocoaError(.fileNoSuchFile) }
-        #expect(await model.push() == false)
-        #expect(model.canPush)
     }
 
     @Test

--- a/Tests/TerminalUITests/CompletionSoundTests.swift
+++ b/Tests/TerminalUITests/CompletionSoundTests.swift
@@ -27,4 +27,25 @@ struct CompletionSoundTests {
         #expect(CompletionSound.isPlayable("movie.mov") == false)
         #expect(CompletionSound.isPlayable("no-extension") == false)
     }
+
+    @Test
+    func `waking disposes sounds whose completion never came`() {
+        // A sound sleep interrupted mid-play: its completion never
+        // ran, so its id is still registered. The stray id stands in
+        // for one the audio daemon holds; disposing an unknown id is
+        // a harmless error.
+        CompletionSound.lingering.withLock { _ = $0.insert(9_999_999) }
+        CompletionSound.play(path: CompletionSound.defaultPath)
+
+        CompletionSound.stopLingering()
+        // Read outside the macro: the expansion cannot carry the
+        // non-copyable mutex.
+        let drained = CompletionSound.lingering.withLock(\.isEmpty)
+        #expect(drained)
+
+        // A drain with nothing playing is a quiet no-op.
+        CompletionSound.stopLingering()
+        let still = CompletionSound.lingering.withLock(\.isEmpty)
+        #expect(still)
+    }
 }


### PR DESCRIPTION
- One `EditorPane` now fills two slots, the utility pane's Editor tab and the centre pane, each persisting its own finder and open file under `EditorPane.Role`-suffixed defaults keys, so two mounted editors never answer one request twice.
- The centre editor is a branch of `primary(for:)` below every session-shaped branch: a live session can never sit under an editor, by construction rather than policy. Directories of your own become the same mechanism, pinned to the centre slot, which retires the tab-strip hiding and the editor-to-review remap.
- Editor buttons on the repository page, a worktree's conversations and the create-session pane open the centre slot; a header button goes back. The create-pane one clears the form marker, which would otherwise outrank the editor and make the click a no-op.
- Openers write untargeted keys; `RootView+EditorRouting` resolves each open-file and finder-focus request to the side editor unless the centre editor is on screen, and always to the slot already holding the file, so one file never opens twice. `WaitingEdits` asks the same question before taking the utility pane over.
- A session appearing externally (`agentide new`, a phone, a resume) closes the centre editor and moves its file to the side editor; `FileEditorView` saves on its way off screen, so displacement, worktree switches and moves cannot lose typing, while Close stays the one deliberate discard and a file a command waits on is never written behind its back.
- `listFiles` coalesces per worktree through `FileListings`: the two slots mounting together share one ripgrep run.