### PR TITLE
Add signed release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,173 @@
+name: Release
+
+on:
+  # Run from `main` to release the current commit at its version.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Bare MAJOR.MINOR.PATCH version, for example 0.1.0
+        required: true
+        type: string
+  # Dry run whenever the release process itself changes, so it cannot
+  # rot unnoticed between releases.
+  push:
+    paths:
+      - .github/workflows/release.yml
+      - App/AgentIDE.entitlements
+      - project.yml
+      - script/build
+      - script/package
+      - script/zip
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: xcode-27
+    timeout-minutes: 45
+    permissions:
+      contents: write # to push the tag and create the release
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The version needs tags and the build number counts commits.
+          fetch-depth: 0
+
+      - name: Check the branch
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Releases are cut from main, not ${GITHUB_REF}."
+          exit 1
+
+      - name: Create local version tag
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            version="${RELEASE_VERSION}"
+            if [[ "${version}" == "0.0.0" || "${version}" == "9999.0.0" ]]; then
+              echo "::error::Version ${version} is reserved for development and dry runs."
+              exit 1
+            fi
+          else
+            version="9999.0.0"
+          fi
+          if [[ ! "${version}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Version must be bare MAJOR.MINOR.PATCH, for example 0.1.0."
+            exit 1
+          fi
+          if git show-ref --verify --quiet "refs/tags/${version}"; then
+            echo "::error::Tag ${version} already exists."
+            exit 1
+          fi
+          if [[ -n "$(git tag --points-at HEAD)" ]]; then
+            echo "::error::The current commit already has a tag."
+            exit 1
+          fi
+          git tag "${version}"
+          [[ "$(git describe --tags --exact-match HEAD)" == "${version}" ]]
+          echo "VERSION=${version}" >>"${GITHUB_ENV}"
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          core: false
+          cask: false
+          test-bot: false
+
+      - name: Select Xcode 27
+        run: |
+          xcode="$(find /Applications -maxdepth 1 -name 'Xcode*27*.app' -print -quit)"
+          if [[ -z "${xcode}" ]]; then
+            echo "::error::Xcode 27 is not installed on this runner image."
+            exit 1
+          fi
+          sudo xcode-select -s "${xcode}/Contents/Developer"
+          xcodebuild -version
+
+      - name: Download Metal toolchain
+        run: xcodebuild -downloadComponent MetalToolchain
+
+      - name: Bootstrap
+        run: script/bootstrap
+
+      - name: Build
+        env:
+          XCODE_CONFIGURATION: Release
+        run: script/build
+
+      - name: Zip
+        run: script/zip
+
+      - name: Sign and notarise
+        # Human dry runs test the credentials too. Dependabot cannot
+        # read Actions secrets, while a release must fail without them.
+        if: github.event_name == 'workflow_dispatch' || github.actor != 'dependabot[bot]'
+        env:
+          DEVELOPER_ID_APPLICATION_CERTIFICATE: ${{ secrets.DEVELOPER_ID_APPLICATION_CERTIFICATE }}
+          DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD }}
+          NOTARIZATION_KEY: ${{ secrets.NOTARIZATION_KEY }}
+          NOTARIZATION_KEY_ID: ${{ secrets.NOTARIZATION_KEY_ID }}
+          NOTARIZATION_ISSUER_ID: ${{ secrets.NOTARIZATION_ISSUER_ID }}
+        run: script/package
+
+      - name: Upload the app
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: AgentIDE
+          path: .build/AgentIDE-*.zip
+          # The zip lives in a hidden directory, skipped by default.
+          include-hidden-files: true
+          if-no-files-found: error
+
+      - name: Check releases in a dry run
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release list
+
+      - name: Create the release
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh auth setup-git
+          git push origin "refs/tags/${VERSION}"
+          gh release create "${VERSION}" --verify-tag --generate-notes \
+            ".build/AgentIDE-${VERSION}.zip"
+
+  bump-cask:
+    # `false` holds the bump back until the `agentide` cask exists in
+    # Homebrew/homebrew-cask and `HOMEBREW_GITHUB_API_TOKEN`, a personal
+    # access token with the `public_repo` and `workflow` scopes, is a
+    # repository secret. `brew bump` then reads the new version through
+    # `brew livecheck` and opens the pull request.
+    if: false && github.event_name == 'workflow_dispatch'
+    needs: release
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          core: false
+          cask: true
+          test-bot: false
+
+      - name: Bump the cask
+        uses: Homebrew/actions/bump-packages@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          casks: agentide

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,10 @@ conventional-commit prefixes such as `feat:`, `fix:` or `chore:`.
   changed, then build the app with xcodebuild
 - `script/install`: build, then copy the app into /Applications so
   the running copy survives rebuilds
