### PR TITLE
Detect where the window is placed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,6 +299,14 @@ Hard-won on macOS 27 beta; check before assuming they expired.
   move and told nobody anything. Setting the
   frame of a window in a fullscreen space to chase this blacks out
   both displays until the app is killed; do not try it.
+- SwiftUI names the main window's frame autosave when it makes the
+  window, and `setFrameAutosaveName` refuses a second name while it
+  holds one, so a name of the app's own never saved anything. Beneath
+  that, since Monterey AppKit's restoration moves a window that was
+  on a second display to the main one, keeping its place within the
+  screen. `WindowConfigurator` clears the name and sets the saved
+  frame itself once the window is really on a screen; a frame set
+  before then is constrained to the main display.
 - A window changing screens can leave an `NSViewRepresentable`'s
   AppKit view on the old screen's geometry while the SwiftUI chrome
   around it lays out correctly (seen: the editor's text bleeding

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -897,7 +897,21 @@ selects the worktree holding it, and `agentide new` starts a session.
 | Code, branches, diffs, worktrees | git in the shared workspace | operate host-side, hardened |
 | Conversation history | agent transcripts | read-only |
 | Pull request, CI and review state | GitHub via `gh` | poll, cache with timestamps |
-| Unread markers, prompt history, per-repository settings, session names and resume ids, drafts, window state, last sidebar snapshot | metadata store | sole owner |
+| Unread markers, prompt history, per-repository settings, session names and resume ids, drafts, last sidebar snapshot | metadata store | sole owner |
+| Window frame, display and fullscreen state | `UserDefaults` | sole owner |
+
+The window's own shape is the exception to the metadata store.
+`WindowConfigurator` keeps the frame, the display it was on and whether
+it was fullscreen in `UserDefaults`. The autosave SwiftUI names is
+cleared rather than used: since Monterey, AppKit's own restoration moves
+a window that was on a second display to the main one, keeping where it
+sat within that screen, so the window came back the right size in the
+wrong place however it was stored. With nothing left for AppKit to
+restore, the frame is put back by hand: once as the window is
+configured, so nothing shows at a default size, and again once the
+window is really on a screen, since a frame set before then is
+constrained to the main display. Only then is the window moved onto its
+display and into fullscreen, and only then are its moves recorded.
 
 The metadata store is `~/Library/Application Support/AgentIDE/state.json`,
 outside the shared workspace so agents can neither read nor corrupt it.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -902,16 +902,19 @@ selects the worktree holding it, and `agentide new` starts a session.
 
 The window's own shape is the exception to the metadata store.
 `WindowConfigurator` keeps the frame, the display it was on and whether
-it was fullscreen in `UserDefaults`. The autosave SwiftUI names is
-cleared rather than used: since Monterey, AppKit's own restoration moves
-a window that was on a second display to the main one, keeping where it
-sat within that screen, so the window came back the right size in the
-wrong place however it was stored. With nothing left for AppKit to
-restore, the frame is put back by hand: once as the window is
-configured, so nothing shows at a default size, and again once the
-window is really on a screen, since a frame set before then is
+it was fullscreen in `UserDefaults`. AppKit's frame autosave is not
+used: SwiftUI names it when it makes the window and restores that entry
+before the configurator runs, refuses the app a name of its own, and
+since Monterey its restoration moves a window that was on a second
+display to the main one, keeping where it sat within that screen, so the
+window came back the right size in the wrong place however it was
+stored. The configurator clears the name, so AppKit writes nothing more
+under it, and sets the frame over whatever was restored: once as the
+window is configured, so nothing shows at a default size, and again once
+the window is really on a screen, since a frame set before then is
 constrained to the main display. Only then is the window moved onto its
-display and into fullscreen, and only then are its moves recorded.
+display and into fullscreen, and only then are its moves recorded, once
+each drag or resize pauses rather than per step.
 
 The metadata store is `~/Library/Application Support/AgentIDE/state.json`,
 outside the shared workspace so agents can neither read nor corrupt it.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -912,9 +912,13 @@ stored. The configurator clears the name, so AppKit writes nothing more
 under it, and sets the frame over whatever was restored: once as the
 window is configured, so nothing shows at a default size, and again once
 the window is really on a screen, since a frame set before then is
-constrained to the main display. Only then is the window moved onto its
-display and into fullscreen, and only then are its moves recorded, once
-each drag or resize pauses rather than per step.
+constrained to the main display. The window is invisible until that
+second set, so it is never seen on the main display first, and a window
+that never reports itself on a screen is shown where it is after a
+couple of seconds rather than left invisible. Only then is the window
+moved onto its display, brought onto a screen that exists if the one it
+was left on has gone, and put into fullscreen, and only then are its
+moves recorded, once each drag or resize pauses rather than per step.
 
 The metadata store is `~/Library/Application Support/AgentIDE/state.json`,
 outside the shared workspace so agents can neither read nor corrupt it.

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -165,7 +165,7 @@ struct RootView: View {
         .ignoresSafeArea(.container, edges: .top)
         .background(WindowConfigurator(
             onVisibilityChange: { visible in windowVisibilityChanged(visible) },
-            onFullScreenChange: { isFullScreen = $0 },
+            onPlacementChange: { isFullScreen = $0.isFullScreen },
         ))
         // The title bar hides the string, but Mission Control, the
         // Window menu and window switching all read it.

--- a/App/WindowConfigurator.ConfiguringView+Fitting.swift
+++ b/App/WindowConfigurator.ConfiguringView+Fitting.swift
@@ -77,7 +77,7 @@ extension WindowConfigurator.ConfiguringView {
 
     /// Brings the frame back inside the screen it is on, keeping
     /// its size where it fits and its corner where it can.
-    private func fitToScreen() {
+    func fitToScreen() {
         guard let window, let visible = (window.screen ?? NSScreen.main)?.visibleFrame else {
             return
         }

--- a/App/WindowConfigurator.ConfiguringView+Fitting.swift
+++ b/App/WindowConfigurator.ConfiguringView+Fitting.swift
@@ -3,6 +3,20 @@ import AppKit
 /// Fitting the window to the screen it lands on, used by the window
 /// configurator; its own file for that file's length.
 extension WindowConfigurator.ConfiguringView {
+    /// The margin left around a window filling its screen.
+    private static let screenInset: CGFloat = 8
+
+    /// Fills whichever screen the window is on, less a margin: a
+    /// fixed default is either too big for a laptop or too small
+    /// for a desk.
+    func fill(_ window: NSWindow) {
+        guard let visible = (window.screen ?? NSScreen.main)?.visibleFrame else {
+            return
+        }
+
+        window.setFrame(visible.insetBy(dx: Self.screenInset, dy: Self.screenInset), display: true)
+    }
+
     /// Lays the window out for the screen it is on: a fullscreen
     /// window to the display it lost, any other back inside its
     /// screen's edges.
@@ -13,7 +27,9 @@ extension WindowConfigurator.ConfiguringView {
 
         if window.styleMask.contains(.fullScreen) {
             fitFullScreen(of: window, hasLostDisplay: displayGone)
-        } else {
+        } else if isPlacing == false {
+            // Not while the saved frame is still being put back: the
+            // frame that wants fitting is not there yet.
             fitToScreen()
         }
         // The space a fullscreen window lands on paints black

--- a/App/WindowConfigurator.ConfiguringView+Fitting.swift
+++ b/App/WindowConfigurator.ConfiguringView+Fitting.swift
@@ -1,0 +1,72 @@
+import AppKit
+
+/// Fitting the window to the screen it lands on, used by the window
+/// configurator; its own file for that file's length.
+extension WindowConfigurator.ConfiguringView {
+    /// Lays the window out for the screen it is on: a fullscreen
+    /// window to the display it lost, any other back inside its
+    /// screen's edges.
+    func fit(displayGone: Bool) {
+        guard let window else {
+            return
+        }
+
+        if window.styleMask.contains(.fullScreen) {
+            fitFullScreen(of: window, hasLostDisplay: displayGone)
+        } else {
+            fitToScreen()
+        }
+        // The space a fullscreen window lands on paints black
+        // behind it; a window that fitted itself into one must
+        // ask for the redraw that the move itself never did.
+        window.viewsNeedDisplay = true
+        window.displayIfNeeded()
+    }
+
+    /// A fullscreen window keeps the size of the display it was
+    /// on when that display goes. macOS moves the space to a
+    /// screen that exists, but the content stays drawn to the
+    /// old, larger frame: what shows is the black behind it.
+    /// Only the display the window was on going away is fitted
+    /// by hand: AppKit owns the frame of a window in a
+    /// fullscreen space, and setting it while a space merely
+    /// moved between two live displays left both screens black
+    /// until the app was killed, which a resolution, scaling or
+    /// arrangement change must not be able to reproduce. Every
+    /// other change lays the content out again for the size
+    /// AppKit gave it, and nothing more.
+    private func fitFullScreen(of window: NSWindow, hasLostDisplay: Bool) {
+        guard let screen = window.screen else {
+            // No screen at all to fit: leaving fullscreen puts
+            // the window back on one that exists.
+            window.toggleFullScreen(nil)
+            return
+        }
+        guard hasLostDisplay, window.frame != screen.frame else {
+            window.contentView?.needsLayout = true
+            window.contentView?.layoutSubtreeIfNeeded()
+            return
+        }
+
+        window.setFrame(screen.frame, display: true, animate: false)
+    }
+
+    /// Brings the frame back inside the screen it is on, keeping
+    /// its size where it fits and its corner where it can.
+    private func fitToScreen() {
+        guard let window, let visible = (window.screen ?? NSScreen.main)?.visibleFrame else {
+            return
+        }
+
+        var frame = window.frame
+        frame.size.width = min(frame.width, visible.width)
+        frame.size.height = min(frame.height, visible.height)
+        frame.origin.x = min(max(frame.minX, visible.minX), visible.maxX - frame.width)
+        frame.origin.y = min(max(frame.minY, visible.minY), visible.maxY - frame.height)
+        guard frame != window.frame else {
+            return
+        }
+
+        window.setFrame(frame, display: true, animate: false)
+    }
+}

--- a/App/WindowConfigurator.ConfiguringView+Fitting.swift
+++ b/App/WindowConfigurator.ConfiguringView+Fitting.swift
@@ -1,10 +1,18 @@
 import AppKit
 
-/// Fitting the window to the screen it lands on, used by the window
-/// configurator; its own file for that file's length.
+/// Getting the window onto its screen and fitting it there, used by
+/// the window configurator; its own file for that file's length.
 extension WindowConfigurator.ConfiguringView {
-    /// The margin left around a window filling its screen.
+    /// The margin left around a window filling its screen, and what
+    /// centring divides by.
     private static let screenInset: CGFloat = 8
+    private static let halves: CGFloat = 2
+
+    /// How long the window gets to appear before a saved frame or a
+    /// remembered fullscreen is given up on: a fifth of a second at
+    /// a time, for a couple of seconds.
+    private static let readyAttempts = 20
+    private static let readySeconds = 0.2
 
     /// Fills whichever screen the window is on, less a margin: a
     /// fixed default is either too big for a laptop or too small
@@ -84,5 +92,55 @@ extension WindowConfigurator.ConfiguringView {
         }
 
         window.setFrame(frame, display: true, animate: false)
+    }
+
+    /// Centres the window on the display it was left on, named by
+    /// that display's own identity since numbers move, when it has
+    /// come back anywhere else.
+    func move(_ window: NSWindow, ontoDisplay name: String?) {
+        let screen = name.flatMap { name in
+            NSScreen.screens.first { $0.displayID.map(NSScreen.uuid(of:)) == name }
+        }
+        guard let screen, screen.frame.contains(CGPoint(x: window.frame.midX, y: window.frame.midY)) == false else {
+            return
+        }
+
+        window.setFrameOrigin(CGPoint(
+            x: screen.visibleFrame.midX - window.frame.width / Self.halves,
+            y: screen.visibleFrame.midY - window.frame.height / Self.halves,
+        ))
+    }
+
+    /// Goes fullscreen once the window is really on a screen:
+    /// AppKit drops the toggle on a window it has not shown yet.
+    func enterFullScreen(_ window: NSWindow) {
+        guard window.styleMask.contains(.fullScreen) == false else {
+            return
+        }
+
+        whenOnScreen(window) { onScreen in
+            if onScreen {
+                window.toggleFullScreen(nil)
+            }
+        }
+    }
+
+    /// Calls back once the window is visible and on a screen, a
+    /// fifth of a second at a time for a couple of seconds, and
+    /// with `false` when it never appeared.
+    func whenOnScreen(
+        _ window: NSWindow,
+        attempts: Int = WindowConfigurator.ConfiguringView.readyAttempts,
+        then act: @escaping (Bool) -> Void,
+    ) {
+        if window.isVisible, window.screen != nil {
+            act(true)
+        } else if attempts > 0 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.readySeconds) { [weak self] in
+                self?.whenOnScreen(window, attempts: attempts - 1, then: act)
+            }
+        } else {
+            act(false)
+        }
     }
 }

--- a/App/WindowConfigurator.swift
+++ b/App/WindowConfigurator.swift
@@ -79,14 +79,10 @@ struct WindowConfigurator: NSViewRepresentable {
         private static let minimumWidth: CGFloat = 640
         private static let minimumHeight: CGFloat = 420
 
-        /// How long the window gets to appear before a remembered
-        /// fullscreen is given up on: a fifth of a second at a time,
-        /// for a couple of seconds.
-        private static let readyAttempts = 20
-        private static let readySeconds = 0.2
-
-        /// What centring divides by.
-        private static let halves: CGFloat = 2
+        /// How long a drag or resize must pause before its frame is
+        /// recorded: one defaults write per gesture rather than per
+        /// pixel, and short enough that a kill loses next to nothing.
+        private static let recordSeconds = 0.25
 
         /// Where the window was left, and how.
         private static let frameKey = "mainWindowFrame"
@@ -99,6 +95,10 @@ struct WindowConfigurator: NSViewRepresentable {
         private static let settleSeconds = 0.6
 
         private var observers: [any NSObjectProtocol] = []
+
+        /// Which recording is the latest, so an earlier one still
+        /// waiting on its pause writes nothing.
+        private var recordGeneration = 0
 
         /// The window already configured, so re-renders reconfigure
         /// nothing.
@@ -141,7 +141,6 @@ struct WindowConfigurator: NSViewRepresentable {
                 window.standardWindowButton(kind)?.isHidden = false
             }
             restoreFrame(of: window)
-            rememberDisplay()
         }
 
         /// Displays come and go. Unplugging the one a fullscreen
@@ -157,20 +156,24 @@ struct WindowConfigurator: NSViewRepresentable {
             }
 
             let centre = NotificationCenter.default
-            let names: [(Notification.Name, Any?)] = [
+            // Only a real change of screen or fullscreen state fits
+            // the window. Becoming main or being uncovered says
+            // nothing about geometry, and fitting on those ran a
+            // clamp at launch that beat the frame being put back.
+            let fits: [(Notification.Name, Any?)] = [
                 (NSApplication.didChangeScreenParametersNotification, nil),
-                (NSWindow.didBecomeMainNotification, window),
                 (NSWindow.didEnterFullScreenNotification, window),
                 (NSWindow.didExitFullScreenNotification, window),
                 (NSWindow.didChangeScreenNotification, window),
-                (NSWindow.didChangeOcclusionStateNotification, window),
             ]
-            for (name, object) in names {
+            for (name, object) in fits {
                 observers.append(centre.addObserver(forName: name, object: object, queue: .main) { [weak self] _ in
-                    MainActor.assumeIsolated {
-                        self?.moved(displayGone: self?.displayGone ?? false)
-                        self?.reportWindowState()
-                    }
+                    MainActor.assumeIsolated { self?.moved(displayGone: self?.displayGone ?? false) }
+                })
+            }
+            for name in [NSWindow.didBecomeMainNotification, NSWindow.didChangeOcclusionStateNotification] {
+                observers.append(centre.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
+                    MainActor.assumeIsolated { self?.reportWindowState() }
                 })
             }
             // A fullscreen space sent to another display posts no
@@ -178,16 +181,9 @@ struct WindowConfigurator: NSViewRepresentable {
             // the screen change, so the window's own move is the one
             // signal it always gives; a resize can carry a window
             // onto another display just as quietly.
-            observers.append(centre.addObserver(
-                forName: NSWindow.didMoveNotification,
-                object: window,
-                queue: .main,
-            ) { [weak self] _ in
-                MainActor.assumeIsolated { self?.movedByHand() }
-            })
-            for name in [NSWindow.didResizeNotification, NSWindow.didEndLiveResizeNotification] {
+            for name in [NSWindow.didMoveNotification, NSWindow.didResizeNotification] {
                 observers.append(centre.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
-                    MainActor.assumeIsolated { self?.placedByHand() }
+                    MainActor.assumeIsolated { self?.frameChanged() }
                 })
             }
             reportWindowState()
@@ -203,33 +199,39 @@ struct WindowConfigurator: NSViewRepresentable {
             onVisibilityChange?(window.occlusionState.contains(.visible))
         }
 
-        /// The window moved. Only fullscreen fits itself on it:
-        /// fitting a dragged window would stop it being pulled past
-        /// a screen edge on purpose. Every window notes where it
-        /// landed.
-        private func movedByHand() {
+        /// The window moved or resized. Only fullscreen fits itself
+        /// on it: fitting a dragged window would stop it being pulled
+        /// past a screen edge on purpose. Any other window records
+        /// where it is now.
+        private func frameChanged() {
             guard window?.styleMask.contains(.fullScreen) == true else {
-                placedByHand()
+                recordFrame()
                 return
             }
 
             moved(displayGone: false)
         }
 
-        /// Records the frame the window was dragged or resized to,
-        /// once the drag or resize has ended and never while it is
-        /// still being put back. A fullscreen frame is only its
-        /// screen's and never the one to come back to.
-        private func placedByHand() {
+        /// Records the frame once a drag or resize has paused. A
+        /// fullscreen frame is only its screen's and never recorded.
+        private func recordFrame() {
             guard isPlacing == false, let window, window.styleMask.contains(.fullScreen) == false else {
                 return
             }
-            guard window.inLiveResize == false else {
-                return
-            }
 
-            UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: Self.frameKey)
-            rememberDisplay()
+            rememberPlacement()
+            recordGeneration += 1
+            let generation = recordGeneration
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.recordSeconds) { [weak self] in
+                guard let self, generation == recordGeneration, let window = self.window else {
+                    return
+                }
+                guard window.styleMask.contains(.fullScreen) == false else {
+                    return
+                }
+
+                UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: Self.frameKey)
+            }
         }
 
         /// The window changed screen or fullscreen state. Fitting
@@ -238,16 +240,16 @@ struct WindowConfigurator: NSViewRepresentable {
         /// notification arrives.
         private func moved(displayGone: Bool) {
             fit(displayGone: displayGone)
-            rememberDisplay()
+            rememberPlacement()
             DispatchQueue.main.asyncAfter(deadline: .now() + Self.settleSeconds) { [weak self] in
                 self?.fit(displayGone: displayGone)
-                self?.rememberDisplay()
+                self?.rememberPlacement()
             }
         }
 
         /// Notes where the window is, and says so only when that
         /// changed.
-        private func rememberDisplay() {
+        private func rememberPlacement() {
             guard isPlacing == false, let window, let current = window.screen?.displayID else {
                 return
             }
@@ -266,94 +268,49 @@ struct WindowConfigurator: NSViewRepresentable {
             onPlacementChange?(placement)
         }
 
-        /// Puts the window back where it was left: the same display,
-        /// and fullscreen again when that is how it was closed. The
-        /// frame is placed before any toggle, since a window in a
-        /// fullscreen space must never be moved.
-        private func restorePlacement(of window: NSWindow) {
-            let defaults = UserDefaults.standard
-            let saved = defaults.string(forKey: Self.displayKey)
-            let screen = saved.flatMap { name in
-                NSScreen.screens.first { $0.displayID.map(NSScreen.uuid(of:)) == name }
-            }
-            if let screen, screen.frame.contains(CGPoint(x: window.frame.midX, y: window.frame.midY)) == false {
-                window.setFrameOrigin(CGPoint(
-                    x: screen.visibleFrame.midX - window.frame.width / Self.halves,
-                    y: screen.visibleFrame.midY - window.frame.height / Self.halves,
-                ))
-            }
-            guard defaults.bool(forKey: Self.fullScreenKey) else {
-                return
-            }
-
-            enterFullScreen(window)
-        }
-
-        /// Goes fullscreen once the window is really on a screen.
-        /// AppKit drops the toggle on a window it has not shown yet,
-        /// which is exactly where this runs from, so it waits for
-        /// one rather than asking once and hoping.
-        private func enterFullScreen(_ window: NSWindow, attempts: Int = ConfiguringView.readyAttempts) {
-            guard window.styleMask.contains(.fullScreen) == false else {
-                return
-            }
-            guard window.isVisible, window.screen != nil else {
-                guard attempts > 0 else {
-                    return
-                }
-
-                DispatchQueue.main.asyncAfter(deadline: .now() + Self.readySeconds) { [weak self] in
-                    self?.enterFullScreen(window, attempts: attempts - 1)
-                }
-                return
-            }
-
-            window.toggleFullScreen(nil)
-        }
-
         /// Puts the window back as it was left. AppKit's autosave is
         /// neither named nor read: SwiftUI holds the name, and since
         /// Monterey restoring through it brings a window left on a
-        /// second display back to the main one. The frame is set over
-        /// whatever AppKit restored, once now so nothing shows at a
-        /// default size, and again once the window is really on a
-        /// screen, since a frame set before then is constrained to
-        /// the main display. A frame too small for three panes is
-        /// thrown away, and with none the window fills the screen it
-        /// lands on.
+        /// second display back to the main one (see the platform
+        /// notes). The frame is set over whatever AppKit restored,
+        /// once now so nothing shows at a default size, and again once
+        /// the window is really on a screen, since a frame set before
+        /// then is constrained to the main display. A frame too small
+        /// for three panes is thrown away, and with none the window
+        /// fills the display it was left on.
         private func restoreFrame(of window: NSWindow) {
             window.setFrameAutosaveName("")
             let saved = UserDefaults.standard.string(forKey: Self.frameKey).map(NSRectFromString)
-            guard let saved, saved.width >= Self.minimumWidth, saved.height >= Self.minimumHeight else {
-                isPlacing = false
+            let usable = saved.flatMap { $0.width >= Self.minimumWidth && $0.height >= Self.minimumHeight ? $0 : nil }
+            if let usable {
+                window.setFrame(usable, display: false)
+            } else {
                 fill(window)
-                restorePlacement(of: window)
-                return
             }
-
-            // Set now, so nothing shows at a default size, and again
-            // once the window is really on a screen: a frame set
-            // before then is constrained to the main display.
-            window.setFrame(saved, display: false)
-            place(window, at: saved)
+            whenOnScreen(window) { [weak self] _ in
+                self?.place(window, at: usable)
+            }
         }
 
-        /// Sets the frame once the window is on a screen, then lets
-        /// moves be recorded and puts the window on its display and
-        /// into fullscreen, in that order: a window in a fullscreen
-        /// space must never be moved.
-        private func place(_ window: NSWindow, at frame: NSRect, attempts: Int = ConfiguringView.readyAttempts) {
-            if window.isVisible, window.screen != nil {
+        /// Puts the window where it was left, now that it is really
+        /// on a screen: the saved frame, or filling the display it
+        /// was left on when there is none, then fullscreen when it
+        /// was closed that way, in that order, since a window in a
+        /// fullscreen space must never be moved. Only from here on
+        /// are its moves recorded and its placement reported.
+        private func place(_ window: NSWindow, at frame: NSRect?) {
+            if let frame {
                 window.setFrame(frame, display: true)
-            } else if attempts > 0 {
-                DispatchQueue.main.asyncAfter(deadline: .now() + Self.readySeconds) { [weak self] in
-                    self?.place(window, at: frame, attempts: attempts - 1)
-                }
-                return
             }
-
+            move(window, ontoDisplay: UserDefaults.standard.string(forKey: Self.displayKey))
+            if frame == nil {
+                fill(window)
+            }
             isPlacing = false
-            restorePlacement(of: window)
+            rememberPlacement()
+            if UserDefaults.standard.bool(forKey: Self.fullScreenKey) {
+                enterFullScreen(window)
+            }
         }
     }
 

--- a/App/WindowConfigurator.swift
+++ b/App/WindowConfigurator.swift
@@ -33,6 +33,13 @@ struct WindowConfigurator: NSViewRepresentable {
         var onVisibilityChange: ((Bool) -> Void)?
         var onPlacementChange: ((Placement) -> Void)?
 
+        /// Set while the saved frame is being put back, so the moves
+        /// that placing causes are neither recorded as the user's own
+        /// nor fitted: a frame AppKit constrained on the way to the
+        /// screen would otherwise be saved over the one being
+        /// restored.
+        private(set) var isPlacing = true
+
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
             guard window != nil else {
@@ -64,8 +71,6 @@ struct WindowConfigurator: NSViewRepresentable {
 
         // MARK: Private
 
-        private static let autosaveName = "AgentIDEMainWindow"
-
         /// The size below which a saved frame is treated as junk.
         /// Small enough to be a deliberate choice on a small
         /// screen, since a window shrunk on purpose must come back
@@ -80,12 +85,11 @@ struct WindowConfigurator: NSViewRepresentable {
         private static let readyAttempts = 20
         private static let readySeconds = 0.2
 
-        /// The margin left around a window filling its screen, and
-        /// what centring divides by.
-        private static let screenInset: CGFloat = 8
+        /// What centring divides by.
         private static let halves: CGFloat = 2
 
         /// Where the window was left, and how.
+        private static let frameKey = "mainWindowFrame"
         private static let displayKey = "mainWindowDisplay"
         private static let fullScreenKey = "mainWindowFullScreen"
 
@@ -181,13 +185,11 @@ struct WindowConfigurator: NSViewRepresentable {
             ) { [weak self] _ in
                 MainActor.assumeIsolated { self?.movedByHand() }
             })
-            observers.append(centre.addObserver(
-                forName: NSWindow.didResizeNotification,
-                object: window,
-                queue: .main,
-            ) { [weak self] _ in
-                MainActor.assumeIsolated { self?.placedByHand() }
-            })
+            for name in [NSWindow.didResizeNotification, NSWindow.didEndLiveResizeNotification] {
+                observers.append(centre.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
+                    MainActor.assumeIsolated { self?.placedByHand() }
+                })
+            }
             reportWindowState()
         }
 
@@ -215,18 +217,18 @@ struct WindowConfigurator: NSViewRepresentable {
         }
 
         /// Records the frame the window was dragged or resized to,
-        /// under this app's own name. Naming the autosave is not
-        /// enough: SwiftUI names the window's autosave itself once
-        /// its content is up, after which AppKit saves every change
-        /// under that name and none under this one, and the next
-        /// launch found nothing and filled the main display. A
-        /// fullscreen frame is never the one to come back to.
+        /// once the drag or resize has ended and never while it is
+        /// still being put back. A fullscreen frame is only its
+        /// screen's and never the one to come back to.
         private func placedByHand() {
-            guard let window, window.styleMask.contains(.fullScreen) == false else {
+            guard isPlacing == false, let window, window.styleMask.contains(.fullScreen) == false else {
+                return
+            }
+            guard window.inLiveResize == false else {
                 return
             }
 
-            window.saveFrame(usingName: Self.autosaveName)
+            UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: Self.frameKey)
             rememberDisplay()
         }
 
@@ -246,7 +248,7 @@ struct WindowConfigurator: NSViewRepresentable {
         /// Notes where the window is, and says so only when that
         /// changed.
         private func rememberDisplay() {
-            guard let window, let current = window.screen?.displayID else {
+            guard isPlacing == false, let window, let current = window.screen?.displayID else {
                 return
             }
 
@@ -262,17 +264,6 @@ struct WindowConfigurator: NSViewRepresentable {
             defaults.set(NSScreen.uuid(of: current), forKey: Self.displayKey)
             defaults.set(placement.isFullScreen, forKey: Self.fullScreenKey)
             onPlacementChange?(placement)
-        }
-
-        /// Fills whichever screen the window is on, less a margin: a
-        /// fixed default is either too big for a laptop or too small
-        /// for a desk.
-        private func fill(_ window: NSWindow) {
-            guard let visible = (window.screen ?? NSScreen.main)?.visibleFrame else {
-                return
-            }
-
-            window.setFrame(visible.insetBy(dx: Self.screenInset, dy: Self.screenInset), display: true)
         }
 
         /// Puts the window back where it was left: the same display,
@@ -320,35 +311,48 @@ struct WindowConfigurator: NSViewRepresentable {
             window.toggleFullScreen(nil)
         }
 
-        /// Puts the window back as it was left: the autosaved frame
-        /// applied rather than merely named, on the display it was
-        /// closed on, fullscreen again when it was closed that way,
-        /// and filling whichever screen it lands on when there is
-        /// nothing saved or what was saved is too small for three
-        /// panes. macOS reopens a fullscreen space on the display it
-        /// chooses, which is why the display is remembered by its
-        /// own identity and the window placed before any toggle.
+        /// Puts the window back as it was left. AppKit's autosave is
+        /// neither named nor read: SwiftUI holds the name, and since
+        /// Monterey restoring through it brings a window left on a
+        /// second display back to the main one. The frame is set over
+        /// whatever AppKit restored, once now so nothing shows at a
+        /// default size, and again once the window is really on a
+        /// screen, since a frame set before then is constrained to
+        /// the main display. A frame too small for three panes is
+        /// thrown away, and with none the window fills the screen it
+        /// lands on.
         private func restoreFrame(of window: NSWindow) {
-            guard window.frameAutosaveName != Self.autosaveName else {
-                return
-            }
-
-            window.setFrameAutosaveName(Self.autosaveName)
-            // Naming the autosave does not apply it: without this the
-            // window opens at whatever size its content asked for,
-            // which changed the moment the sidebar started painting
-            // from cache. A frame too small for the panes is grown to
-            // the default rather than restored as saved.
-            if window.setFrameUsingName(Self.autosaveName) {
-                let minimum = NSSize(width: Self.minimumWidth, height: Self.minimumHeight)
-                if window.frame.width < minimum.width || window.frame.height < minimum.height {
-                    fill(window)
-                }
+            window.setFrameAutosaveName("")
+            let saved = UserDefaults.standard.string(forKey: Self.frameKey).map(NSRectFromString)
+            guard let saved, saved.width >= Self.minimumWidth, saved.height >= Self.minimumHeight else {
+                isPlacing = false
+                fill(window)
                 restorePlacement(of: window)
                 return
             }
 
-            fill(window)
+            // Set now, so nothing shows at a default size, and again
+            // once the window is really on a screen: a frame set
+            // before then is constrained to the main display.
+            window.setFrame(saved, display: false)
+            place(window, at: saved)
+        }
+
+        /// Sets the frame once the window is on a screen, then lets
+        /// moves be recorded and puts the window on its display and
+        /// into fullscreen, in that order: a window in a fullscreen
+        /// space must never be moved.
+        private func place(_ window: NSWindow, at frame: NSRect, attempts: Int = ConfiguringView.readyAttempts) {
+            if window.isVisible, window.screen != nil {
+                window.setFrame(frame, display: true)
+            } else if attempts > 0 {
+                DispatchQueue.main.asyncAfter(deadline: .now() + Self.readySeconds) { [weak self] in
+                    self?.place(window, at: frame, attempts: attempts - 1)
+                }
+                return
+            }
+
+            isPlacing = false
             restorePlacement(of: window)
         }
     }

--- a/App/WindowConfigurator.swift
+++ b/App/WindowConfigurator.swift
@@ -49,6 +49,12 @@ struct WindowConfigurator: NSViewRepresentable {
                 let centre = NotificationCenter.default
                 observers.forEach(centre.removeObserver)
                 observers = []
+                // A window hidden for a placement this view no
+                // longer lives to finish must not stay hidden.
+                if pendingPlacement != nil {
+                    pendingPlacement = nil
+                    configuredWindow?.alphaValue = 1
+                }
                 return
             }
 
@@ -99,6 +105,11 @@ struct WindowConfigurator: NSViewRepresentable {
         /// Which recording is the latest, so an earlier one still
         /// waiting on its pause writes nothing.
         private var recordGeneration = 0
+
+        /// The placement waiting for the window to be on a screen,
+        /// run by the first notification that finds it there, or by
+        /// the poll when none comes.
+        private var pendingPlacement: (() -> Void)?
 
         /// The window already configured, so re-renders reconfigure
         /// nothing.
@@ -171,9 +182,14 @@ struct WindowConfigurator: NSViewRepresentable {
                     MainActor.assumeIsolated { self?.moved(displayGone: self?.displayGone ?? false) }
                 })
             }
+            // These are also the first word that the window is on a
+            // screen, which is what a pending placement waits for.
             for name in [NSWindow.didBecomeMainNotification, NSWindow.didChangeOcclusionStateNotification] {
                 observers.append(centre.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
-                    MainActor.assumeIsolated { self?.reportWindowState() }
+                    MainActor.assumeIsolated {
+                        self?.reportWindowState()
+                        self?.runPendingPlacementIfVisible()
+                    }
                 })
             }
             // A fullscreen space sent to another display posts no
@@ -275,9 +291,10 @@ struct WindowConfigurator: NSViewRepresentable {
         /// notes). The frame is set over whatever AppKit restored,
         /// once now so nothing shows at a default size, and again once
         /// the window is really on a screen, since a frame set before
-        /// then is constrained to the main display. A frame too small
-        /// for three panes is thrown away, and with none the window
-        /// fills the display it was left on.
+        /// then is constrained to the main display; the window stays
+        /// invisible until then rather than flash on the main display.
+        /// A frame too small for three panes is thrown away, and with
+        /// none the window fills the display it was left on.
         private func restoreFrame(of window: NSWindow) {
             window.setFrameAutosaveName("")
             let saved = UserDefaults.standard.string(forKey: Self.frameKey).map(NSRectFromString)
@@ -287,17 +304,48 @@ struct WindowConfigurator: NSViewRepresentable {
             } else {
                 fill(window)
             }
-            whenOnScreen(window) { [weak self] _ in
-                self?.place(window, at: usable)
+            window.alphaValue = 0
+            pendingPlacement = { [weak self] in self?.place(window, at: usable) }
+            // The notifications place it the moment it is drawn; the
+            // poll is for a window that never says so, which is shown
+            // where it is rather than left invisible, and still placed
+            // if it appears later.
+            whenOnScreen(window) { [weak self] onScreen in
+                if onScreen {
+                    self?.runPendingPlacement()
+                } else {
+                    window.alphaValue = 1
+                }
             }
+        }
+
+        /// A visible window with no screen is placed too: its frame
+        /// is off every screen, and placing is what brings it back.
+        private func runPendingPlacementIfVisible() {
+            guard window?.isVisible == true else {
+                return
+            }
+
+            runPendingPlacement()
+        }
+
+        private func runPendingPlacement() {
+            guard let pending = pendingPlacement else {
+                return
+            }
+
+            pendingPlacement = nil
+            pending()
         }
 
         /// Puts the window where it was left, now that it is really
         /// on a screen: the saved frame, or filling the display it
-        /// was left on when there is none, then fullscreen when it
-        /// was closed that way, in that order, since a window in a
-        /// fullscreen space must never be moved. Only from here on
-        /// are its moves recorded and its placement reported.
+        /// was left on when there is none, then shows it, then
+        /// fullscreen when it was closed that way, in that order,
+        /// since a window in a fullscreen space must never be moved.
+        /// A frame left on a display that has gone is brought onto
+        /// one that exists. Only from here on are its moves recorded
+        /// and its placement reported.
         private func place(_ window: NSWindow, at frame: NSRect?) {
             if let frame {
                 window.setFrame(frame, display: true)
@@ -306,6 +354,10 @@ struct WindowConfigurator: NSViewRepresentable {
             if frame == nil {
                 fill(window)
             }
+            if window.screen == nil {
+                fitToScreen()
+            }
+            window.alphaValue = 1
             isPlacing = false
             rememberPlacement()
             if UserDefaults.standard.bool(forKey: Self.fullScreenKey) {

--- a/App/WindowConfigurator.swift
+++ b/App/WindowConfigurator.swift
@@ -9,6 +9,13 @@ import SwiftUI
 /// launches. SwiftUI's toolbar hiding removed the dead strip but
 /// took the traffic lights with it; AppKit puts them back.
 struct WindowConfigurator: NSViewRepresentable {
+    /// Where the window is: the display it sits on and whether it
+    /// fills it.
+    struct Placement: Equatable {
+        let displayID: CGDirectDisplayID
+        let isFullScreen: Bool
+    }
+
     /// A zero-sized view that configures whatever window hosts it.
     final class ConfiguringView: NSView {
         // MARK: Lifecycle
@@ -24,7 +31,7 @@ struct WindowConfigurator: NSViewRepresentable {
 
         /// The representable's callbacks, refreshed per update.
         var onVisibilityChange: ((Bool) -> Void)?
-        var onFullScreenChange: ((Bool) -> Void)?
+        var onPlacementChange: ((Placement) -> Void)?
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
@@ -93,10 +100,11 @@ struct WindowConfigurator: NSViewRepresentable {
         /// nothing.
         private weak var configuredWindow: NSWindow?
 
-        /// The display the window was last seen on, so a screen
-        /// change can tell one that has gone from one that merely
-        /// changed resolution or place.
-        private var lastDisplayID: CGDirectDisplayID?
+        /// Where the window was last seen, so a screen change can
+        /// tell a display that has gone from one that merely changed
+        /// resolution or place, and a move that changed nothing
+        /// reports nothing.
+        private var lastPlacement: Placement?
 
         /// Whether the display the window was last seen on has gone.
         /// Screen parameters change for resolution, scaling and
@@ -104,7 +112,7 @@ struct WindowConfigurator: NSViewRepresentable {
         /// all of those: only a display that is really absent earns
         /// the frame being set by hand.
         private var displayGone: Bool {
-            guard let last = lastDisplayID else {
+            guard let last = lastPlacement?.displayID else {
                 return false
             }
 
@@ -164,33 +172,42 @@ struct WindowConfigurator: NSViewRepresentable {
             // A fullscreen space sent to another display posts no
             // screen-parameter change and does not always announce
             // the screen change, so the window's own move is the one
-            // signal it always gives. Only fullscreen acts on it:
-            // fitting a dragged window would stop it being pulled
-            // past a screen edge on purpose.
+            // signal it always gives; a resize can carry a window
+            // onto another display just as quietly.
             observers.append(centre.addObserver(
                 forName: NSWindow.didMoveNotification,
                 object: window,
                 queue: .main,
             ) { [weak self] _ in
-                MainActor.assumeIsolated { self?.movedIfFullScreen() }
+                MainActor.assumeIsolated { self?.movedByHand() }
+            })
+            observers.append(centre.addObserver(
+                forName: NSWindow.didResizeNotification,
+                object: window,
+                queue: .main,
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.rememberDisplay() }
             })
             reportWindowState()
         }
 
         /// Minimised or fully covered, the window is not being
-        /// read and the poll slows; fullscreen hides the traffic
-        /// lights and the sidebar reclaims their band.
+        /// read and the poll slows.
         private func reportWindowState() {
             guard let window else {
                 return
             }
 
             onVisibilityChange?(window.occlusionState.contains(.visible))
-            onFullScreenChange?(window.styleMask.contains(.fullScreen))
         }
 
-        private func movedIfFullScreen() {
+        /// The window moved. Only fullscreen fits itself on it:
+        /// fitting a dragged window would stop it being pulled past
+        /// a screen edge on purpose. Every window notes where it
+        /// landed.
+        private func movedByHand() {
             guard window?.styleMask.contains(.fullScreen) == true else {
+                rememberDisplay()
                 return
             }
 
@@ -210,17 +227,25 @@ struct WindowConfigurator: NSViewRepresentable {
             }
         }
 
+        /// Notes where the window is, and says so only when that
+        /// changed.
         private func rememberDisplay() {
-            guard let current = window?.screen?.displayID else {
+            guard let window, let current = window.screen?.displayID else {
                 return
             }
 
-            lastDisplayID = current
+            let placement = Placement(displayID: current, isFullScreen: window.styleMask.contains(.fullScreen))
+            guard placement != lastPlacement else {
+                return
+            }
+
+            lastPlacement = placement
             // Where and how the window was left, for the next run:
             // its own display, and whether it was filling it.
             let defaults = UserDefaults.standard
             defaults.set(NSScreen.uuid(of: current), forKey: Self.displayKey)
-            defaults.set(window?.styleMask.contains(.fullScreen) == true, forKey: Self.fullScreenKey)
+            defaults.set(placement.isFullScreen, forKey: Self.fullScreenKey)
+            onPlacementChange?(placement)
         }
 
         /// Fills whichever screen the window is on, less a margin: a
@@ -279,70 +304,6 @@ struct WindowConfigurator: NSViewRepresentable {
             window.toggleFullScreen(nil)
         }
 
-        private func fit(displayGone: Bool) {
-            guard let window else {
-                return
-            }
-
-            if window.styleMask.contains(.fullScreen) {
-                fitFullScreen(of: window, hasLostDisplay: displayGone)
-            } else {
-                fitToScreen()
-            }
-            // The space a fullscreen window lands on paints black
-            // behind it; a window that fitted itself into one must
-            // ask for the redraw that the move itself never did.
-            window.viewsNeedDisplay = true
-            window.displayIfNeeded()
-        }
-
-        /// A fullscreen window keeps the size of the display it was
-        /// on when that display goes. macOS moves the space to a
-        /// screen that exists, but the content stays drawn to the
-        /// old, larger frame: what shows is the black behind it.
-        /// Only the display the window was on going away is fitted
-        /// by hand: AppKit owns the frame of a window in a
-        /// fullscreen space, and setting it while a space merely
-        /// moved between two live displays left both screens black
-        /// until the app was killed, which a resolution, scaling or
-        /// arrangement change must not be able to reproduce. Every
-        /// other change lays the content out again for the size
-        /// AppKit gave it, and nothing more.
-        private func fitFullScreen(of window: NSWindow, hasLostDisplay: Bool) {
-            guard let screen = window.screen else {
-                // No screen at all to fit: leaving fullscreen puts
-                // the window back on one that exists.
-                window.toggleFullScreen(nil)
-                return
-            }
-            guard hasLostDisplay, window.frame != screen.frame else {
-                window.contentView?.needsLayout = true
-                window.contentView?.layoutSubtreeIfNeeded()
-                return
-            }
-
-            window.setFrame(screen.frame, display: true, animate: false)
-        }
-
-        /// Brings the frame back inside the screen it is on, keeping
-        /// its size where it fits and its corner where it can.
-        private func fitToScreen() {
-            guard let window, let visible = (window.screen ?? NSScreen.main)?.visibleFrame else {
-                return
-            }
-
-            var frame = window.frame
-            frame.size.width = min(frame.width, visible.width)
-            frame.size.height = min(frame.height, visible.height)
-            frame.origin.x = min(max(frame.minX, visible.minX), visible.maxX - frame.width)
-            frame.origin.y = min(max(frame.minY, visible.minY), visible.maxY - frame.height)
-            guard frame != window.frame else {
-                return
-            }
-
-            window.setFrame(frame, display: true, animate: false)
-        }
-
         /// Puts the window back as it was left: the autosaved frame
         /// applied rather than merely named, on the display it was
         /// closed on, fullscreen again when it was closed that way,
@@ -383,9 +344,10 @@ struct WindowConfigurator: NSViewRepresentable {
     /// window is ours.
     let onVisibilityChange: (Bool) -> Void
 
-    /// Told when the window enters or leaves fullscreen, where the
-    /// traffic lights hide and the sidebar can start higher.
-    let onFullScreenChange: (Bool) -> Void
+    /// Told where the window is whenever that changes: the display
+    /// it landed on, and whether it is fullscreen, where the traffic
+    /// lights hide and the sidebar can start higher.
+    let onPlacementChange: (Placement) -> Void
 
     func makeNSView(context _: Context) -> ConfiguringView {
         ConfiguringView()
@@ -393,7 +355,7 @@ struct WindowConfigurator: NSViewRepresentable {
 
     func updateNSView(_ view: ConfiguringView, context _: Context) {
         view.onVisibilityChange = onVisibilityChange
-        view.onFullScreenChange = onFullScreenChange
+        view.onPlacementChange = onPlacementChange
         view.configureWindowIfNeeded()
     }
 }

--- a/App/WindowConfigurator.swift
+++ b/App/WindowConfigurator.swift
@@ -186,7 +186,7 @@ struct WindowConfigurator: NSViewRepresentable {
                 object: window,
                 queue: .main,
             ) { [weak self] _ in
-                MainActor.assumeIsolated { self?.rememberDisplay() }
+                MainActor.assumeIsolated { self?.placedByHand() }
             })
             reportWindowState()
         }
@@ -207,11 +207,27 @@ struct WindowConfigurator: NSViewRepresentable {
         /// landed.
         private func movedByHand() {
             guard window?.styleMask.contains(.fullScreen) == true else {
-                rememberDisplay()
+                placedByHand()
                 return
             }
 
             moved(displayGone: false)
+        }
+
+        /// Records the frame the window was dragged or resized to,
+        /// under this app's own name. Naming the autosave is not
+        /// enough: SwiftUI names the window's autosave itself once
+        /// its content is up, after which AppKit saves every change
+        /// under that name and none under this one, and the next
+        /// launch found nothing and filled the main display. A
+        /// fullscreen frame is never the one to come back to.
+        private func placedByHand() {
+            guard let window, window.styleMask.contains(.fullScreen) == false else {
+                return
+            }
+
+            window.saveFrame(usingName: Self.autosaveName)
+            rememberDisplay()
         }
 
         /// The window changed screen or fullscreen state. Fitting


### PR DESCRIPTION
- Detect where the window is placed and report it through one placement callback
- Keep the window frame in the app's own defaults, since SwiftUI holds the autosave name
- Set the frame by hand once the window is on a screen, working around AppKit restoring to the main display since Monterey
- Fill the remembered display, not the main one, when no frame is saved
- Stop launch-time fitting from clamping a frame that was just restored
- Record the frame once a drag or resize pauses rather than per pixel
- Keep the window invisible until it is placed, so it never flashes on the main display
- Document the window's defaults keys and the autosave behaviour in ARCHITECTURE.md and the platform notes

----

The desire behind the PR is for the window to remember where it was between being closed and opened. It currently always defaults to opening maximised on the primary display. I'm not super well-versed in Swift, but two rounds with different Claude models ended up with the same fix. 

Happy to close and move on if it's not desirable, or there's a more elegant solution.