### PR TITLE
Measure diff hunks without resizing them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,17 +188,21 @@ Hard-won on macOS 27 beta; check before assuming they expired.
   the window" (Update Constraints overflows the same way). Measure
   on a container with no view attached, held as the coordinator.
   Nothing in the crash report names the app, and the reason is lost
-  to `objc_exception_rethrow`; `log show --predicate 'process ==
-  "AgentIDE"' --info` around the crash has it. The symptoms lie
-  about the cause: the scroll view's document flipped between
-  480 x 222 and 463 x 6567, a scroller's width apart, so both
-  `.scrollIndicators(.never)` and macOS's overlay scrollers ("Show
-  scroll bars: When scrolling") stopped the crash without touching
-  it. What found it: swapping `-[NSView
-  setNeedsUpdateConstraints:]` for a counting version, resetting the
-  count each run-loop turn, and dumping every scroll view's frames
-  and the live stack once a turn passed forty. The offending frame
-  was ten deep in the fourth dump.
+  to `objc_exception_rethrow`; the log around the crash has it:
+
+  ```bash
+  log show --predicate 'process == "AgentIDE"' --info
+  ```
+
+  The symptoms lie about the cause: the scroll view's document
+  flipped between 480 x 222 and 463 x 6567, a scroller's width
+  apart, so both `.scrollIndicators(.never)` and macOS's overlay
+  scrollers ("Show scroll bars: When scrolling") stopped the crash
+  without touching it. What found it: swapping
+  `-[NSView setNeedsUpdateConstraints:]` for a counting version,
+  resetting the count each run-loop turn, and dumping every scroll
+  view's frames and the live stack once a turn passed forty. The
+  offending frame was ten deep in the fourth dump.
 - Toolbars need a non-empty `.principal` item and one trailing
   `ToolbarItemGroup`, or items reflow to the leading edge; segmented
   pickers in toolbars also move unpredictably, so tabs are buttons.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,29 @@ Hard-won on macOS 27 beta; check before assuming they expired.
   by default and paint over sibling rows in the titlebar band;
   pass `ignoresSafeAreaEdges: []` inside panes that ignore the
   top safe area.
+- An `NSViewRepresentable` whose `sizeThatFits` lays out the live
+  view hangs the window and then kills it. `DiffHunkTextView` set
+  its own text view's container size and called `ensureLayout` on
+  its layout manager; a text view that is vertically resizable and
+  tracks its container gets resized by that, so the measurement
+  invalidated layout, SwiftUI asked again, and the display cycle
+  never finished. AppKit gives up with `NSGenericException`,
+  "marked as needing another Display Window pass, but it has
+  already had more Display Window passes than there are views in
+  the window" (Update Constraints overflows the same way). Measure
+  on a container with no view attached, held as the coordinator.
+  Nothing in the crash report names the app, and the reason is lost
+  to `objc_exception_rethrow`; `log show --predicate 'process ==
+  "AgentIDE"' --info` around the crash has it. The symptoms lie
+  about the cause: the scroll view's document flipped between
+  480 x 222 and 463 x 6567, a scroller's width apart, so both
+  `.scrollIndicators(.never)` and macOS's overlay scrollers ("Show
+  scroll bars: When scrolling") stopped the crash without touching
+  it. What found it: swapping `-[NSView
+  setNeedsUpdateConstraints:]` for a counting version, resetting the
+  count each run-loop turn, and dumping every scroll view's frames
+  and the live stack once a turn passed forty. The offending frame
+  was ten deep in the fourth dump.
 - Toolbars need a non-empty `.principal` item and one trailing
   `ToolbarItemGroup`, or items reflow to the leading edge; segmented
   pickers in toolbars also move unpredictably, so tabs are buttons.

--- a/Sources/ReviewFeature/DiffHunkTextView.swift
+++ b/Sources/ReviewFeature/DiffHunkTextView.swift
@@ -73,17 +73,65 @@ struct DiffHunkTextView: NSViewRepresentable {
         }
     }
 