+- `script/zip`: zip the Release build as
+  `.build/AgentIDE-<version>.zip`
+- `script/package`: sign the Release build with a Developer ID
+  certificate, notarise and staple it, then remake its zip
 - `script/test`: run the unit and integration tests, then on the
   host the App Intents tests through `xcodebuild` (a UI testing
   bundle, since `AppIntentsTesting` drives the system's own runtime;

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -855,13 +855,14 @@ organisation.
 System frameworks (WebKit, UserNotifications, FSEvents, Network and
 FoundationModels, weak-linked because CI's runner OS lacks it) and
 runtime tools (herdr via Homebrew, never linked) sit outside the table.
-No updater: releases ship as a Homebrew cask.
+No updater: releases will ship as a Homebrew cask once it exists.
 
 Toolchain: Xcode 27, Swift 6.4, XcodeGen, SwiftLint and SwiftFormat with
 every rule enabled (per-line disables with a reason). Scripts:
-`bootstrap`, `build`, `install`, `test`, `analyze`, `style [--fix]`,
-`performance-log` and `attach [workspace]`; see AGENTS.md. Sandboxed
-builds gate on `SV_SESSION_ID` and disable SwiftPM's sandbox.
+`bootstrap`, `build`, `install`, `zip`, `package`, `test`, `analyze`,
+`style [--fix]`, `performance-log` and `attach [workspace]`; see
+AGENTS.md. Sandboxed builds gate on `SV_SESSION_ID` and disable
+SwiftPM's sandbox.
 
 Tests are two tiers. Unit tests cover Domain's pure functions, Data
 decoders over fixtures and the feature models, whose fetch and
@@ -874,6 +875,66 @@ from the environment so a teardown can never reach the production
 server. CI (`.github/workflows/tests.yml`) runs style on
 every push and pull request, and build-and-test and analyze in parallel
 on the `xcode-27` image, each asserting Xcode 27 rather than skipping.
+
+### Releases
+
+Three scripts turn a checkout into the artefact a release ships, split
+so that only the last needs credentials:
+
+- `script/build` validates an exact tag on the current commit as three
+  period-separated integers with no leading zeroes and passes it as
+  `MARKETING_VERSION`; an untagged development or CI build uses
+  `0.0.0`. `CURRENT_PROJECT_VERSION` remains the build number and
+  counts the default branch's commits. The release workflow selects the
+  Release configuration; local builds stay Debug.
+- `script/zip` verifies the built app's signature, then zips it with
+  `ditto` as `.build/AgentIDE-<version>.zip`, the version read from the
+  built `Info.plist`, with `AgentIDE.app` as the only top-level entry.
+- `script/package` needs every credential in its environment and fails
+  without them. `DEVELOPER_ID_APPLICATION_CERTIFICATE`, a base64
+  encoded `.p12` export of the Developer ID Application certificate and
+  its private key, with
+  `DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD`, is imported into a
+  temporary keychain. The script selects its one valid Developer ID
+  Application identity, signs the app from
+  `App/AgentIDE.entitlements` with a hardened runtime and secure
+  timestamp, and restores the user's keychain list on exit.
+  `NOTARIZATION_KEY`, the contents of an App Store Connect API key's
+  `.p8` file, `NOTARIZATION_KEY_ID` and `NOTARIZATION_ISSUER_ID` send
+  the zip to `notarytool`. The script waits for Apple's verdict, prints
+  its log on failure, staples the accepted ticket, asks Gatekeeper to
+  assess the app and remakes the zip around the stapled app.
+
+The Release workflow (`.github/workflows/release.yml`) requires a bare
+`MAJOR.MINOR.PATCH` version such as `0.1.0` on `workflow_dispatch` and
+must be run on `main`. It rejects leading zeroes, `v`, prerelease
+suffixes and build metadata, the development and dry-run versions, an
+existing requested tag and a commit already carrying any tag. It
+creates the local tag before building so `script/build` stamps it into
+the app, then zips, signs and notarises. Nothing reaches GitHub until
+packaging succeeds; only then does the workflow upload the zip as an
+artefact, push the tag and create a release with generated notes and
+the zip attached.
+
+A push that touches the workflow, packaging scripts or metadata uses
+`9999.0.0` as a reserved local-only version and repeats the build,
+signing and notarisation as a dry run, but uploads no artefact and
+pushes no tag or release. Dependabot cannot read Actions secrets, so
+its dry runs skip signing and notarisation. The disabled `bump-cask`
+job is ready to run `Homebrew/actions/bump-packages` after a release
+once the `agentide` cask exists and `HOMEBREW_GITHUB_API_TOKEN`, a
+personal access token with the `public_repo` and `workflow` scopes, is
+a repository secret.
+
+The release contract is also the cask contract: the tag is the bare
+version, the zip is `AgentIDE-<version>.zip` and the app's
+`CFBundleShortVersionString` is the same value, so the cask can use the
+stable URL
+`https://github.com/MikeMcQuaid/AgentIDE/releases/download/#{version}/AgentIDE-#{version}.zip`.
+Every release is Developer ID signed with the hardened runtime,
+notarised and stapled so Homebrew's signing audit and Gatekeeper accept
+it. Releases are full releases, never drafts or prereleases, which lets
+`brew livecheck` discover the next version without a custom strategy.
 
 ## Potential future plans
 

--- a/App/AgentIDE.entitlements
+++ b/App/AgentIDE.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/App/AppCommands.swift
+++ b/App/AppCommands.swift
@@ -11,13 +11,6 @@ struct AppCommands: Commands {
     let dashboard: DashboardModel
 
     var body: some Commands {
-        CommandGroup(replacing: .appInfo) {
-            // The version already ends in the build number, so the
-            // panel's own build field would say it twice.
-            Button("About AgentIDE") {
-                NSApplication.shared.orderFrontStandardAboutPanel(options: [.version: ""])
-            }
-        }
         CommandGroup(replacing: .newItem) {
             Button("New Agent Session") {
                 // No preset: the menu is repository-agnostic, and a

--- a/Package.swift
+++ b/Package.swift
@@ -66,7 +66,7 @@ let package = Package(
                 "TerminalUI",
             ],
             path: "App",
-            exclude: ["Assets.xcassets"],
+            exclude: ["AgentIDE.entitlements", "Assets.xcassets"],
             swiftSettings: mainActorByDefault,
         ),
         .target(

--- a/README.md
+++ b/README.md
@@ -182,6 +182,18 @@ In workflow order; the loop from prompt to review repeats before shipping.
 
 ## 🖥️ Usage
 
+Every release on the
+[releases page](https://github.com/MikeMcQuaid/AgentIDE/releases) is an
+`AgentIDE-<version>.zip` holding `AgentIDE.app`, signed with a Developer
+ID certificate and notarised by Apple so it opens without a Gatekeeper
+warning: unzip it and move the app to `/Applications`.
+
+Releases will also ship as a Homebrew cask
+(`brew install --cask agentide`) once the cask exists; `brew upgrade`
+will then update the app, which has no updater of its own.
+
+To run the current source instead:
+
 ```bash
 git clone https://github.com/MikeMcQuaid/AgentIDE
 cd AgentIDE
@@ -207,6 +219,20 @@ fi
 
 `agentide .` from any terminal switches the window to the worktree or
 checkout you are in.
+
+### 🚀 Releasing
+
+Run the **Release** workflow from the Actions tab on `main` with a bare
+`MAJOR.MINOR.PATCH` version such as `0.1.0`: three integers, with no
+`v`, prerelease suffix or build metadata. The workflow validates and
+locally tags the commit before building, so the tag becomes the app's
+version as well as the GitHub release and zip name. It pushes the tag
+only after signing and notarisation succeed. No new commit or push is
+needed: dispatching it builds the current `main` commit. A push that
+touches the release workflow, packaging scripts or metadata creates the
+reserved local test tag `9999.0.0`, signs and notarises as a dry run but
+publishes nothing; Dependabot skips that step because GitHub withholds
+its secrets.
 
 ### 📱 From a phone
 

--- a/project.yml
+++ b/project.yml
@@ -38,7 +38,7 @@ targets:
         PRODUCT_NAME: AgentIDE
         GENERATE_INFOPLIST_FILE: YES
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: "0.1.$(CURRENT_PROJECT_VERSION)"
+        MARKETING_VERSION: "0.0.0"
         CURRENT_PROJECT_VERSION: "1"
         INFOPLIST_KEY_NSHumanReadableCopyright: "© 2026 Mike McQuaid."
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.developer-tools
@@ -49,7 +49,8 @@ targets:
         SWIFT_STRICT_CONCURRENCY: complete
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "-"
-        ENABLE_HARDENED_RUNTIME: NO
+        CODE_SIGN_ENTITLEMENTS: App/AgentIDE.entitlements
+        ENABLE_HARDENED_RUNTIME: YES
     scheme:
       testTargets:
         - AgentIDEIntentTests

--- a/script/build
+++ b/script/build
@@ -1,8 +1,16 @@
 #!/bin/bash
-# Build AgentIDE.app; the repo-root AgentIDE.app symlink points at the output.
+# Build AgentIDE.app; the repo-root symlink points at the Debug output.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+
+# A release workflow creates its local version tag before building.
+version="$(git describe --tags --exact-match HEAD 2>/dev/null || true)"
+version="${version:-0.0.0}"
+if [[ ! "${version}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "Version tag must be bare MAJOR.MINOR.PATCH: ${version}" >&2
+  exit 1
+fi
 
 [[ -d AgentIDE.xcodeproj ]] || script/bootstrap
 
@@ -19,23 +27,25 @@ fi
 # taking the production herdr server and its agents with it.
 JOBS="$(sysctl -n hw.ncpu)"
 [[ -n "${SV_SESSION_ID:-}" ]] && JOBS=6
+configuration="${XCODE_CONFIGURATION:-Debug}"
 
 ARGS=(
   -project AgentIDE.xcodeproj
   -scheme AgentIDEApp
+  -configuration "${configuration}"
   -destination "${XCODE_DESTINATION:-platform=macOS,arch=arm64}"
   -derivedDataPath .DerivedData
   -jobs "${JOBS}"
 )
 
-# The version counts the default branch's commits, so numbers are
-# comparable across feature branches: the app is 0.1.<count>.
+# The build number counts the default branch's commits, so numbers are
+# comparable across feature branches.
 BUILD_NUMBER="$(
   git rev-list --count origin/main 2>/dev/null ||
     git rev-list --count main 2>/dev/null ||
     git rev-list --count HEAD
 )"
-ARGS+=("CURRENT_PROJECT_VERSION=${BUILD_NUMBER}")
+ARGS+=("CURRENT_PROJECT_VERSION=${BUILD_NUMBER}" "MARKETING_VERSION=${version}")
 ACTIONS=(build)
 
 # Inside the sandbox this is the whole build: Xcode runs SwiftTerm's
@@ -71,4 +81,4 @@ xcodebuild "${ARGS[@]}" "${ACTIONS[@]}"
 
 # Icon caches key on the bundle's modification time; bump it so the
 # Dock and Finder notice icon changes.
-touch AgentIDE.app
+touch ".DerivedData/Build/Products/${configuration}/AgentIDE.app"

--- a/script/package
+++ b/script/package
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Sign the Release build with the Developer ID Application certificate,
+# notarise it, staple the ticket and zip it through script/zip. Every
+# step needs credentials, taken from the environment:
+# - DEVELOPER_ID_APPLICATION_CERTIFICATE, a base64 encoded .p12 export
+#   of the certificate and its private key, with
+#   DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD
+# - NOTARIZATION_KEY, the contents of an App Store Connect API .p8 key,
+#   with NOTARIZATION_KEY_ID and NOTARIZATION_ISSUER_ID
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+: "${DEVELOPER_ID_APPLICATION_CERTIFICATE:?}"
+: "${DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD:?}"
+: "${NOTARIZATION_KEY:?}"
+: "${NOTARIZATION_KEY_ID:?}"
+: "${NOTARIZATION_ISSUER_ID:?}"
+
+app=.DerivedData/Build/Products/Release/AgentIDE.app
+keychains=()
+while read -r existing_keychain; do
+  existing_keychain="${existing_keychain#\"}"
+  keychains+=("${existing_keychain%\"}")
+done < <(security list-keychains -d user)
+scratch="$(mktemp -d -t agentide-package)"
+keychain="${scratch}/signing.keychain-db"
+cleanup() {
+  security list-keychains -d user -s "${keychains[@]}" &>/dev/null || true
+  security delete-keychain "${keychain}" &>/dev/null || true
+  rm -rf "${scratch}"
+}
+trap cleanup EXIT
+
+keychain_password="$(uuidgen)"
+security create-keychain -p "${keychain_password}" "${keychain}"
+security unlock-keychain -p "${keychain_password}" "${keychain}"
+base64 --decode <<<"${DEVELOPER_ID_APPLICATION_CERTIFICATE}" >"${scratch}/certificate.p12"
+security import "${scratch}/certificate.p12" -k "${keychain}" \
+  -P "${DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD}" -T /usr/bin/codesign
+# Let codesign use the key without a prompt.
+security set-key-partition-list -S apple-tool:,apple: -s \
+  -k "${keychain_password}" "${keychain}" &>/dev/null
+security list-keychains -d user -s "${keychain}" "${keychains[@]}"
+
+identity="$(
+  security find-identity -v -p codesigning "${keychain}" |
+    sed -nE 's/^[[:space:]]*[0-9]+\) ([[:xdigit:]]{40}) "Developer ID Application:.*"$/\1/p'
+)"
+if [[ ! "${identity}" =~ ^[[:xdigit:]]{40}$ ]]; then
+  echo "Expected exactly one valid Developer ID Application identity; found:" >&2
+  security find-identity -p codesigning "${keychain}" >&2
+  exit 1
+fi
+
+# The ad hoc build carries the get-task-allow entitlement, which
+# notarisation rejects, so sign again from the source entitlements with
+# the hardened runtime and secure timestamp notarisation requires.
+codesign --force --sign "${identity}" --keychain "${keychain}" \
+  --options runtime --timestamp --entitlements App/AgentIDE.entitlements "${app}"
+
+zip="$(script/zip)"
+key="${scratch}/notarization.p8"
+(umask 077 && printf '%s\n' "${NOTARIZATION_KEY}" >"${key}")
+credentials=(--key "${key}" --key-id "${NOTARIZATION_KEY_ID}" --issuer "${NOTARIZATION_ISSUER_ID}")
+result="${scratch}/notarization.plist"
+xcrun notarytool submit "${zip}" "${credentials[@]}" --wait --timeout 30m \
+  --output-format plist >"${result}"
+status="$(/usr/libexec/PlistBuddy -c 'Print status' "${result}")"
+if [[ "${status}" != "Accepted" ]]; then
+  echo "Notarisation ${status}:" >&2
+  xcrun notarytool log "$(/usr/libexec/PlistBuddy -c 'Print id' "${result}")" "${credentials[@]}" >&2
+  exit 1
+fi
+xcrun stapler staple "${app}"
+spctl --assess --type execute --verbose=2 "${app}"
+
+# The ticket is stapled to the app, so remake the zip around it.
+script/zip

--- a/script/zip
+++ b/script/zip
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Zip the Release build as .build/AgentIDE-<version>.zip, with
+# AgentIDE.app as the zip's only top-level entry, and print its path.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+app=.DerivedData/Build/Products/Release/AgentIDE.app
+[[ -d "${app}" ]] || {
+  echo "Run XCODE_CONFIGURATION=Release script/build first: ${app} is missing" >&2
+  exit 1
+}
+codesign --verify --deep --strict "${app}"
+
+version="$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' "${app}/Contents/Info.plist" 2>/dev/null || true)"
+[[ -n "${version}" ]] || {
+  echo "${app} has no CFBundleShortVersionString to name the zip by" >&2
+  exit 1
+}
+zip=".build/AgentIDE-${version}.zip"
+rm -f "${zip}"
+ditto -c -k --sequesterRsrc --keepParent "${app}" "${zip}"
+echo "${zip}"


### PR DESCRIPTION
- Stamp the bundle and archive from a validated version tag
- Gate publication on Developer ID signing and notarisation
- Exercise packaging on changes and prepare the future cask bump