### PR TITLE
Commit selected files with improved directory handling and draft PR icon

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -625,6 +625,12 @@ selects the worktree holding it, and `agentide new` starts a session.
   mergeability, a review or comment arriving, unpushed counts --
   changes with nothing happening in the app, so the intervals that
   keep an idle tab quiet must not answer a click.
+- **A draft's one action is to stop being one.** GitHub refuses to
+  merge a draft and refuses automerge on one too, so the merge
+  button reads "Mark ready" while a pull request is a draft and runs
+  `gh pr ready`; the next click is the Merge, Queue or Automerge it
+  would always have been. Nothing is cleaned up behind it, since
+  nothing merged.
 - **A pull request can open as a draft**, chosen by the icon beside
   Open PR: GitHub's two glyphs for the state a click is about to
   create, rather than a checkbox saying the same thing in words.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -644,6 +644,15 @@ selects the worktree holding it, and `agentide new` starts a session.
   no entitlement that declines these prompts in advance: the
   `NS*UsageDescription` strings in `project.yml` decide only what a
   prompt says, so the app's answer is to not look.
+- **Amend adds to the commit before rather than making a new one.**
+  On the uncommitted scope it folds the ticked files into the last
+  commit and keeps its message, since the editor above the button is
+  drafting the *next* commit's message, not rewriting this one's; on
+  the scopes that show a commit it goes on doing what it always did
+  and rewrites that message. The fold names its paths on the amend
+  itself, so the last commit's tree plus those paths is what lands
+  and anything else staged or uncommitted stays where it was. A
+  commit already pushed needs pushing again, which the lease covers.
 - **A commit can take some of the files, not all of them.** Every
   uncommitted file's row carries a tick, all ticked to begin with, and
   the button says what a click will carry ("Commit 3 of 7"). The model

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -625,6 +625,16 @@ selects the worktree holding it, and `agentide new` starts a session.
   mergeability, a review or comment arriving, unpushed counts --
   changes with nothing happening in the app, so the intervals that
   keep an idle tab quiet must not answer a click.
+- **A commit can take some of the files, not all of them.** Every
+  uncommitted file's row carries a tick, all ticked to begin with, and
+  the button says what a click will carry ("Commit 3 of 7"). The model
+  holds what is *unticked*, so a file the agent writes while the pane
+  is open joins the commit rather than being silently dropped. A
+  selective commit stages the named paths and names them again on the
+  commit, so whatever else was staged stays staged; ticking everything
+  goes back to `add -A`, since a commit of everything must sweep up
+  what the diff never listed. The drafted message is used when there
+  is one, and the menu command's own wording when there is not.
 - **The editor reads like a code editor**: page guides at columns 80
   and 118 drawn under the text (`EditingTextView.drawBackground`),
   and a change bar down the gutter's inner edge for every line with

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -625,6 +625,12 @@ selects the worktree holding it, and `agentide new` starts a session.
   mergeability, a review or comment arriving, unpushed counts --
   changes with nothing happening in the app, so the intervals that
   keep an idle tab quiet must not answer a click.
+- **A pull request can open as a draft**, chosen by the form's own
+  icon: GitHub's two glyphs for the state it is about to create,
+  rather than a checkbox saying the same thing in words. The choice
+  is kept with the rest of the form's draft, so leaving the tab and
+  coming back finds the same intention, and the row the creation
+  paints carries the draft glyph before any fetch has been near it.
 - **Nothing is stat'd that macOS would ask permission for.** A
   directory of your own can be anywhere: inside Documents, on a
   network volume, on a disk that is not mounted. macOS asks the user

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -625,6 +625,17 @@ selects the worktree holding it, and `agentide new` starts a session.
   mergeability, a review or comment arriving, unpushed counts --
   changes with nothing happening in the app, so the intervals that
   keep an idle tab quiet must not answer a click.
+- **Nothing is stat'd that macOS would ask permission for.** A
+  directory of your own can be anywhere: inside Documents, on a
+  network volume, on a disk that is not mounted. macOS asks the user
+  before a non-sandboxed app reads any of those and asks again the
+  next time, so only the selected one is read from disk; every other
+  row paints from what it last said (`HostFactsCache`). The
+  home-directory sweep a repository deletion runs skips the guarded
+  folders by name rather than reading and discarding them. There is
+  no entitlement that declines these prompts in advance: the
+  `NS*UsageDescription` strings in `project.yml` decide only what a
+  prompt says, so the app's answer is to not look.
 - **A commit can take some of the files, not all of them.** Every
   uncommitted file's row carries a tick, all ticked to begin with, and
   the button says what a click will carry ("Commit 3 of 7"). The model

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -625,9 +625,11 @@ selects the worktree holding it, and `agentide new` starts a session.
   mergeability, a review or comment arriving, unpushed counts --
   changes with nothing happening in the app, so the intervals that
   keep an idle tab quiet must not answer a click.
-- **A pull request can open as a draft**, chosen by the form's own
-  icon: GitHub's two glyphs for the state it is about to create,
-  rather than a checkbox saying the same thing in words. The choice
+- **A pull request can open as a draft**, chosen by the icon beside
+  Open PR: GitHub's two glyphs for the state a click is about to
+  create, rather than a checkbox saying the same thing in words.
+  It sits in the footer's own row, with the actions, since that is
+  where the button it changes is. The choice
   is kept with the rest of the form's draft, so leaving the tab and
   coming back finds the same intention, and the row the creation
   paints carries the draft glyph before any fetch has been near it.
@@ -652,6 +654,17 @@ selects the worktree holding it, and `agentide new` starts a session.
   goes back to `add -A`, since a commit of everything must sweep up
   what the diff never listed. The drafted message is used when there
   is one, and the menu command's own wording when there is not.
+- **A hunk lays out in the engine that measured it.** The review's
+  hunks are measured off screen (`HunkMeasurer`) because laying out
+  a view's own container resizes it, and a measurement that resizes
+  what it measures loops until AppKit kills the window. Both sides
+  must therefore be TextKit 1: `NSTextView(frame:)` builds a
+  TextKit 2 view that downgrades itself the first time anything asks
+  for its `layoutManager`, and the two engines do not always break
+  the same text into the same lines, so the height measured was not
+  the height drawn and hunks painted over one another. Each hunk
+  also clips to its own frame, so a wrong height can never take the
+  file below it with it.
 - **The editor reads like a code editor**: page guides at columns 80
   and 118 drawn under the text (`EditingTextView.drawBackground`),
   and a change bar down the gutter's inner edge for every line with

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ In workflow order; the loop from prompt to review repeats before shipping.
 - Opens a pull request as a draft or ready for review, chosen by the
   icon the row will carry (so an agent's first attempt can go up as
   something to read rather than something to merge)
+- Adds the ticked files to the previous commit instead of making a new
+  one, keeping its message (so a fix to what an agent just committed
+  lands in the commit it belongs to)
 - Commits some of the uncommitted files rather than all of them, ticking
   the ones to take and drafting the message beside them (so one agent's
   worktree can land as more than one commit)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ In workflow order; the loop from prompt to review repeats before shipping.
   fact (checks a dot, approval a tick, changes requested a diff, a conflict
   a warning), its checks and queued merges watched until they settle (so
   the sidebar is the dashboard and no two badges look alike)
+- Commits some of the uncommitted files rather than all of them, ticking
+  the ones to take and drafting the message beside them (so one agent's
+  worktree can land as more than one commit)
 - Edits with syntax highlighting, `.editorconfig` indentation, page guides
   at columns 80 and 118 and a change bar beside every uncommitted line
   (so the editor says what is yours before the diff does)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ In workflow order; the loop from prompt to review repeats before shipping.
   fact (checks a dot, approval a tick, changes requested a diff, a conflict
   a warning), its checks and queued merges watched until they settle (so
   the sidebar is the dashboard and no two badges look alike)
+- Opens a pull request as a draft or ready for review, chosen by the
+  icon the row will carry (so an agent's first attempt can go up as
+  something to read rather than something to merge)
 - Commits some of the uncommitted files rather than all of them, ticking
   the ones to take and drafting the message beside them (so one agent's
   worktree can land as more than one commit)