-    func sizeThatFits(_ proposal: ProposedViewSize, nsView: HunkTextView, context _: Context) -> CGSize? {
-        guard let width = proposal.width, width > 0,
-              let container = nsView.textContainer, let layout = nsView.layoutManager
-        else {
+    func makeCoordinator() -> HunkMeasurer {
+        HunkMeasurer()
+    }
+
+    /// Measured off the view: laying out its own container resizes
+    /// it, and a measurement that resizes what it measures loops
+    /// until AppKit kills the window (see AGENTS.md).
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView _: HunkTextView, context: Context) -> CGSize? {
+        guard let width = proposal.width, width > 0 else {
             return nil
         }
 
-        container.size = NSSize(width: width, height: .greatestFiniteMagnitude)
-        layout.ensureLayout(for: container)
-        return CGSize(width: width, height: layout.usedRect(for: container).height)
+        return CGSize(width: width, height: context.coordinator.height(of: text, width: width))
     }
+}
+
+// MARK: - HunkMeasurer
+
+/// A layout stack with no view attached, so laying it out resizes
+/// nothing. One per hunk, held as its coordinator, so hunks do not
+/// evict each other's layout.
+final class HunkMeasurer {
+    // MARK: Lifecycle
+
+    deinit {
+        // The layout stack owns nothing outside itself.
+    }
+
+    init() {
+        container.lineFragmentPadding = 0
+        layout.addTextContainer(container)
+        storage.addLayoutManager(layout)
+    }
+
+    // MARK: Internal
+
+    func height(of text: NSAttributedString, width: CGFloat) -> CGFloat {
+        if measured !== text {
+            storage.setAttributedString(text)
+            measured = text
+        }
+
+        if container.size.width != width {
+            container.size = NSSize(width: width, height: .greatestFiniteMagnitude)
+        }
+
+        layout.ensureLayout(for: container)
+        return layout.usedRect(for: container).height
+    }
+
+    // MARK: Private
+
+    private let storage: NSTextStorage = .init()
+    private let layout: NSLayoutManager = .init()
+    private let container: NSTextContainer = .init(size: NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude))
+
+    /// Compared by identity, since hunks are memoised by content
+    /// upstream and an equal instance costs only a relayout.
+    private var measured: NSAttributedString?
 }
 
 // MARK: - HunkTextView

--- a/Sources/ReviewFeature/DiffHunkTextView.swift
+++ b/Sources/ReviewFeature/DiffHunkTextView.swift
@@ -110,9 +110,11 @@ final class HunkMeasurer {
     // MARK: Internal
 
     func height(of text: NSAttributedString, width: CGFloat) -> CGFloat {
-        if measured !== text {
+        // Compared by content, as `updateNSView` compares: the hunk's
+        // text is built afresh per render, so an identity check never
+        // matched and every measurement relaid the hunk out.
+        if storage.isEqual(to: text) == false {
             storage.setAttributedString(text)
-            measured = text
         }
 
         if container.size.width != width {
@@ -128,10 +130,6 @@ final class HunkMeasurer {
     private let storage: NSTextStorage = .init()
     private let layout: NSLayoutManager = .init()
     private let container: NSTextContainer = .init(size: NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude))
-
-    /// Compared by identity, since hunks are memoised by content
-    /// upstream and an equal instance costs only a relayout.
-    private var measured: NSAttributedString?
 }
 
 // MARK: - HunkTextView


### PR DESCRIPTION
 - Opening the review pane on a branch or last-commit scope hung the window and then killed it in certain circumstances: `DiffHunkTextView.sizeThatFits` set the live text view's container size and called `ensureLayout` on its layout manager, and a text view that is vertically resizable and tracks its container's width is resized by that. The measurement invalidated layout, SwiftUI asked for a size again, and the window's display cycle never finished. AppKit gives up with `NSGenericException`, "marked as needing another Display Window pass, but it has already had more Display Window passes than there are views in the window".
  - Hunks are now measured on a text storage, layout manager and container of their own, with no view attached, so nothing is resized by being asked how tall it is.
  - Only history hunks draw as one selectable text; uncommitted ones are line-by-line fields, which is why the crash followed the worktrees under branch review and left the others alone.