--- a/Sources/AgentIDEData/GitClient+Committing.swift
+++ b/Sources/AgentIDEData/GitClient+Committing.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Making commits: everything, some named paths, or folded into
 /// the commit before. Split from the client for length.
 public extension GitClient {

--- a/Sources/AgentIDEData/GitClient+Committing.swift
+++ b/Sources/AgentIDEData/GitClient+Committing.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Making commits: everything, some named paths, or folded into
+/// the commit before. Split from the client for length.
+public extension GitClient {
+    /// Stages everything and commits it.
+    func commitAll(worktreePath: String, message: String) async throws {
+        try await git(["add", "-A"], in: worktreePath)
+        try await git(["commit", "-m", message], in: worktreePath)
+    }
+
+    /// Commits named paths and leaves the rest of the worktree
+    /// alone. The paths are staged first, since a commit given a
+    /// pathspec refuses a path git has never seen, and named again
+    /// on the commit, so whatever else was staged stays staged: a
+    /// selective commit must not sweep up what the agent left in
+    /// the index.
+    func commit(worktreePath: String, paths: [String], message: String) async throws {
+        guard paths.isEmpty == false else {
+            return
+        }
+
+        try await git(["add", "--"] + paths, in: worktreePath)
+        try await git(["commit", "-m", message, "--"] + paths, in: worktreePath)
+    }
+
+    /// Amends the last commit, optionally replacing its message.
+    func amend(worktreePath: String, message: String?) async throws {
+        var arguments = ["commit", "--amend"]
+        if let message {
+            arguments += ["-m", message]
+        } else {
+            arguments.append("--no-edit")
+        }
+        try await git(arguments, in: worktreePath)
+    }
+
+    /// Folds named paths into the last commit, keeping everything
+    /// else where it is. The paths are staged first, since a commit
+    /// given a pathspec refuses a path git has never seen, and named
+    /// again on the amend, which then takes the last commit's tree
+    /// plus those paths' working-tree state: anything else already
+    /// staged stays staged, and anything else uncommitted stays
+    /// uncommitted.
+    func amend(worktreePath: String, paths: [String], message: String?) async throws {
+        guard paths.isEmpty == false else {
+            try await git(["add", "-A"], in: worktreePath)
+            try await amend(worktreePath: worktreePath, message: message)
+            return
+        }
+
+        try await git(["add", "--"] + paths, in: worktreePath)
+        let wording = message.map { ["-m", $0] } ?? ["--no-edit"]
+        try await git(["commit", "--amend"] + wording + ["--"] + paths, in: worktreePath)
+    }
+}

--- a/Sources/AgentIDEData/GitClient.swift
+++ b/Sources/AgentIDEData/GitClient.swift
@@ -254,17 +254,6 @@ public struct GitClient: Sendable {
         try await git(["apply", "-R", "--index", url.path], in: worktreePath)
     }
 
-    /// Amends the last commit, optionally replacing its message.
-    public func amend(worktreePath: String, message: String?) async throws {
-        var arguments = ["commit", "--amend"]
-        if let message {
-            arguments += ["-m", message]
-        } else {
-            arguments.append("--no-edit")
-        }
-        try await git(arguments, in: worktreePath)
-    }
-
     /// The last commit's subject and body.
     public func lastCommitMessage(worktreePath: String) async throws -> String {
         try await commitMessage(worktreePath: worktreePath, commit: "HEAD")
@@ -275,27 +264,6 @@ public struct GitClient: Sendable {
         try await git(["log", "-1", "--format=%B", commit], in: worktreePath)
             .standardOutput
             .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    /// Stages everything and commits it.
-    public func commitAll(worktreePath: String, message: String) async throws {
-        try await git(["add", "-A"], in: worktreePath)
-        try await git(["commit", "-m", message], in: worktreePath)
-    }
-
-    /// Commits named paths and leaves the rest of the worktree
-    /// alone. The paths are staged first, since a commit given a
-    /// pathspec refuses a path git has never seen, and named again
-    /// on the commit, so whatever else was staged stays staged: a
-    /// selective commit must not sweep up what the agent left in
-    /// the index.
-    public func commit(worktreePath: String, paths: [String], message: String) async throws {
-        guard paths.isEmpty == false else {
-            return
-        }
-
-        try await git(["add", "--"] + paths, in: worktreePath)
-        try await git(["commit", "-m", message, "--"] + paths, in: worktreePath)
     }
 
     /// Pushes the branch, creating its upstream.

--- a/Sources/AgentIDEData/GitClient.swift
+++ b/Sources/AgentIDEData/GitClient.swift
@@ -283,6 +283,21 @@ public struct GitClient: Sendable {
         try await git(["commit", "-m", message], in: worktreePath)
     }
 
+    /// Commits named paths and leaves the rest of the worktree
+    /// alone. The paths are staged first, since a commit given a
+    /// pathspec refuses a path git has never seen, and named again
+    /// on the commit, so whatever else was staged stays staged: a
+    /// selective commit must not sweep up what the agent left in
+    /// the index.
+    public func commit(worktreePath: String, paths: [String], message: String) async throws {
+        guard paths.isEmpty == false else {
+            return
+        }
+
+        try await git(["add", "--"] + paths, in: worktreePath)
+        try await git(["commit", "-m", message, "--"] + paths, in: worktreePath)
+    }
+
     /// Pushes the branch, creating its upstream.
     /// Removes a worktree and deletes its branch; the archive bundle
     /// keeps the commits recoverable. Pruning drops any stale

--- a/Sources/AgentIDEData/GitHubClient.swift
+++ b/Sources/AgentIDEData/GitHubClient.swift
@@ -150,6 +150,7 @@ public struct GitHubClient: Sendable {
         let arguments = ["pr", "create", "--title", request.title, "--body-file", bodyFile]
             + ["--head", head, "--base", base]
             + request.labels.flatMap { ["--label", $0] }
+            + (request.isDraft ? ["--draft"] : [])
         return try await gh(arguments, in: worktreePath)
             .standardOutput
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -370,31 +371,4 @@ public struct GitHubClient: Sendable {
         }
         return "PENDING"
     }
-}
-
-// MARK: - NewPullRequest
-
-/// What a pull request opens with, apart from where: the form's
-/// title, its body with the template appended, and the labels
-/// picked from the repository's own.
-public struct NewPullRequest: Sendable {
-    // MARK: Lifecycle
-
-    /// Creates the request.
-    public init(title: String, body: String, labels: [String]) {
-        self.title = title
-        self.body = body
-        self.labels = labels
-    }
-
-    // MARK: Public
-
-    /// The title.
-    public let title: String
-
-    /// The body.
-    public let body: String
-
-    /// The labels to attach.
-    public let labels: [String]
 }

--- a/Sources/AgentIDEData/GitHubClient.swift
+++ b/Sources/AgentIDEData/GitHubClient.swift
@@ -168,6 +168,13 @@ public struct GitHubClient: Sendable {
         try await gh(["pr", "merge", String(number), "--disable-auto"], in: repositoryPath)
     }
 
+    /// Takes a pull request out of draft. GitHub refuses to merge
+    /// or automerge a draft at all, so this is the step that has to
+    /// come first rather than an error to report.
+    public func markReady(repositoryPath: String, number: Int) async throws {
+        try await gh(["pr", "ready", String(number)], in: repositoryPath)
+    }
+
     /// Merges a pull request immediately.
     public func merge(repositoryPath: String, number: Int) async throws {
         let flag = await mergeMethodFlag(repositoryPath: repositoryPath)

--- a/Sources/AgentIDEData/HostFacts.swift
+++ b/Sources/AgentIDEData/HostFacts.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Synchronization
+
+// MARK: - HostFacts
+
+/// What one directory of your own last said about itself.
+struct HostFacts: Hashable {
+    /// Whether it was there at all when it was last read.
+    let exists: Bool
+    let branch: String
+    let isDirty: Bool
+    let aheadOfUpstream: Int?
+}
+
+// MARK: - HostFactsCache
+
+/// The facts each directory of your own last gave, so its row keeps
+/// painting while nothing on disk is touched again.
+///
+/// A directory of your own can be anywhere: inside Documents, on a
+/// network volume, on a disk that is not mounted. macOS asks the
+/// user before any of those can be read, and asks again every time,
+/// so AgentIDE reads one only while it is the row in front of you
+/// and remembers what it said for the rest.
+final class HostFactsCache: Sendable {
+    // MARK: Lifecycle
+
+    deinit {
+        // Nothing owned beyond the dictionary.
+    }
+
+    // MARK: Internal
+
+    func facts(of path: String) -> HostFacts? {
+        held.withLock { $0[path] }
+    }
+
+    func remember(_ facts: HostFacts, of path: String) {
+        held.withLock { $0[path] = facts }
+    }
+
+    // MARK: Private
+
+    private let held: Mutex<[String: HostFacts]> = .init([:])
+}

--- a/Sources/AgentIDEData/HostFacts.swift
+++ b/Sources/AgentIDEData/HostFacts.swift
@@ -1,9 +1,13 @@
-import Foundation
 import Synchronization
 
 // MARK: - HostFacts
 
 /// What one directory of your own last said about itself.
+///
+/// `Sendable` by inference rather than by annotation: everything it
+/// holds is, and an internal type gets the conformance for free,
+/// which is why writing it out here is removed again by the
+/// formatter as redundant.
 struct HostFacts: Hashable {
     /// Whether it was there at all when it was last read.
     let exists: Bool

--- a/Sources/AgentIDEData/NewPullRequest.swift
+++ b/Sources/AgentIDEData/NewPullRequest.swift
@@ -1,0 +1,31 @@
+// MARK: - NewPullRequest
+
+/// What a pull request opens with, apart from where: the form's
+/// title, its body with the template appended, and the labels
+/// picked from the repository's own.
+public struct NewPullRequest: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates the request.
+    public init(title: String, body: String, labels: [String], isDraft: Bool = false) {
+        self.title = title
+        self.body = body
+        self.labels = labels
+        self.isDraft = isDraft
+    }
+
+    // MARK: Public
+
+    /// The title.
+    public let title: String
+
+    /// The body.
+    public let body: String
+
+    /// The labels to attach.
+    public let labels: [String]
+
+    /// Whether it opens as a draft: work to read rather than work
+    /// to merge, which is what an agent's first attempt usually is.
+    public let isDraft: Bool
+}

--- a/Sources/AgentIDEData/PullRequestFormDraft.swift
+++ b/Sources/AgentIDEData/PullRequestFormDraft.swift
@@ -4,11 +4,18 @@ public struct PullRequestFormDraft: Codable, Equatable, Sendable {
     // MARK: Lifecycle
 
     /// Creates a draft.
-    public init(title: String, body: String, template: String, labels: [String] = []) {
+    public init(
+        title: String,
+        body: String,
+        template: String,
+        labels: [String] = [],
+        isDraft: Bool = false,
+    ) {
         self.title = title
         self.body = body
         self.template = template
         self.labels = labels
+        self.isDraft = isDraft
     }
 
     /// Drafts saved before labels existed have no key for them.
@@ -18,6 +25,7 @@ public struct PullRequestFormDraft: Codable, Equatable, Sendable {
         body = try container.decode(String.self, forKey: .body)
         template = try container.decode(String.self, forKey: .template)
         labels = try container.decodeIfPresent([String].self, forKey: .labels) ?? []
+        isDraft = try container.decodeIfPresent(Bool.self, forKey: .isDraft) ?? false
     }
 
     // MARK: Public
@@ -33,4 +41,7 @@ public struct PullRequestFormDraft: Codable, Equatable, Sendable {
 
     /// The labels picked for the pull request.
     public let labels: [String]
+
+    /// Whether it is to open as a draft.
+    public let isDraft: Bool
 }

--- a/Sources/AgentIDEData/SessionService+Host.swift
+++ b/Sources/AgentIDEData/SessionService+Host.swift
@@ -7,6 +7,20 @@ import Foundation
 /// sandbox user may well be able to read `/opt/homebrew`, but
 /// AgentIDE must never give it a reason to write to one.
 public extension SessionService {
+    /// The home-directory folders macOS guards, which this app has
+    /// no business reading: a stat inside one asks the user for
+    /// permission, and the answer is asked for again next time.
+    static var guardedFolders: Set<String> {
+        ["Documents", "Desktop", "Downloads", "Movies", "Music", "Pictures"]
+    }
+
+    /// The storage-bus key naming the selected row, which the
+    /// sidebar writes; the only directory of your own worth reading
+    /// from disk is the one in front of you.
+    static var selectedWorktreeKey: String {
+        "selectedWorktreePath"
+    }
+
     /// Lists a directory of your own under a repository.
     func addHostDirectory(_ path: String, to repository: Repository) {
         var listed = store.load().hostDirectories[repository.path] ?? []
@@ -82,40 +96,60 @@ public extension SessionService {
         )
     }
 
-    /// The repository's listed directories, as rows: their branch is
-    /// shown for orientation, and a missing one is dropped rather
-    /// than shown as a row that opens nothing.
+    /// The repository's listed directories, as rows.
+    ///
+    /// Only the selected one is read from disk; the rest are drawn
+    /// from what it last said. A directory of your own can be
+    /// anywhere on the Mac, and macOS guards Documents, Desktop,
+    /// Downloads and every network volume: a poll that stats one of
+    /// those asks the user for permission, and asks again on the
+    /// next poll, for a row nobody was looking at. Nothing here can
+    /// know which paths are guarded, so nothing here touches a path
+    /// the user is not looking at.
     internal func hostItems(of repository: Repository, metadata: AppMetadata) async -> [WorktreeItem] {
+        let listed = metadata.hostDirectories[repository.path] ?? []
+        let selected = UserDefaults.standard.string(forKey: Self.selectedWorktreeKey)
         var items = [WorktreeItem]()
-        let listed = (metadata.hostDirectories[repository.path] ?? [])
-            .filter { FileManager.default.fileExists(atPath: $0) }
-        let branches = await withTaskGroup(of: (String, String).self) { tasks in
-            for path in listed {
-                tasks.addTask { await (path, self.git.currentBranch(worktreePath: path) ?? "") }
-            }
-            var collected = [String: String]()
-            for await (path, branch) in tasks {
-                collected[path] = branch
-            }
-            return collected
-        }
         for path in listed {
-            let branch = branches[path] ?? ""
-            await items.append(WorktreeItem(
+            let facts = path == selected ? await readHostFacts(of: path) : hostFacts.facts(of: path)
+            guard facts?.exists != false else {
+                continue
+            }
+
+            items.append(WorktreeItem(
                 worktree: Worktree(
                     repositoryName: repository.name,
                     repositoryPath: repository.path,
-                    branch: branch,
+                    branch: facts?.branch ?? "",
                     path: path,
                     isHostDirectory: true,
                 ),
                 session: nil,
-                isDirty: git.isDirty(worktreePath: path),
-                aheadOfUpstream: git.aheadOfUpstream(worktreePath: path),
+                isDirty: facts?.isDirty ?? false,
+                aheadOfUpstream: facts?.aheadOfUpstream,
                 hasUnread: false,
             ))
         }
         return items
+    }
+
+    /// Reads one directory of your own and remembers what it said,
+    /// so its row keeps painting while nothing touches it again.
+    private func readHostFacts(of path: String) async -> HostFacts {
+        guard FileManager.default.fileExists(atPath: path) else {
+            let gone = HostFacts(exists: false, branch: "", isDirty: false, aheadOfUpstream: nil)
+            hostFacts.remember(gone, of: path)
+            return gone
+        }
+
+        let facts = await HostFacts(
+            exists: true,
+            branch: git.currentBranch(worktreePath: path) ?? "",
+            isDirty: git.isDirty(worktreePath: path),
+            aheadOfUpstream: git.aheadOfUpstream(worktreePath: path),
+        )
+        hostFacts.remember(facts, of: path)
+        return facts
     }
 
     /// The local branches a worktree could switch to: everything

--- a/Sources/AgentIDEData/SessionService+Host.swift
+++ b/Sources/AgentIDEData/SessionService+Host.swift
@@ -142,12 +142,10 @@ public extension SessionService {
             return gone
         }
 
-        let facts = await HostFacts(
-            exists: true,
-            branch: git.currentBranch(worktreePath: path) ?? "",
-            isDirty: git.isDirty(worktreePath: path),
-            aheadOfUpstream: git.aheadOfUpstream(worktreePath: path),
-        )
+        let branch = await git.currentBranch(worktreePath: path) ?? ""
+        let isDirty = await git.isDirty(worktreePath: path)
+        let ahead = await git.aheadOfUpstream(worktreePath: path)
+        let facts = HostFacts(exists: true, branch: branch, isDirty: isDirty, aheadOfUpstream: ahead)
         hostFacts.remember(facts, of: path)
         return facts
     }

--- a/Sources/AgentIDEData/SessionService+Lifecycle.swift
+++ b/Sources/AgentIDEData/SessionService+Lifecycle.swift
@@ -78,8 +78,13 @@ public extension SessionService {
             try await removeAsSandboxUser(path: repository.path)
         }
         try? FileManager.default.removeItem(atPath: worktreeContainer(repository: repository))
+        // The symlink this app made sits at the top of the home
+        // directory and nowhere else. Guarded folders are skipped by
+        // name rather than read and discarded: reading one is what
+        // asks the user for permission to see their Documents.
         let home = FileManager.default.homeDirectoryForCurrentUser
-        for entry in (try? FileManager.default.contentsOfDirectory(atPath: home.path)) ?? [] {
+        let entries = (try? FileManager.default.contentsOfDirectory(atPath: home.path)) ?? []
+        for entry in entries where Self.guardedFolders.contains(entry) == false {
             let link = home.appending(path: entry).path
             if (try? FileManager.default.destinationOfSymbolicLink(atPath: link)) == repository.path {
                 try? FileManager.default.removeItem(atPath: link)

--- a/Sources/AgentIDEData/SessionService+PullRequests.swift
+++ b/Sources/AgentIDEData/SessionService+PullRequests.swift
@@ -99,7 +99,13 @@ public extension SessionService {
     /// branch as `owner:branch` when it lives in a fork: the pull
     /// request belongs to the repository it is opened against rather
     /// than the one holding the branch.
-    func createPullRequest(worktree: Worktree, title: String, body: String, labels: [String]) async throws -> String {
+    func createPullRequest(
+        worktree: Worktree,
+        title: String,
+        body: String,
+        labels: [String],
+        isDraft: Bool = false,
+    ) async throws -> String {
         // The branch is the caller's, which is the entry whose form
         // was filled in, never whatever the worktree has checked out.
         // A branch opening against the branch below it is what makes
@@ -112,7 +118,7 @@ public extension SessionService {
         let branch = worktree.branch
         return try await github.createPullRequest(
             worktreePath: worktree.path,
-            request: NewPullRequest(title: title, body: body, labels: labels),
+            request: NewPullRequest(title: title, body: body, labels: labels, isDraft: isDraft),
             head: pushDestination(worktree: worktree).head(branch: branch),
             base: base(for: branch, in: stack, of: worktree),
         )

--- a/Sources/AgentIDEData/SessionService+Sessions.swift
+++ b/Sources/AgentIDEData/SessionService+Sessions.swift
@@ -183,6 +183,22 @@ public extension SessionService {
         try await git.commit(worktreePath: worktreePath, paths: paths, message: written)
     }
 
+    /// Folds what the agent left uncommitted into the last commit:
+    /// the named paths alone, or everything when none are named. The
+    /// message is kept as it is, since the editor above the button
+    /// is drafting the next commit's message rather than rewriting
+    /// this one's.
+    func amendOutstanding(worktreePath: String, paths: [String] = []) async throws {
+        guard await git.commitHash(of: "HEAD", worktreePath: worktreePath) != nil else {
+            throw SessionServiceError("There is no commit here yet to add these changes to.")
+        }
+        guard await git.isDirty(worktreePath: worktreePath) else {
+            return
+        }
+
+        try await git.amend(worktreePath: worktreePath, paths: paths, message: nil)
+    }
+
     /// Ends the session's workspace and everything in it, asking
     /// again when the polite close does not take; worktree,
     /// transcript and metadata survive so it stays resumable. The

--- a/Sources/AgentIDEData/SessionService+Sessions.swift
+++ b/Sources/AgentIDEData/SessionService+Sessions.swift
@@ -160,13 +160,27 @@ public extension SessionService {
         }
     }
 
-    /// Commits anything the agent left uncommitted.
-    func commitOutstanding(worktreePath: String) async throws {
+    /// Commits what the agent left uncommitted: the named paths
+    /// alone, or the whole worktree when none are named. An empty
+    /// message takes the wording the menu command has always used,
+    /// so committing without drafting one still says something.
+    func commitOutstanding(
+        worktreePath: String,
+        paths: [String] = [],
+        message: String = "",
+    ) async throws {
         guard await git.isDirty(worktreePath: worktreePath) else {
             return
         }
 
-        try await git.commitAll(worktreePath: worktreePath, message: "Commit outstanding agent work")
+        let wording = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        let written = wording.isEmpty ? "Commit outstanding agent work" : wording
+        guard paths.isEmpty == false else {
+            try await git.commitAll(worktreePath: worktreePath, message: written)
+            return
+        }
+
+        try await git.commit(worktreePath: worktreePath, paths: paths, message: written)
     }
 
     /// Ends the session's workspace and everything in it, asking

--- a/Sources/AgentIDEData/SessionService.swift
+++ b/Sources/AgentIDEData/SessionService.swift
@@ -144,6 +144,11 @@ public struct SessionService: Sendable {
     /// untouched.
     let overwriteTips: OverwriteTips = .init()
 
+    /// See `HostFactsCache`; a default so the public init is
+    /// untouched, and a class so every copy of the service shares
+    /// what each directory of your own last said.
+    let hostFacts: HostFactsCache = .init()
+
     /// See `PaneLoads`; a default so the public init is untouched,
     /// and a class so every copy of the service shares one set of
     /// pane shells and busy spells.

--- a/Sources/PRFeature/PullRequestCreateForm.swift
+++ b/Sources/PRFeature/PullRequestCreateForm.swift
@@ -16,7 +16,6 @@ struct PullRequestCreateForm: View {
                 Text("No open pull request for this branch")
                     .font(.subheadline.weight(.semibold))
                 Spacer()
-                draftToggle
                 generateButton
                 resetButton
             }
@@ -71,29 +70,6 @@ struct PullRequestCreateForm: View {
     /// replace what is being typed.
     private var isBlocked: Bool {
         model.unpushedBelow != nil || model.isOpening || model.isBranchActionRunning
-    }
-
-    /// Opens as a draft or ready for review, in GitHub's own two
-    /// glyphs: an icon rather than a checkbox, since the pull
-    /// request's own state is drawn with these everywhere else in
-    /// the app.
-    private var draftToggle: some View {
-        Button {
-            model.prIsDraft.toggle()
-        } label: {
-            Octicon(
-                ChecksStyle.stateOcticonName(state: "OPEN", isDraft: model.prIsDraft),
-                colour: ChecksStyle.stateColour(state: "OPEN", isDraft: model.prIsDraft),
-            )
-            .accessibilityLabel(model.prIsDraft ? "Opens as a draft" : "Opens ready for review")
-        }
-        .buttonStyle(.plain)
-        .disabled(isGenerating || isBlocked)
-        .hoverHelp(
-            model.prIsDraft
-                ? "Opens as a draft: work to read rather than work to merge. Click to open it ready for review"
-                : "Opens ready for review. Click to open it as a draft instead",
-        )
     }
 
     /// Back to what the commits say. Typed text asks first; blank

--- a/Sources/PRFeature/PullRequestCreateForm.swift
+++ b/Sources/PRFeature/PullRequestCreateForm.swift
@@ -16,6 +16,7 @@ struct PullRequestCreateForm: View {
                 Text("No open pull request for this branch")
                     .font(.subheadline.weight(.semibold))
                 Spacer()
+                draftToggle
                 generateButton
                 resetButton
             }
@@ -70,6 +71,29 @@ struct PullRequestCreateForm: View {
     /// replace what is being typed.
     private var isBlocked: Bool {
         model.unpushedBelow != nil || model.isOpening || model.isBranchActionRunning
+    }
+
+    /// Opens as a draft or ready for review, in GitHub's own two
+    /// glyphs: an icon rather than a checkbox, since the pull
+    /// request's own state is drawn with these everywhere else in
+    /// the app.
+    private var draftToggle: some View {
+        Button {
+            model.prIsDraft.toggle()
+        } label: {
+            Octicon(
+                ChecksStyle.stateOcticonName(state: "OPEN", isDraft: model.prIsDraft),
+                colour: ChecksStyle.stateColour(state: "OPEN", isDraft: model.prIsDraft),
+            )
+            .accessibilityLabel(model.prIsDraft ? "Opens as a draft" : "Opens ready for review")
+        }
+        .buttonStyle(.plain)
+        .disabled(isGenerating || isBlocked)
+        .hoverHelp(
+            model.prIsDraft
+                ? "Opens as a draft: work to read rather than work to merge. Click to open it ready for review"
+                : "Opens ready for review. Click to open it as a draft instead",
+        )
     }
 
     /// Back to what the commits say. Typed text asks first; blank

--- a/Sources/PRFeature/PullRequestListView.swift
+++ b/Sources/PRFeature/PullRequestListView.swift
@@ -160,6 +160,7 @@ struct PullRequestFooterView: View {
             }
             Spacer()
             if model.needsCreateForm {
+                draftToggle
                 openButton
             }
             if model.isStackedEntry {
@@ -176,6 +177,28 @@ struct PullRequestFooterView: View {
         }
         .padding(Self.padding)
         .background(.bar)
+    }
+
+    /// Whether the pull request opens as a draft, beside the button
+    /// that opens it: GitHub's own two glyphs for the state a click
+    /// is about to create, in the colour the row will carry, rather
+    /// than a checkbox saying the same thing in words.
+    var draftToggle: some View {
+        Button {
+            model.prIsDraft.toggle()
+        } label: {
+            Octicon(
+                ChecksStyle.stateOcticonName(state: "OPEN", isDraft: model.prIsDraft),
+                colour: ChecksStyle.stateColour(state: "OPEN", isDraft: model.prIsDraft),
+            )
+            .accessibilityLabel(model.prIsDraft ? "Opens as a draft" : "Opens ready for review")
+        }
+        .buttonStyle(.glass)
+        .hoverHelp(
+            model.prIsDraft
+                ? "Opens as a draft: work to read rather than work to merge. Click to open it ready for review"
+                : "Opens ready for review. Click to open it as a draft instead",
+        )
     }
 
     var rebaseButton: some View {

--- a/Sources/PRFeature/PullRequestsModel+Branch.swift
+++ b/Sources/PRFeature/PullRequestsModel+Branch.swift
@@ -144,6 +144,12 @@ extension PullRequestsModel {
             return nil
         }
 
+        // A draft cannot be merged or queued, and GitHub refuses
+        // automerge on one too: what a click can do here is take it
+        // out of draft, and the label says so.
+        if selected.isDraft {
+            return "Mark ready"
+        }
         if selected.hasAutomerge {
             return hasMergeQueue ? "Dequeue" : "Cancel automerge"
         }
@@ -156,6 +162,9 @@ extension PullRequestsModel {
     /// The present-tense form while the merge action runs.
     var mergeActionBusyTitle: String {
         switch mergeActionTitle {
+        case "Mark ready":
+            "Marking ready"
+
         case "Dequeue":
             "Dequeuing"
 

--- a/Sources/PRFeature/PullRequestsModel+Create.swift
+++ b/Sources/PRFeature/PullRequestsModel+Create.swift
@@ -27,7 +27,7 @@ extension PullRequestsModel {
         isOpening = true
         defer { isOpening = false }
         do {
-            let url = try await performCreate(worktree, title, body, prLabels)
+            let url = try await performCreate(worktree, title, body, prLabels, prIsDraft)
             note("Opened pull request " + url)
             // A stack is built one pull request at a time: each one
             // links what is open into the stack, and failing to link
@@ -54,6 +54,7 @@ extension PullRequestsModel {
                 worktree: worktree,
                 base: defaultBranch,
                 listed: summaries,
+                isDraft: prIsDraft,
             )
             if let created {
                 cacheCreated(created, branch: worktree.branch)
@@ -124,6 +125,7 @@ extension PullRequestsModel {
         worktree: Worktree,
         base: String?,
         listed: [PullRequestSummary],
+        isDraft: Bool = false,
     ) -> PullRequestSummary? {
         guard let number = number(inURL: url) else {
             return nil
@@ -142,6 +144,7 @@ extension PullRequestsModel {
             checks: "",
             baseBranch: base ?? "",
             state: "OPEN",
+            isDraft: isDraft,
         )
     }
 

--- a/Sources/PRFeature/PullRequestsModel+Draft.swift
+++ b/Sources/PRFeature/PullRequestsModel+Draft.swift
@@ -99,6 +99,7 @@ extension PullRequestsModel {
                 body: prBody,
                 template: prTemplate,
                 labels: prLabels,
+                isDraft: prIsDraft,
             )
         }
     }
@@ -127,6 +128,7 @@ extension PullRequestsModel {
         if prLabels.isEmpty {
             prLabels = draft.labels
         }
+        prIsDraft = draft.isDraft
         loadingDraft = false
         // What was already typed may be newer than the draft, so the
         // draft is brought back up to date rather than left behind.

--- a/Sources/PRFeature/PullRequestsModel+Listing.swift
+++ b/Sources/PRFeature/PullRequestsModel+Listing.swift
@@ -3,6 +3,21 @@ import AgentIDEDomain
 /// What the tab is listing and how it asks for it. Split from the
 /// model for length.
 extension PullRequestsModel {
+    /// Takes the cache's summary for the selected pull request and
+    /// every listed row, so what the sidebar just learnt shows here
+    /// too; the cache is written by whichever side fetched last.
+    func repaintFromCache() {
+        if let selected,
+           let cached = pullRequests.cachedSummary(repositoryPath: repository.path, number: selected.number),
+           cached != selected
+        {
+            self.selected = cached
+        }
+        summaries = summaries.map { row in
+            pullRequests.cachedSummary(repositoryPath: repository.path, number: row.number) ?? row
+        }
+    }
+
     /// The branch the tab lists and compares against: the checked
     /// out one when known, the worktree's recorded one otherwise.
     var listedBranch: String? {

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -127,7 +127,9 @@ final class PullRequestsModel {
         }
         performMergeChange = { summary in
             defer { gate.invalidate(repositoryPath: repository.path, number: summary.number) }
-            if summary.hasAutomerge {
+            if summary.isDraft {
+                try await github.markReady(repositoryPath: repository.path, number: summary.number)
+            } else if summary.hasAutomerge {
                 try await github.disableAutomerge(repositoryPath: repository.path, number: summary.number)
             } else if Self.isReadyToMerge(summary) {
                 try await github.merge(repositoryPath: repository.path, number: summary.number)

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -66,8 +66,14 @@ final class PullRequestsModel {
             }
             return answer?.threads ?? []
         }
-        performCreate = { worktree, title, body, labels in
-            try await service.createPullRequest(worktree: worktree, title: title, body: body, labels: labels)
+        performCreate = { worktree, title, body, labels, isDraft in
+            try await service.createPullRequest(
+                worktree: worktree,
+                title: title,
+                body: body,
+                labels: labels,
+                isDraft: isDraft,
+            )
         }
         fetchLabels = {
             await github.labels(repositoryPath: repository.path)
@@ -273,7 +279,7 @@ final class PullRequestsModel {
     var fetchSummary: (Int) async throws -> PullRequestSummary?
     var fetchHasMergeQueue: () async -> Bool
     var fetchThreads: (Int) async -> [ReviewThread]
-    var performCreate: (Worktree, String, String, [String]) async throws -> String
+    var performCreate: (Worktree, String, String, [String], Bool) async throws -> String
 
     /// The repository's labels, read once per model when the form
     /// first needs them.
@@ -359,6 +365,11 @@ final class PullRequestsModel {
         didSet { saveDraft() }
     }
 
+    /// See `PullRequestsModel+Create`: whether it opens as a draft.
+    var prIsDraft = false {
+        didSet { saveDraft() }
+    }
+
     /// The repository's worktree items, refreshed by the view as the
     /// dashboard polls. The pushed mark outlives a refresh: it is
     /// the branch's tip moving that clears it, read with the other
@@ -370,21 +381,6 @@ final class PullRequestsModel {
             // into the shared cache since these rows were painted.
             repaintFromCache()
             reverifyBranchFacts(from: oldValue)
-        }
-    }
-
-    /// Takes the cache's summary for the selected pull request and
-    /// every listed row, so what the sidebar just learnt shows here
-    /// too; the cache is written by whichever side fetched last.
-    func repaintFromCache() {
-        if let selected,
-           let cached = pullRequests.cachedSummary(repositoryPath: repository.path, number: selected.number),
-           cached != selected
-        {
-            self.selected = cached
-        }
-        summaries = summaries.map { row in
-            pullRequests.cachedSummary(repositoryPath: repository.path, number: row.number) ?? row
         }
     }
 }

--- a/Sources/ReviewFeature/DiffFileView+Committing.swift
+++ b/Sources/ReviewFeature/DiffFileView+Committing.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import TerminalUI
+
+/// The per-file commit tick; split from the file view for
+/// length.
+extension DiffFileView {
+    /// The tick that says whether this file joins the next commit,
+    /// shown only where a commit can happen at all.
+    @ViewBuilder var commitTick: some View {
+        if model.showsUncommitted, model.isReadOnly == false {
+            Toggle(
+                "Commit this file",
+                isOn: Binding(
+                    get: { model.isCommitting(file.path) },
+                    set: { model.setCommitting($0, path: file.path) },
+                ),
+            )
+            .toggleStyle(.checkbox)
+            .labelsHidden()
+            .hoverHelp("Include this file in the next commit")
+        }
+    }
+}

--- a/Sources/ReviewFeature/DiffFileView.swift
+++ b/Sources/ReviewFeature/DiffFileView.swift
@@ -191,6 +191,7 @@ struct DiffFileView: View {
     /// copy and edit actions.
     private var headerRow: some View {
         HStack {
+            commitTick
             FileCollapseCaret(isCollapsed: isCollapsed, onToggle: onToggleCollapse)
             Text(file.path).font(.headline.monospaced())
             if file.isNew {

--- a/Sources/ReviewFeature/DiffHunkTextView.swift
+++ b/Sources/ReviewFeature/DiffHunkTextView.swift
@@ -51,7 +51,19 @@ struct DiffHunkTextView: NSViewRepresentable {
     let onToggleLine: (Int) -> Void
 
     func makeNSView(context _: Context) -> HunkTextView {
-        let view = HunkTextView(frame: .zero)
+        // A hand-built TextKit 1 stack, the same one the measurer
+        // lays out in. `NSTextView(frame:)` builds a TextKit 2 view
+        // whose `layoutManager` (which the gutter's clicks ask for)
+        // silently downgrades it to TextKit 1 later, and the two
+        // engines do not always break the same text into the same
+        // lines: the height measured here was then not the height
+        // drawn, and hunks painted over one another.
+        let storage = NSTextStorage()
+        let layout = NSLayoutManager()
+        storage.addLayoutManager(layout)
+        let container = NSTextContainer(size: NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude))
+        layout.addTextContainer(container)
+        let view = HunkTextView(frame: .zero, textContainer: container)
         view.isEditable = false
         view.isSelectable = true
         view.drawsBackground = false
@@ -61,6 +73,11 @@ struct DiffHunkTextView: NSViewRepresentable {
         view.isVerticallyResizable = true
         view.isHorizontallyResizable = false
         view.autoresizingMask = []
+        // Whatever the measurement says, a hunk may never draw
+        // outside its own frame: unclipped, one wrong height took
+        // the file below it with it.
+        view.wantsLayer = true
+        view.layer?.masksToBounds = true
         return view
     }
 

--- a/Sources/ReviewFeature/ReviewFooterView.swift
+++ b/Sources/ReviewFeature/ReviewFooterView.swift
@@ -72,6 +72,28 @@ struct ReviewFooterView: View {
     private var messageHeight = 150.0
     @State private var messageDragBase: Double?
 
+    /// The button's own words: everything, or the count that is
+    /// ticked, so what a click is about to commit is on the button.
+    private var commitTitle: String {
+        let committing = model.committingCount
+        guard committing < model.files.count else {
+            return "Commit"
+        }
+
+        return "Commit " + String(committing) + " of " + String(model.files.count)
+    }
+
+    private var commitHelp: String {
+        guard model.committingCount > 0 else {
+            return "Tick the files to commit; every file is ticked to begin with"
+        }
+        guard model.pathsToCommit.isEmpty else {
+            return "Commit the ticked files, leaving the rest uncommitted"
+        }
+
+        return "Commit everything uncommitted; enabled on the uncommitted scope with changes"
+    }
+
     private var subjectBinding: Binding<String> {
         Binding(
             get: { Self.subject(of: model.commitMessage) },
@@ -123,13 +145,13 @@ struct ReviewFooterView: View {
                 + "only fills an empty message",
         )
         BusyButton(
-            "Commit",
+            commitTitle,
             busy: "Committing",
-            disabled: canCommit == false,
+            disabled: canCommit == false || model.committingCount == 0,
             keepsTitle: true,
             action: onCommit,
         )
-        .hoverHelp("Commit everything uncommitted; enabled on the uncommitted scope with changes")
+        .hoverHelp(commitHelp)
         BusyButton(
             "Amend",
             busy: "Amending",

--- a/Sources/ReviewFeature/ReviewFooterView.swift
+++ b/Sources/ReviewFeature/ReviewFooterView.swift
@@ -15,6 +15,9 @@ struct ReviewFooterView: View {
     /// Commits everything the agent left uncommitted.
     let onCommit: @MainActor () async -> Void
 
+    /// Adds it to the last commit instead.
+    let onAmend: @MainActor () async -> Void
+
     /// Whether Commit applies: the uncommitted scope with changes.
     let canCommit: Bool
 
@@ -71,6 +74,30 @@ struct ReviewFooterView: View {
     @AppStorage("reviewMessageHeight")
     private var messageHeight = 150.0
     @State private var messageDragBase: Double?
+
+    /// Amend folds the ticked files into the last commit on the
+    /// uncommitted scope, and rewrites a commit's message on the
+    /// scopes that show one.
+    private var canAmend: Bool {
+        guard model.showsUncommitted else {
+            return model.messageEdited
+        }
+
+        return canCommit && model.committingCount > 0
+    }
+
+    private var amendHelp: String {
+        guard model.showsUncommitted else {
+            return "Rewrite the last commit's message; dimmed until the text differs from it"
+        }
+        guard model.committingCount > 0 else {
+            return "Tick the files to add to the last commit"
+        }
+
+        let count = model.pathsToCommit.isEmpty ? "everything uncommitted" : String(model.committingCount) + " files"
+        return "Add " + count + " to the last commit, keeping its message. "
+            + "A commit already pushed needs Push again, which leases the overwrite"
+    }
 
     /// The button's own words: everything, or the count that is
     /// ticked, so what a click is about to commit is on the button.
@@ -155,9 +182,10 @@ struct ReviewFooterView: View {
         BusyButton(
             "Amend",
             busy: "Amending",
-            disabled: model.showsUncommitted || model.messageEdited == false,
-        ) { await model.saveCommitMessage() }
-            .hoverHelp("Rewrite the last commit's message; dimmed until the text differs from it")
+            disabled: canAmend == false,
+            action: amend,
+        )
+        .hoverHelp(amendHelp)
     }
 
     /// A slim grab area over the divider: dragging resizes the
@@ -295,5 +323,15 @@ struct ReviewFooterView: View {
             .frame(width: 1)
             .offset(x: inset + width * CGFloat(limit))
             .allowsHitTesting(false)
+    }
+
+    /// The uncommitted scope folds files in; the scopes that show a
+    /// commit rewrite its message.
+    private func amend() async {
+        if model.showsUncommitted {
+            await onAmend()
+        } else {
+            await model.saveCommitMessage()
+        }
     }
 }

--- a/Sources/ReviewFeature/ReviewModel+Committing.swift
+++ b/Sources/ReviewFeature/ReviewModel+Committing.swift
@@ -26,6 +26,15 @@ extension ReviewModel {
         files.count { isCommitting($0.path) }
     }
 
+    /// Whether anything is ticked at all. An empty `pathsToCommit`
+    /// says "the whole worktree" to the service, and unticking every
+    /// file empties it too: the menu bar's own Commit does not ask
+    /// the button whether it is dimmed, so the answer has to be
+    /// here rather than in the button's state.
+    var hasSomethingToCommit: Bool {
+        files.isEmpty == false && committingCount > 0
+    }
+
     /// Whether a file is ticked for the next commit.
     func isCommitting(_ path: String) -> Bool {
         excludedFromCommit.contains(path) == false

--- a/Sources/ReviewFeature/ReviewModel+Committing.swift
+++ b/Sources/ReviewFeature/ReviewModel+Committing.swift
@@ -1,0 +1,42 @@
+/// Which uncommitted files the next commit carries; split from the
+/// model for length.
+///
+/// `excludedFromCommit` holds what is left out rather than what is
+/// in, so a file the agent writes while the pane is open joins the
+/// commit instead of being silently dropped from it.
+extension ReviewModel {
+    var isReadOnly: Bool {
+        stackTarget != nil || commitTarget != nil
+    }
+
+    /// The uncommitted files the next commit will carry, in the
+    /// order they are listed. Empty when every file is ticked, which
+    /// is what says "the whole worktree" to the service: a commit of
+    /// everything must also sweep up anything the diff never listed.
+    var pathsToCommit: [String] {
+        guard excludedFromCommit.isEmpty == false else {
+            return []
+        }
+
+        return files.map(\.path).filter { excludedFromCommit.contains($0) == false }
+    }
+
+    /// How many files the next commit carries.
+    var committingCount: Int {
+        files.count { isCommitting($0.path) }
+    }
+
+    /// Whether a file is ticked for the next commit.
+    func isCommitting(_ path: String) -> Bool {
+        excludedFromCommit.contains(path) == false
+    }
+
+    /// Ticks or unticks one file.
+    func setCommitting(_ committing: Bool, path: String) {
+        if committing {
+            excludedFromCommit.remove(path)
+        } else {
+            excludedFromCommit.insert(path)
+        }
+    }
+}

--- a/Sources/ReviewFeature/ReviewModel.swift
+++ b/Sources/ReviewFeature/ReviewModel.swift
@@ -69,6 +69,9 @@ final class ReviewModel {
     /// Whether the diff shows uncommitted changes; rejection amends committed ones only.
     private(set) var showsUncommitted = false
 
+    /// See `ReviewModel+Committing`.
+    var excludedFromCommit: Set<String> = []
+
     /// Set only by the find extension, which recounts them.
     var findTargets: [FindTarget] = []
     var currentFind = 0
@@ -124,24 +127,21 @@ final class ReviewModel {
         didSet { remember(scope) }
     }
 
-    /// Whether what is shown can only be read: a branch this
-    /// worktree does not hold, or a commit further back than the
-    /// last one. Either way rejecting lines or amending would have
-    /// to rewrite history that is not the tip in front of you.
-    var isReadOnly: Bool {
-        stackTarget != nil || commitTarget != nil
+    // Whether what is shown can only be read: a branch this
+    // worktree does not hold, or a commit further back than the
+    // last one. Either way rejecting lines or amending would have
+    // to rewrite history that is not the tip in front of you.
+
+    /// Whether the commit message differs from the commit's actual
+    /// message, so Amend only lights up with something to amend.
+    var messageEdited: Bool {
+        commitMessage != originalMessage
     }
 
     /// The find bar's query; the hunks holding a match and which of
     /// them is showing are derived from it.
     var findQuery = "" {
         didSet { updateFindTargets() }
-    }
-
-    /// Whether the commit message differs from the commit's actual
-    /// message, so Amend only lights up with something to amend.
-    var messageEdited: Bool {
-        commitMessage != originalMessage
     }
 
     /// Flips one conversation's resolved state on GitHub, then

--- a/Sources/ReviewFeature/ReviewView+Commit.swift
+++ b/Sources/ReviewFeature/ReviewView+Commit.swift
@@ -1,9 +1,9 @@
 import AgentIDEData
 import SwiftUI
 
-/// Committing from the review pane: the ticked files, or the
-/// whole worktree when every file is ticked. Split from the view
-/// for length.
+/// Committing from the review pane: the ticked files, or the whole
+/// worktree when every file is ticked. Split from the view for
+/// length.
 extension ReviewView {
     func commitOutstanding(model: ReviewModel) async {
         do {
@@ -12,6 +12,18 @@ extension ReviewView {
                 paths: model.pathsToCommit,
                 message: model.commitMessage,
             )
+            model.excludedFromCommit = []
+            await model.reload()
+        } catch {
+            model.report(error.localizedDescription)
+        }
+    }
+
+    /// Adds what is ticked to the last commit rather than making a
+    /// new one.
+    func amendOutstanding(model: ReviewModel) async {
+        do {
+            try await service.amendOutstanding(worktreePath: worktreePath, paths: model.pathsToCommit)
             model.excludedFromCommit = []
             await model.reload()
         } catch {

--- a/Sources/ReviewFeature/ReviewView+Commit.swift
+++ b/Sources/ReviewFeature/ReviewView+Commit.swift
@@ -1,0 +1,21 @@
+import AgentIDEData
+import SwiftUI
+
+/// Committing from the review pane: the ticked files, or the
+/// whole worktree when every file is ticked. Split from the view
+/// for length.
+extension ReviewView {
+    func commitOutstanding(model: ReviewModel) async {
+        do {
+            try await service.commitOutstanding(
+                worktreePath: worktreePath,
+                paths: model.pathsToCommit,
+                message: model.commitMessage,
+            )
+            model.excludedFromCommit = []
+            await model.reload()
+        } catch {
+            model.report(error.localizedDescription)
+        }
+    }
+}

--- a/Sources/ReviewFeature/ReviewView+Commit.swift
+++ b/Sources/ReviewFeature/ReviewView+Commit.swift
@@ -1,11 +1,15 @@
 import AgentIDEData
-import SwiftUI
 
 /// Committing from the review pane: the ticked files, or the whole
 /// worktree when every file is ticked. Split from the view for
 /// length.
 extension ReviewView {
     func commitOutstanding(model: ReviewModel) async {
+        guard model.hasSomethingToCommit else {
+            model.setStatus("Nothing ticked to commit.")
+            return
+        }
+
         do {
             try await service.commitOutstanding(
                 worktreePath: worktreePath,
@@ -22,6 +26,11 @@ extension ReviewView {
     /// Adds what is ticked to the last commit rather than making a
     /// new one.
     func amendOutstanding(model: ReviewModel) async {
+        guard model.hasSomethingToCommit else {
+            model.setStatus("Nothing ticked to add to the last commit.")
+            return
+        }
+
         do {
             try await service.amendOutstanding(worktreePath: worktreePath, paths: model.pathsToCommit)
             model.excludedFromCommit = []

--- a/Sources/ReviewFeature/ReviewView.swift
+++ b/Sources/ReviewFeature/ReviewView.swift
@@ -81,7 +81,7 @@ public struct ReviewView: View {
             diffList
             ReviewFooterView(
                 model: model,
-                onCommit: { await commitOutstanding() },
+                onCommit: { await commitOutstanding(model: model) },
                 canCommit: model.showsUncommitted && model.files.isEmpty == false && model.isReadOnly == false,
             )
         }
@@ -107,8 +107,16 @@ public struct ReviewView: View {
         .onChange(of: findPreviousRequest) { model.moveFind(by: -1) }
         // The menu bar's Commit Outstanding lands here through the
         // storage bus.
-        .onChange(of: commitRequest) { Task { await commitOutstanding() } }
+        .onChange(of: commitRequest) { Task { await commitOutstanding(model: model) } }
     }
+
+    // MARK: Internal
+
+    /// Internal, since the commit extension file reads them.
+    let worktreePath: String
+
+    /// Internal for the same reason as `worktreePath`.
+    let service: SessionService
 
     // MARK: Private
 
@@ -145,9 +153,8 @@ public struct ReviewView: View {
     @AppStorage("reviewFindPreviousRequest")
     private var findPreviousRequest = 0
 
-    private let worktreePath: String
     private let worktree: Worktree
-    private let service: SessionService
+
     private let makeModel: () -> ReviewModel
 
     /// Icon-only controls in two grouped capsules, every one
@@ -308,14 +315,5 @@ public struct ReviewView: View {
     private func closeFind() {
         showsFind = false
         model.findQuery = ""
-    }
-
-    private func commitOutstanding() async {
-        do {
-            try await service.commitOutstanding(worktreePath: worktreePath)
-            await model.reload()
-        } catch {
-            model.report(error.localizedDescription)
-        }
     }
 }

--- a/Sources/ReviewFeature/ReviewView.swift
+++ b/Sources/ReviewFeature/ReviewView.swift
@@ -82,6 +82,7 @@ public struct ReviewView: View {
             ReviewFooterView(
                 model: model,
                 onCommit: { await commitOutstanding(model: model) },
+                onAmend: { await amendOutstanding(model: model) },
                 canCommit: model.showsUncommitted && model.files.isEmpty == false && model.isReadOnly == false,
             )
         }

--- a/Tests/AgentIDEDataTests/GitClientIntegrationTests+Committing.swift
+++ b/Tests/AgentIDEDataTests/GitClientIntegrationTests+Committing.swift
@@ -1,0 +1,43 @@
+@testable import AgentIDEData
+import AgentIDEDomain
+import Foundation
+import Testing
+
+/// Committing named paths and leaving the rest alone; split from
+/// the client's integration tests for length.
+extension GitClientIntegrationTests {
+    @Test
+    func `a commit of named files leaves everything else uncommitted`() async throws {
+        let root = try TestSupport.temporaryDirectory("git-partial")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let git = GitClient(runner: FoundationProcessRunner())
+        let repoPath = root + "/repo"
+        try await TestSupport.makeRepository(at: repoPath)
+
+        // One file the agent changed, one it added, and one to be
+        // left behind; a new file matters because a commit given a
+        // pathspec refuses a path git has never seen.
+        try "edited\n".write(toFile: repoPath + "/README.md", atomically: true, encoding: .utf8)
+        try "added\n".write(toFile: repoPath + "/added.txt", atomically: true, encoding: .utf8)
+        try "later\n".write(toFile: repoPath + "/later.txt", atomically: true, encoding: .utf8)
+
+        try await git.commit(
+            worktreePath: repoPath,
+            paths: ["README.md", "added.txt"],
+            message: "Take two of the three",
+        )
+
+        #expect(try await git.lastCommitMessage(worktreePath: repoPath) == "Take two of the three")
+        let committed = try await git.lastCommitDiff(worktreePath: repoPath)
+        #expect(committed.contains("+edited"))
+        #expect(committed.contains("+added"))
+        #expect(committed.contains("+later") == false)
+        // The file nobody ticked is still there to commit.
+        #expect(await git.isDirty(worktreePath: repoPath))
+
+        // And committing nothing is not a commit at all.
+        let before = try await git.lastCommitMessage(worktreePath: repoPath)
+        try await git.commit(worktreePath: repoPath, paths: [], message: "Nothing to see")
+        #expect(try await git.lastCommitMessage(worktreePath: repoPath) == before)
+    }
+}

--- a/Tests/AgentIDEDataTests/GitClientIntegrationTests+Committing.swift
+++ b/Tests/AgentIDEDataTests/GitClientIntegrationTests+Committing.swift
@@ -1,5 +1,4 @@
 @testable import AgentIDEData
-import AgentIDEDomain
 import Foundation
 import Testing
 

--- a/Tests/AgentIDEDataTests/GitClientIntegrationTests+Committing.swift
+++ b/Tests/AgentIDEDataTests/GitClientIntegrationTests+Committing.swift
@@ -40,4 +40,32 @@ extension GitClientIntegrationTests {
         try await git.commit(worktreePath: repoPath, paths: [], message: "Nothing to see")
         #expect(try await git.lastCommitMessage(worktreePath: repoPath) == before)
     }
+
+    @Test
+    func `an amend folds named files into the last commit and leaves the rest`() async throws {
+        let root = try TestSupport.temporaryDirectory("git-amend")
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let git = GitClient(runner: FoundationProcessRunner())
+        let repoPath = root + "/repo"
+        try await TestSupport.makeRepository(at: repoPath)
+
+        try "first\n".write(toFile: repoPath + "/first.txt", atomically: true, encoding: .utf8)
+        try await git.commitAll(worktreePath: repoPath, message: "The commit being added to")
+        let before = try await git.commitCount(worktreePath: repoPath, range: "HEAD")
+
+        // One file to fold in, one to leave behind.
+        try "edited\n".write(toFile: repoPath + "/README.md", atomically: true, encoding: .utf8)
+        try "later\n".write(toFile: repoPath + "/later.txt", atomically: true, encoding: .utf8)
+        try await git.amend(worktreePath: repoPath, paths: ["README.md"], message: nil)
+
+        // One commit, not two, and its message is the one it had.
+        #expect(try await git.commitCount(worktreePath: repoPath, range: "HEAD") == before)
+        #expect(try await git.lastCommitMessage(worktreePath: repoPath) == "The commit being added to")
+        let amended = try await git.lastCommitDiff(worktreePath: repoPath)
+        #expect(amended.contains("+edited"))
+        #expect(amended.contains("+first"))
+        #expect(amended.contains("+later") == false)
+        // What was not ticked is still waiting to be committed.
+        #expect(await git.isDirty(worktreePath: repoPath))
+    }
 }

--- a/Tests/AgentIDEDataTests/HostFactsTests.swift
+++ b/Tests/AgentIDEDataTests/HostFactsTests.swift
@@ -1,0 +1,28 @@
+@testable import AgentIDEData
+import Testing
+
+/// What a directory of your own last said, kept so nothing touches
+/// it again until you look at it.
+struct HostFactsTests {
+    @Test
+    func `a directory nobody has read has nothing to say`() {
+        #expect(HostFactsCache().facts(of: "/Users/someone/Documents/notes") == nil)
+    }
+
+    @Test
+    func `the last reading answers for a directory nobody is looking at`() {
+        let cache = HostFactsCache()
+        let read = HostFacts(exists: true, branch: "main", isDirty: true, aheadOfUpstream: 2)
+        cache.remember(read, of: "/Volumes/share/work")
+
+        // The row paints from this rather than from a stat that
+        // would ask macOS, and the user, all over again.
+        #expect(cache.facts(of: "/Volumes/share/work") == read)
+
+        // A directory that has gone is remembered as gone, so its
+        // row stops being drawn without anything touching it.
+        let gone = HostFacts(exists: false, branch: "", isDirty: false, aheadOfUpstream: nil)
+        cache.remember(gone, of: "/Volumes/share/work")
+        #expect(cache.facts(of: "/Volumes/share/work")?.exists == false)
+    }
+}

--- a/Tests/PRFeatureTests/PullRequestStackTests.swift
+++ b/Tests/PRFeatureTests/PullRequestStackTests.swift
@@ -59,7 +59,7 @@ struct PullRequestStackTests {
             BranchStack(base: "main", branches: ["lower", "upper"], checkedOut: "upper")
         }
         let opened = Mutex([String]())
-        model.performCreate = { worktree, _, _, _ in
+        model.performCreate = { worktree, _, _, _, _ in
             opened.withLock { $0.append(worktree.branch) }
             return "https://example.com/1"
         }

--- a/Tests/PRFeatureTests/PullRequestsModelTests+Create.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests+Create.swift
@@ -10,9 +10,29 @@ import Testing
 /// without waiting for a poll. Split from the model tests for length.
 extension PullRequestsModelTests {
     @Test
+    func `the draft toggle opens a draft and is remembered`() async {
+        let model = makeModel(items: [item(branch: "feature", ahead: 0)])
+        var openedAsDraft = false
+        model.performCreate = { _, _, _, _, isDraft in
+            openedAsDraft = isDraft
+            return "https://github.com/o/r/pull/42"
+        }
+        await model.reload()
+        model.prTitle = "A change"
+        model.prIsDraft = true
+
+        #expect(await model.createPullRequest())
+
+        // What the form said reaches `gh`, and the row shows the
+        // draft's own glyph before any fetch has been near it.
+        #expect(openedAsDraft)
+        #expect(model.selected?.isDraft == true)
+    }
+
+    @Test
     func `opening a pull request lands it in the shared branch cache`() async {
         let model = makeModel(items: [item(branch: "feature", ahead: 1)])
-        model.performCreate = { _, _, _, _ in "https://github.com/o/r/pull/42" }
+        model.performCreate = { _, _, _, _, _ in "https://github.com/o/r/pull/42" }
         model.prTitle = "A change"
         await model.reload()
         let before = UserDefaults.standard.integer(forKey: UtilityTabTarget.pullRequestCacheKey)
@@ -32,7 +52,7 @@ extension PullRequestsModelTests {
     @Test
     func `the listing's own answer beats the one the form assembled`() async {
         let model = makeModel(items: [item(branch: "feature", ahead: 1)])
-        model.performCreate = { _, _, _, _ in "https://github.com/o/r/pull/42" }
+        model.performCreate = { _, _, _, _, _ in "https://github.com/o/r/pull/42" }
         // GitHub has it already: its answer carries the checks and
         // mergeability the form could not know.
         let listed = PullRequestSummary(

--- a/Tests/PRFeatureTests/PullRequestsModelTests+Fixtures.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests+Fixtures.swift
@@ -25,7 +25,7 @@ extension PullRequestsModelTests {
         model.fetchSummary = { _ in nil }
         model.fetchHasMergeQueue = { false }
         model.fetchThreads = { _ in [] }
-        model.performCreate = { _, _, _, _ in "" }
+        model.performCreate = { _, _, _, _, _ in "" }
         model.performLinkStack = { _ in
             // Succeeds without side effects.
         }

--- a/Tests/PRFeatureTests/PullRequestsModelTests+Merge.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests+Merge.swift
@@ -27,4 +27,35 @@ extension PullRequestsModelTests {
         await model.performMergeAction()
         #expect(cleaned == false)
     }
+
+    @Test
+    func `a draft is taken out of draft rather than merged`() async {
+        let draft = PullRequestSummary(
+            number: 45,
+            title: "Still a draft",
+            url: "",
+            headBranch: "feature",
+            mergeable: "MERGEABLE",
+            reviewDecision: "",
+            checks: "SUCCESS",
+            baseBranch: "main",
+            state: "OPEN",
+            isDraft: true,
+        )
+        let model = makeModel(items: [item(branch: "feature", ahead: 0)])
+        var cleaned = false
+        model.performPostMergeCleanup = { _, _ in cleaned = true }
+        model.selected = draft
+
+        // Everything else about it says merge, and GitHub would
+        // refuse both that and automerge: "Pull Request is still a
+        // draft". The button says the step that has to come first.
+        #expect(model.mergeActionTitle == "Mark ready")
+        #expect(model.mergeActionBusyTitle == "Marking ready")
+        #expect(PullRequestsModel.isReadyToMerge(draft) == false)
+
+        await model.performMergeAction()
+        // Nothing merged, so nothing is cleaned up behind it.
+        #expect(cleaned == false)
+    }
 }

--- a/Tests/PRFeatureTests/PullRequestsModelTests.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests.swift
@@ -131,9 +131,11 @@ struct PullRequestsModelTests {
         }
         var created: (title: String, body: String)?
         var createdLabels = [String]()
-        model.performCreate = { _, title, body, labels in
+        var createdAsDraft = true
+        model.performCreate = { _, title, body, labels, isDraft in
             created = (title, body)
             createdLabels = labels
+            createdAsDraft = isDraft
             return "https://example.invalid/pull/1"
         }
         model.prTitle = "A change"
@@ -146,6 +148,9 @@ struct PullRequestsModelTests {
         #expect(created?.title == "A change")
         #expect(created?.body == "Why it changed.\n\n- [ ] Checked")
         #expect(createdLabels == ["bug", "ci"])
+        // Ready for review unless the form's own toggle says
+        // otherwise; seeded true so the call is what clears it.
+        #expect(createdAsDraft == false)
         #expect(model.prTitle.isEmpty && model.prLabels.isEmpty)
 
         // Unpushed commits dim Open PR instead of pushing for it.

--- a/Tests/ReviewFeatureTests/ReviewModelTests.swift
+++ b/Tests/ReviewFeatureTests/ReviewModelTests.swift
@@ -30,6 +30,40 @@ struct ReviewModelTests {
     // MARK: Internal
 
     @Test
+    func `unticking every file is not the same as ticking them all`() async throws {
+        let path = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("agentide-ticks-" + UUID().uuidString, isDirectory: true)
+            .path
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        try await makeRepository(at: path)
+        try "a\n".write(toFile: path + "/file.txt", atomically: true, encoding: .utf8)
+        try await runGit(["add", "-A"], in: path)
+        try await runGit(["commit", "-q", "-m", "Add file"], in: path)
+        try "b\n".write(toFile: path + "/file.txt", atomically: true, encoding: .utf8)
+        let model = ReviewModel(
+            worktreePath: path,
+            repositoryName: "repo",
+            git: GitClient(runner: FoundationProcessRunner()),
+        )
+        model.scope = .uncommitted
+        await model.reload()
+        let file = try #require(model.files.first)
+
+        // Everything ticked: no paths, which says the whole worktree.
+        #expect(model.hasSomethingToCommit)
+        #expect(model.pathsToCommit.isEmpty)
+
+        // Nothing ticked empties the paths too, and that must never
+        // read as the whole worktree: the menu bar's own Commit does
+        // not ask the button whether it is dimmed.
+        model.setCommitting(false, path: file.path)
+        #expect(model.pathsToCommit.isEmpty)
+        #expect(model.hasSomethingToCommit == false)
+        #expect(model.committingCount == 0)
+    }
+
+    @Test
     func `a working line is replaced by the typed lines and the diff follows`() async throws {
         let path = FileManager.default
             .temporaryDirectory

--- a/project.yml
+++ b/project.yml
@@ -42,6 +42,32 @@ targets:
         CURRENT_PROJECT_VERSION: "1"
         INFOPLIST_KEY_NSHumanReadableCopyright: "© 2026 Mike McQuaid."
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.developer-tools
+        # macOS has no way to decline these prompts in advance: a
+        # non-sandboxed app is asked the first time it touches one of
+        # these places, and these strings are only what the prompt
+        # says. AgentIDE reaches them for one reason, so the prompt
+        # says which directory of your own asked and offers the
+        # honest way out.
+        INFOPLIST_KEY_NSDocumentsFolderUsageDescription: >-
+          AgentIDE reads a directory you listed yourself. Deny this and remove
+          the directory from its repository's menu if you would rather it never
+          looked.
+        INFOPLIST_KEY_NSDesktopFolderUsageDescription: >-
+          AgentIDE reads a directory you listed yourself. Deny this and remove
+          the directory from its repository's menu if you would rather it never
+          looked.
+        INFOPLIST_KEY_NSDownloadsFolderUsageDescription: >-
+          AgentIDE reads a directory you listed yourself. Deny this and remove
+          the directory from its repository's menu if you would rather it never
+          looked.
+        INFOPLIST_KEY_NSNetworkVolumesUsageDescription: >-
+          AgentIDE reads a directory you listed yourself, or a repository on a
+          share. Deny this and keep your work on a local disk if you would
+          rather it never looked.
+        INFOPLIST_KEY_NSRemovableVolumesUsageDescription: >-
+          AgentIDE reads a directory you listed yourself, or a repository on a
+          removable disk. Deny this and keep your work on the internal disk if
+          you would rather it never looked.
         MACOSX_DEPLOYMENT_TARGET: "27.0"
         SWIFT_VERSION: "6.0"
         SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor


### PR DESCRIPTION
- Selective file committing now includes unticked work, avoids silent exclusion
- macOS no longer probes guarded folders for every row, uses cached state
- Draft pull request creation uses icon toggle and preserves draft intent