### PR TITLE
Harden sandbox launch through a single SandboxLaunching injection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,7 +92,9 @@ plus resume.
 sandvault's sudoers rules let the host user run exactly `/bin/zsh`,
 `/usr/bin/env` and `/usr/bin/true` as the sandbox user without a
 password, so every sandbox interaction uses one launch shape, assembled
-in exactly one place (`SandvaultLauncher`):
+in exactly one place through the `SandboxLaunching` protocol
+(`SandvaultLauncher` is the macOS implementation). Call sites hold
+one injected launcher and never reconstruct it:
 
 ```bash
 sudo --login --set-home --user="sandvault-${USER}" /usr/bin/env -i \
@@ -313,7 +315,7 @@ flowchart TD
   network and database APIs are banned.
 - **AgentIDEData**: the adapters, composed by `SessionService`:
   `GitClient`, `GitHubClient` (every question through the host's `gh`),
-  `SandvaultLauncher`, `HerdrClient`, `HerdrTerminalChannel`,
+  `SandboxLaunching` (`SandvaultLauncher`), `HerdrClient`, `HerdrTerminalChannel`,
   `TranscriptReader` and `CodexTranscriptIndex`, `EventSpool`,
   `MetadataStore` (one JSON file), `PullRequestStore`, `ProcessRunner`
   (Foundation `Process`), `WorkspaceWatcher` (FSEvents),
@@ -1255,5 +1257,5 @@ Not scheduled, recorded so the pieces already built line up with them:
 | R1 | herdr is pre-1.0; releases may change behaviour | schema'd protocol; integration tests run against the real server so drift fails loudly; app-owned PTYs are not acceptable because they forfeit resilience |
 | R2 | the `xcode-27` runner image may change or lag betas | jobs assert Xcode 27 and fail loudly; self-hosted is the fallback |
 | R3 | agent transcript formats drift | tolerant decoders, per-release fixtures |
-| R4 | sandvault updates could change paths, profile or sudoers | `SandvaultLauncher` is the single construction point |
+| R4 | sandvault updates could change paths, profile or sudoers | `SandboxLaunching` / `SandvaultLauncher` is the single construction point |
 | R5 | resume ids depend on transcript internals | record defensively; fall back to a fresh session in the same worktree |

--- a/App/AppDependencies.swift
+++ b/App/AppDependencies.swift
@@ -1,4 +1,5 @@
 import AgentIDEData
+import AgentIDEDomain
 import DashboardFeature
 import TerminalUI
 
@@ -10,15 +11,19 @@ final class AppDependencies {
 
     init() {
         defer { Self.shared = self }
+        let roots = PlatformRoots.detect()
+        PerformanceLog.sharedTemporaryDirectory = roots.sharedTemporaryDirectory
         let paths = WorkspacePaths.current()
         let runner = FoundationProcessRunner()
         let gitClient = GitClient(runner: runner)
         let githubClient = GitHubClient(runner: runner)
         let metadataStore = MetadataStore(file: paths.metadataFile)
         let launchProgress = LaunchProgress()
+        let launcher = SandvaultLauncher(hostUser: paths.hostUser)
+        let power: any PowerObserving = IOKitPower()
         let herdr = HerdrClient(
             runner: runner,
-            launcher: SandvaultLauncher(hostUser: paths.hostUser),
+            launcher: launcher,
             isInsideSandbox: WorkspacePaths.isInsideSandbox,
             progress: launchProgress.reporter,
         )
@@ -31,6 +36,8 @@ final class AppDependencies {
             spool: EventSpool(directory: paths.eventsDirectory),
             store: metadataStore,
             runners: [ClaudeCodeRunner(), CodexRunner()],
+            launcher: launcher,
+            summariser: FoundationModelClient(),
             progress: launchProgress.reporter,
         )
         git = gitClient
@@ -45,7 +52,7 @@ final class AppDependencies {
         )
         // The machine's own power state, wired here rather than read
         // by the model, so the model under test is always plugged in.
-        dashboard.isOnBattery = { PowerSource.isOnBattery }
+        dashboard.isOnBattery = { power.isOnBattery }
         // Off the launch path: installing hooks writes into the
         // shared workspace and nothing about the first paint needs
         // it done first.

--- a/Package.swift
+++ b/Package.swift
@@ -140,7 +140,7 @@ let package = Package(
         ),
         .testTarget(
             name: "AgentIDEDataTests",
-            dependencies: ["AgentIDEData"],
+            dependencies: ["AgentIDEData", "AgentIDEDomain"],
             swiftSettings: approachableConcurrency,
         ),
         .testTarget(

--- a/Sources/AgentIDEData/FileWatching.swift
+++ b/Sources/AgentIDEData/FileWatching.swift
@@ -1,0 +1,15 @@
+/// A watcher over workspace roots whose file-system events decide
+/// when a repository's git is worth reading again. Mac uses FSEvents;
+/// Linux will use inotify.
+public protocol FileWatching: Sendable {
+    /// Whether the stream is running; false answers every question
+    /// with "assume changed", so a machine where watching fails
+    /// falls back to time-based reads.
+    var isWatching: Bool { get }
+
+    /// Starts watching; safe to call more than once.
+    func start()
+
+    /// The directories changed since last asked, cleared by the asking.
+    func consumeChangedPaths() -> Set<String>
+}

--- a/Sources/AgentIDEData/FoundationModelClient.swift
+++ b/Sources/AgentIDEData/FoundationModelClient.swift
@@ -1,11 +1,16 @@
+import AgentIDEDomain
 import Foundation
-import FoundationModels
+#if canImport(FoundationModels)
+    import FoundationModels
+#endif
+
+// MARK: - FoundationModelClient
 
 /// The on-device Apple foundation model, kept behind one client so
 /// summarisation is reusable: branch names today, commit and pull
 /// request summaries later. Every helper answers nil when the model
 /// is unavailable or unhelpful, so callers always carry a fallback.
-public struct FoundationModelClient: Sendable {
+public struct FoundationModelClient: OnDeviceSummarising, Sendable {
     // MARK: Lifecycle
 
     /// Creates the client; availability is checked per call.
@@ -20,12 +25,18 @@ public struct FoundationModelClient: Sendable {
     /// One instruction applied to one input, nil when the on-device
     /// model is unavailable or errors.
     public func respond(instructions: String, to input: String) async -> String? {
-        guard isEnabled, SystemLanguageModel.default.isAvailable else {
+        guard isEnabled else {
             return nil
         }
 
-        let session = LanguageModelSession(instructions: instructions)
-        return try? await session.respond(to: input).content
+        #if canImport(FoundationModels)
+            if #available(macOS 26, *) {
+                return await respondWithFoundationModel(instructions: instructions, to: input)
+            }
+            return nil
+        #else
+            return nil
+        #endif
     }
 
     /// A short underscore-separated branch name summarising a
@@ -41,7 +52,7 @@ public struct FoundationModelClient: Sendable {
             return nil
         }
 
-        return Self.branchName(fromModelAnswer: raw)
+        return ModelAnswerParsing.branchName(fromModelAnswer: raw)
     }
 
     /// A commit message drafted from a diff: a subject line, a
@@ -80,12 +91,12 @@ public struct FoundationModelClient: Sendable {
         whole branch as a dash list, grouping related work, with every line \
         under 73 characters. Answer with the title and body alone.
         """
-        let input = Self.commitDigest(commits, branch: branch, limit: Self.commitsLimit)
+        let input = ModelAnswerParsing.commitDigest(commits, branch: branch, limit: Self.commitsLimit)
         guard let raw = await respond(instructions: instructions, to: input) else {
             return nil
         }
 
-        return Self.pullRequestDescription(fromModelAnswer: raw)
+        return ModelAnswerParsing.pullRequestDescription(fromModelAnswer: raw)
     }
 
     /// The repository's pull request template completed from the
@@ -98,122 +109,47 @@ public struct FoundationModelClient: Sendable {
         checkbox only when the commits clearly justify it. Answer with the \
         completed template alone.
         """
-        let input = Self.commitDigest(commits, branch: nil, limit: Self.commitsLimit)
+        let input = ModelAnswerParsing.commitDigest(commits, branch: nil, limit: Self.commitsLimit)
             + "\n\nTemplate:\n\n" + String(template.prefix(Self.commitsLimit))
         guard let raw = await respond(instructions: instructions, to: input) else {
             return nil
         }
 
-        let filled = Self.strippedCodeFences(raw).trimmingCharacters(in: .whitespacesAndNewlines)
+        let filled = ModelAnswerParsing.strippedCodeFences(raw).trimmingCharacters(in: .whitespacesAndNewlines)
         return filled.isEmpty ? nil : filled
     }
 
     // MARK: Internal
 
-    /// Lays the branch out for the model: its name when given, every
-    /// commit's subject first, so a tight context budget never hides
-    /// later commits entirely, then each commit's whole message while
-    /// the budget allows, so the why in bodies informs the draft too.
+    /// Forwards to `ModelAnswerParsing` so existing tests keep calling
+    /// these names on the client.
     static func commitDigest(_ commits: [String], branch: String?, limit: Int) -> String {
-        let subjects = commits.map { commit in
-            commit.split(separator: "\n").first.map(String.init) ?? ""
-        }
-        // Parenthesised: `??` binds looser than `+`, and without
-        // them a named branch lost the whole subject list.
-        let head = (branch.map { "Branch: " + $0 + "\n\n" } ?? "")
-            + "Subjects:\n" + subjects.joined(separator: "\n")
-        var details = ""
-        for (index, commit) in commits.enumerated() where commit.contains("\n") {
-            let block = "\n\nCommit " + String(index + 1) + ":\n" + commit
-            guard head.count + details.count + block.count <= limit else {
-                break
-            }
-
-            details += block
-        }
-        return details.isEmpty ? head : head + "\n\nDetails:" + details
+        ModelAnswerParsing.commitDigest(commits, branch: branch, limit: limit)
     }
 
-    /// Splits a model answer into title and body, nil when nothing
-    /// usable came back; models sometimes wrap answers in quotes or
-    /// markdown heading markers despite instructions.
+    /// Forwards to `ModelAnswerParsing`.
     static func pullRequestDescription(fromModelAnswer raw: String) -> (title: String, body: String)? {
-        let lines = Self.strippedCodeFences(raw).trimmingCharacters(in: .whitespacesAndNewlines).split(
-            separator: "\n",
-            omittingEmptySubsequences: false,
-        )
-        let title = String(lines.first ?? "")
-            .trimmingCharacters(in: .whitespaces)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "#*\"'`"))
-            .trimmingCharacters(in: .whitespaces)
-        guard title.isEmpty == false else {
-            return nil
-        }
-
-        let body = lines.dropFirst()
-            .map(Self.collapsedListMarker)
-            .joined(separator: "\n")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return (Self.capitalisedFirst(title), body)
+        ModelAnswerParsing.pullRequestDescription(fromModelAnswer: raw)
     }
 
-    /// Drops Markdown fence lines; models sometimes wrap answers in
-    /// code blocks despite instructions, and a fence line carries no
-    /// content of its own.
+    /// Forwards to `ModelAnswerParsing`.
     static func strippedCodeFences(_ text: String) -> String {
-        text.split(separator: "\n", omittingEmptySubsequences: false)
-            .filter { $0.trimmingCharacters(in: .whitespaces).hasPrefix("```") == false }
-            .joined(separator: "\n")
+        ModelAnswerParsing.strippedCodeFences(text)
     }
 
-    /// Uppercases only the leading character; models sometimes echo
-    /// a lowercase commit subject as the title.
+    /// Forwards to `ModelAnswerParsing`.
     static func capitalisedFirst(_ text: String) -> String {
-        guard let first = text.first else {
-            return text
-        }
-
-        return first.uppercased() + text.dropFirst()
+        ModelAnswerParsing.capitalisedFirst(text)
     }
 
-    /// Collapses repeated list markers like `- - item` to one dash;
-    /// models echo commit bodies that are already dash lists and
-    /// prefix another dash. Lines not starting with `- ` (including
-    /// `--flags` and indented continuations) pass through untouched.
+    /// Forwards to `ModelAnswerParsing`.
     static func collapsedListMarker(_ line: Substring) -> String {
-        let indent = line.prefix { $0 == " " }
-        var rest = line.dropFirst(indent.count)
-        var isListItem = false
-        while rest.first == "-", rest.dropFirst().first == " " {
-            isListItem = true
-            rest = rest.dropFirst().drop { $0 == " " }
-        }
-        return isListItem ? indent + "- " + rest : String(line)
+        ModelAnswerParsing.collapsedListMarker(line)
     }
 
-    /// Normalises a model answer into a safe branch name, nil when
-    /// nothing usable remains; models sometimes answer with quotes,
-    /// punctuation or prose despite instructions.
+    /// Forwards to `ModelAnswerParsing`.
     static func branchName(fromModelAnswer raw: String) -> String? {
-        var cleaned = ""
-        for character in raw.lowercased() {
-            cleaned.append(character.isLetter || character.isNumber ? character : " ")
-        }
-        let words = cleaned.split(separator: " ").map(String.init)
-        var name = ""
-        for word in words {
-            let candidate = name.isEmpty ? word : name + "_" + word
-            guard candidate.count <= Self.nameLimit else {
-                break
-            }
-
-            name = candidate
-        }
-        guard name.isEmpty == false, name.contains(where: \.isLetter) else {
-            return nil
-        }
-
-        return name
+        ModelAnswerParsing.branchName(fromModelAnswer: raw)
     }
 
     // MARK: Private
@@ -228,8 +164,17 @@ public struct FoundationModelClient: Sendable {
     /// Enough commit text for a description within the context cap.
     private static let commitsLimit = 8_000
 
-    /// Git and the file system are happier with short branch names.
-    private static let nameLimit = 40
-
     private let isEnabled: Bool
+
+    #if canImport(FoundationModels)
+        @available(macOS 26, *)
+        private func respondWithFoundationModel(instructions: String, to input: String) async -> String? {
+            guard SystemLanguageModel.default.isAvailable else {
+                return nil
+            }
+
+            let session = LanguageModelSession(instructions: instructions)
+            return try? await session.respond(to: input).content
+        }
+    #endif
 }

--- a/Sources/AgentIDEData/FoundationModelClient.swift
+++ b/Sources/AgentIDEData/FoundationModelClient.swift
@@ -119,39 +119,6 @@ public struct FoundationModelClient: OnDeviceSummarising, Sendable {
         return filled.isEmpty ? nil : filled
     }
 
-    // MARK: Internal
-
-    /// Forwards to `ModelAnswerParsing` so existing tests keep calling
-    /// these names on the client.
-    static func commitDigest(_ commits: [String], branch: String?, limit: Int) -> String {
-        ModelAnswerParsing.commitDigest(commits, branch: branch, limit: limit)
-    }
-
-    /// Forwards to `ModelAnswerParsing`.
-    static func pullRequestDescription(fromModelAnswer raw: String) -> (title: String, body: String)? {
-        ModelAnswerParsing.pullRequestDescription(fromModelAnswer: raw)
-    }
-
-    /// Forwards to `ModelAnswerParsing`.
-    static func strippedCodeFences(_ text: String) -> String {
-        ModelAnswerParsing.strippedCodeFences(text)
-    }
-
-    /// Forwards to `ModelAnswerParsing`.
-    static func capitalisedFirst(_ text: String) -> String {
-        ModelAnswerParsing.capitalisedFirst(text)
-    }
-
-    /// Forwards to `ModelAnswerParsing`.
-    static func collapsedListMarker(_ line: Substring) -> String {
-        ModelAnswerParsing.collapsedListMarker(line)
-    }
-
-    /// Forwards to `ModelAnswerParsing`.
-    static func branchName(fromModelAnswer raw: String) -> String? {
-        ModelAnswerParsing.branchName(fromModelAnswer: raw)
-    }
-
     // MARK: Private
 
     /// Enough of a diff to summarise without paying for a whole

--- a/Sources/AgentIDEData/HerdrClient.swift
+++ b/Sources/AgentIDEData/HerdrClient.swift
@@ -79,7 +79,7 @@ public struct HerdrClient: Sendable {
     /// config home, so neither can list or kill the other's.
     public init(
         runner: any ProcessRunner,
-        launcher: SandvaultLauncher,
+        launcher: any SandboxLaunching,
         isInsideSandbox: Bool,
         configHome: String? = nil,
         progress: @escaping LaunchReporter = silentLaunchReporter,
@@ -146,15 +146,14 @@ public struct HerdrClient: Sendable {
         let log = "\"${XDG_CONFIG_HOME:-$HOME/.config}/herdr/agentide-server.log\""
         let payload = exportPrefix
             + "herdr api snapshot &>/dev/null && exit 0; "
-            + (isInsideSandbox ? "" : "cd ~ && ~/configure; "
-                + "source ~/.zshenv; source ~/.zprofile; source ~/.zshrc; ")
+            + (isInsideSandbox ? "" : launcher.profileBootstrap)
             + "mkdir -p \"$(dirname " + log + ")\"; "
-            + "herdr server &> " + log + " &!; "
+            + "herdr server &> " + log + " " + launcher.detachSuffix + "; "
             + "for _ in {1..50}; do herdr api snapshot &>/dev/null && exit 0; sleep 0.1; done; "
             + "cat " + log + " >&2; exit 1"
         let argv =
             if isInsideSandbox {
-                ["/bin/zsh", "-c", payload]
+                [launcher.loginShell, "-c", payload]
             } else {
                 launcher.command(
                     payload: payload,
@@ -184,7 +183,7 @@ public struct HerdrClient: Sendable {
             + "herdr server reload-config &>/dev/null; exit 0"
         let argv =
             if isInsideSandbox {
-                ["/bin/zsh", "-c", payload]
+                [launcher.loginShell, "-c", payload]
             } else {
                 launcher.command(
                     payload: payload,
@@ -226,7 +225,7 @@ public struct HerdrClient: Sendable {
     private let sessionName: String
 
     private let runner: any ProcessRunner
-    private let launcher: SandvaultLauncher
+    private let launcher: any SandboxLaunching
     private let isInsideSandbox: Bool
     private let configHome: String?
 

--- a/Sources/AgentIDEData/OnDeviceSummarising.swift
+++ b/Sources/AgentIDEData/OnDeviceSummarising.swift
@@ -1,0 +1,58 @@
+// MARK: - OnDeviceSummarising
+
+/// On-device summarisation for branch names, commit messages and pull
+/// request drafts. Mac uses Apple's foundation model; platforms
+/// without one inject `NullSummariser`.
+public protocol OnDeviceSummarising: Sendable {
+    /// A short underscore-separated branch name summarising a
+    /// prompt, nil when the model cannot help.
+    func branchName(for prompt: String) async -> String?
+
+    /// A commit message drafted from a diff, nil when the model
+    /// cannot help.
+    func commitMessage(fromDiff diff: String) async -> String?
+
+    /// A pull request title and body drafted from the branch's
+    /// commit messages, nil when the model cannot help.
+    func pullRequestDescription(
+        fromCommits commits: [String],
+        branch: String,
+    ) async -> (title: String, body: String)?
+
+    /// The repository's pull request template completed from the
+    /// branch's commit messages, nil when the model cannot help.
+    func filledTemplate(fromCommits commits: [String], template: String) async -> String?
+}
+
+// MARK: - NullSummariser
+
+/// A summariser that always answers nil, so callers take their
+/// deterministic fallbacks.
+public struct NullSummariser: OnDeviceSummarising {
+    // MARK: Lifecycle
+
+    public init() {
+        // Always answers nil.
+    }
+
+    // MARK: Public
+
+    public func branchName(for _: String) -> String? {
+        nil
+    }
+
+    public func commitMessage(fromDiff _: String) -> String? {
+        nil
+    }
+
+    public func pullRequestDescription(
+        fromCommits _: [String],
+        branch _: String,
+    ) -> (title: String, body: String)? {
+        nil
+    }
+
+    public func filledTemplate(fromCommits _: [String], template _: String) -> String? {
+        nil
+    }
+}

--- a/Sources/AgentIDEData/PlatformRoots.swift
+++ b/Sources/AgentIDEData/PlatformRoots.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// The OS-specific directory roots AgentIDE builds every other path
+/// from. `detect()` is the single place Mac and Linux layouts diverge.
+public struct PlatformRoots: Sendable {
+    // MARK: Lifecycle
+
+    /// Creates roots from explicit values.
+    public init(
+        hostUser: String,
+        sharedWorkspace: String,
+        sandboxHome: String,
+        metadataFile: String,
+        sharedTemporaryDirectory: String,
+    ) {
+        self.hostUser = hostUser
+        self.sharedWorkspace = sharedWorkspace
+        self.sandboxHome = sandboxHome
+        self.metadataFile = metadataFile
+        self.sharedTemporaryDirectory = sharedTemporaryDirectory
+    }
+
+    // MARK: Public
+
+    /// The host (GUI) user name, with any sandvault prefix stripped.
+    public let hostUser: String
+
+    /// The workspace shared by the host and sandbox users.
+    public let sharedWorkspace: String
+
+    /// The sandbox user's home directory.
+    public let sandboxHome: String
+
+    /// Where the app's own metadata file lives.
+    public let metadataFile: String
+
+    /// A temporary directory both users can read, for the performance
+    /// log and similar cross-user scratch.
+    public let sharedTemporaryDirectory: String
+
+    /// Detects roots for the current process.
+    public static func detect() -> Self {
+        let user = NSUserName()
+        let prefix = "sandvault-"
+        let host = user.hasPrefix(prefix) ? String(user.dropFirst(prefix.count)) : user
+        #if os(macOS)
+            let shared = "/Users/Shared/sv-" + host
+            return Self(
+                hostUser: host,
+                sharedWorkspace: shared,
+                sandboxHome: "/Users/sandvault-" + host,
+                metadataFile: NSHomeDirectory() + "/Library/Application Support/AgentIDE/state.json",
+                sharedTemporaryDirectory: shared + "/tmp/agentide",
+            )
+        #else
+            let shared = "/var/lib/agentide/" + host
+            let xdgState = ProcessInfo.processInfo.environment["XDG_STATE_HOME"]
+                ?? (NSHomeDirectory() + "/.local/state")
+            return Self(
+                hostUser: host,
+                sharedWorkspace: shared,
+                sandboxHome: "/home/sandvault-" + host,
+                metadataFile: xdgState + "/agentide/state.json",
+                sharedTemporaryDirectory: shared + "/tmp/agentide",
+            )
+        #endif
+    }
+}

--- a/Sources/AgentIDEData/PowerObserving.swift
+++ b/Sources/AgentIDEData/PowerObserving.swift
@@ -1,0 +1,44 @@
+// MARK: - PowerObserving
+
+/// Whether the machine is running on battery, which slows safety
+/// ticks that should cost nothing when they find nothing.
+public protocol PowerObserving: Sendable {
+    /// True on battery; false plugged in, or when the system will
+    /// not say.
+    var isOnBattery: Bool { get }
+}
+
+// MARK: - PluggedInPower
+
+/// Always reports plugged in: the default for tests and for machines
+/// that have no battery observer wired.
+public struct PluggedInPower: PowerObserving {
+    // MARK: Lifecycle
+
+    public init() {
+        // Always plugged in.
+    }
+
+    // MARK: Public
+
+    public var isOnBattery: Bool {
+        false
+    }
+}
+
+#if os(macOS)
+    /// Reads power state through IOKit.
+    public struct IOKitPower: PowerObserving {
+        // MARK: Lifecycle
+
+        public init() {
+            // Defers to PowerSource.
+        }
+
+        // MARK: Public
+
+        public var isOnBattery: Bool {
+            PowerSource.isOnBattery
+        }
+    }
+#endif

--- a/Sources/AgentIDEData/PowerObserving.swift
+++ b/Sources/AgentIDEData/PowerObserving.swift
@@ -12,16 +12,16 @@ public protocol PowerObserving: Sendable {
 
 /// Always reports plugged in: the default for tests and for machines
 /// that have no battery observer wired.
-public struct PluggedInPower: PowerObserving {
+struct PluggedInPower: PowerObserving {
     // MARK: Lifecycle
 
-    public init() {
+    init() {
         // Always plugged in.
     }
 
     // MARK: Public
 
-    public var isOnBattery: Bool {
+    var isOnBattery: Bool {
         false
     }
 }

--- a/Sources/AgentIDEData/PowerSource.swift
+++ b/Sources/AgentIDEData/PowerSource.swift
@@ -2,10 +2,10 @@ import IOKit.ps
 
 /// Whether the machine is running on its battery, which is when a
 /// safety tick that finds nothing should have cost nothing.
-public enum PowerSource {
+enum PowerSource {
     /// True on battery; false plugged in, or on a machine with no
     /// battery, or when the system will not say.
-    public static var isOnBattery: Bool {
+    static var isOnBattery: Bool {
         guard let info = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
               let providing = IOPSGetProvidingPowerSourceType(info)?.takeUnretainedValue()
         else {

--- a/Sources/AgentIDEData/PullRequestStore.swift
+++ b/Sources/AgentIDEData/PullRequestStore.swift
@@ -22,7 +22,7 @@ public struct PullRequestStore: Sendable {
     public init(
         github: GitHubClient,
         store: MetadataStore,
-        onBattery: @escaping @Sendable () -> Bool = { PowerSource.isOnBattery },
+        onBattery: @escaping @Sendable () -> Bool = { false },
     ) {
         self.github = github
         self.store = store
@@ -236,16 +236,18 @@ public struct PullRequestStore: Sendable {
         let queued = store.load().queuedCache
         // One batched query for every repository is cheap enough to
         // allow under the floor while something is queued.
-        let due = repositoryPaths.filter { due("queue#" + $0, interval: interval, floor: Self.inFlightFloor) }
+        let duePaths = repositoryPaths.filter { path in
+            due("queue#" + path, interval: interval, floor: Self.inFlightFloor)
+        }
         var answers = [String: Set<Int>]()
-        for path in repositoryPaths where due.contains(path) == false {
+        for path in repositoryPaths where duePaths.contains(path) == false {
             answers[path] = Set(queued[path] ?? [])
         }
-        guard due.isEmpty == false else {
+        guard duePaths.isEmpty == false else {
             return answers
         }
 
-        let fetched = await github.queuedNumbers(repositoryPaths: due)
+        let fetched = await github.queuedNumbers(repositoryPaths: duePaths)
         store.update { metadata in
             for (path, numbers) in fetched {
                 metadata.queuedCache[path] = numbers.sorted()

--- a/Sources/AgentIDEData/PullRequestStore.swift
+++ b/Sources/AgentIDEData/PullRequestStore.swift
@@ -22,7 +22,7 @@ public struct PullRequestStore: Sendable {
     public init(
         github: GitHubClient,
         store: MetadataStore,
-        onBattery: @escaping @Sendable () -> Bool = { false },
+        onBattery: @escaping @Sendable () -> Bool = { PluggedInPower().isOnBattery },
     ) {
         self.github = github
         self.store = store

--- a/Sources/AgentIDEData/SandboxLaunching.swift
+++ b/Sources/AgentIDEData/SandboxLaunching.swift
@@ -1,0 +1,40 @@
+/// The privilege-crossing launch shape: how a host process runs a
+/// payload as the sandbox user. Mac uses sandvault; Linux will use
+/// `agentide-sandbox enter`. Call sites take this protocol so they
+/// never reconstruct a concrete launcher.
+public protocol SandboxLaunching: Sendable {
+    /// The host (GUI) user the sandbox identity is derived from.
+    var hostUser: String { get }
+
+    /// The sandbox user that owns herdr and the agent processes.
+    var sandboxUser: String { get }
+
+    /// The sandbox user's home directory.
+    var sandboxHome: String { get }
+
+    /// The workspace directory both users read and write.
+    var sharedWorkspace: String { get }
+
+    /// The login shell that runs payloads inside the sandbox.
+    var loginShell: String { get }
+
+    /// How a background server is detached from the launch shell
+    /// (zsh's `&!` on Mac; Linux will use `nohup`/`setsid`).
+    var detachSuffix: String { get }
+
+    /// Shell statements that load the sandbox user's profile before
+    /// starting a long-lived server outside an already-configured
+    /// session.
+    var profileBootstrap: String { get }
+
+    /// The `PATH` injected into the clean sandbox environment.
+    var sandboxPath: String { get }
+
+    /// The full argv that runs `payload` inside the sandbox.
+    func command(
+        payload: String,
+        initialDirectory: String,
+        sessionID: String,
+        sessionName: String,
+    ) -> [String]
+}

--- a/Sources/AgentIDEData/SandboxLaunching.swift
+++ b/Sources/AgentIDEData/SandboxLaunching.swift
@@ -4,12 +4,15 @@
 /// never reconstruct a concrete launcher.
 public protocol SandboxLaunching: Sendable {
     /// The host (GUI) user the sandbox identity is derived from.
+    // periphery:ignore - concrete launchers expose this; callers take command()
     var hostUser: String { get }
 
     /// The sandbox user that owns herdr and the agent processes.
+    // periphery:ignore - used inside concrete command() builders
     var sandboxUser: String { get }
 
     /// The sandbox user's home directory.
+    // periphery:ignore - used inside concrete command() builders
     var sandboxHome: String { get }
 
     /// The workspace directory both users read and write.
@@ -28,6 +31,7 @@ public protocol SandboxLaunching: Sendable {
     var profileBootstrap: String { get }
 
     /// The `PATH` injected into the clean sandbox environment.
+    // periphery:ignore - used inside concrete command() builders
     var sandboxPath: String { get }
 
     /// The full argv that runs `payload` inside the sandbox.

--- a/Sources/AgentIDEData/SandboxLaunching.swift
+++ b/Sources/AgentIDEData/SandboxLaunching.swift
@@ -3,16 +3,16 @@
 /// `agentide-sandbox enter`. Call sites take this protocol so they
 /// never reconstruct a concrete launcher.
 public protocol SandboxLaunching: Sendable {
-    /// The host (GUI) user the sandbox identity is derived from.
     // periphery:ignore - concrete launchers expose this; callers take command()
+    /// The host (GUI) user the sandbox identity is derived from.
     var hostUser: String { get }
 
-    /// The sandbox user that owns herdr and the agent processes.
     // periphery:ignore - used inside concrete command() builders
+    /// The sandbox user that owns herdr and the agent processes.
     var sandboxUser: String { get }
 
-    /// The sandbox user's home directory.
     // periphery:ignore - used inside concrete command() builders
+    /// The sandbox user's home directory.
     var sandboxHome: String { get }
 
     /// The workspace directory both users read and write.
@@ -30,8 +30,8 @@ public protocol SandboxLaunching: Sendable {
     /// session.
     var profileBootstrap: String { get }
 
-    /// The `PATH` injected into the clean sandbox environment.
     // periphery:ignore - used inside concrete command() builders
+    /// The `PATH` injected into the clean sandbox environment.
     var sandboxPath: String { get }
 
     /// The full argv that runs `payload` inside the sandbox.

--- a/Sources/AgentIDEData/SandvaultLauncher.swift
+++ b/Sources/AgentIDEData/SandvaultLauncher.swift
@@ -1,72 +1,88 @@
-/// Builds the sudo, env and sandbox-exec command line that runs a payload as
-/// the sandvault sandbox user. This is the single place the launch shape is
-/// constructed, so a sandvault change is a one-file fix.
-public struct SandvaultLauncher: Sendable {
-    // MARK: Lifecycle
+#if os(macOS)
+    /// Builds the sudo, env and sandbox-exec command line that runs a payload as
+    /// the sandvault sandbox user. This is the single place the launch shape is
+    /// constructed, so a sandvault change is a one-file fix.
+    public struct SandvaultLauncher: SandboxLaunching, Sendable {
+        // MARK: Lifecycle
 
-    /// Creates a launcher for the given host (GUI) user name.
-    public init(hostUser: String) {
-        self.hostUser = hostUser
+        /// Creates a launcher for the given host (GUI) user name.
+        public init(hostUser: String) {
+            self.hostUser = hostUser
+        }
+
+        // MARK: Public
+
+        /// The host user the sandbox identity is derived from.
+        public let hostUser: String
+
+        /// The login shell that runs payloads inside the sandbox.
+        public let loginShell = "/bin/zsh"
+
+        /// zsh's disown-and-background, which works without a controlling
+        /// terminal (macOS `nohup` does not).
+        public let detachSuffix = "&!"
+
+        /// Loads the sandbox user's configure script and zsh startup
+        /// files before a long-lived server start.
+        public let profileBootstrap =
+            "cd ~ && ~/configure; source ~/.zshenv; source ~/.zprofile; source ~/.zshrc; "
+
+        /// Homebrew first: herdr and the agent CLIs live there, and
+        /// `env -i` wipes whatever PATH the login shell would build.
+        public let sandboxPath =
+            "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+        /// The sandbox user, the host user with a `sandvault-` prefix.
+        public var sandboxUser: String {
+            "sandvault-" + hostUser
+        }
+
+        /// The sandbox user's home directory.
+        public var sandboxHome: String {
+            "/Users/" + sandboxUser
+        }
+
+        /// The workspace directory both users read and write.
+        public var sharedWorkspace: String {
+            "/Users/Shared/sv-" + hostUser
+        }
+
+        /// The path of sandvault's generated sandbox-exec profile.
+        public var sandboxProfile: String {
+            "/var/sandvault/sandbox-" + sandboxUser + ".sb"
+        }
+
+        /// The full argv that runs `payload` inside the sandbox through
+        /// the login shell, with the documented environment injected.
+        public func command(
+            payload: String,
+            initialDirectory: String,
+            sessionID: String,
+            sessionName: String,
+        ) -> [String] {
+            [
+                "sudo", "--login", "--set-home", "--user=" + sandboxUser,
+                "/usr/bin/env", "-i",
+                "HOME=" + sandboxHome,
+                "USER=" + sandboxUser,
+                "SHELL=" + loginShell,
+                "TERM=xterm-256color",
+                "COLORTERM=truecolor",
+                // Without a UTF-8 locale the multiplexer draws box
+                // characters as ASCII, which made agent panes render
+                // differently from host shells.
+                "LANG=en_US.UTF-8",
+                "INITIAL_DIR=" + initialDirectory,
+                "SHARED_WORKSPACE=" + sharedWorkspace,
+                "SV_SESSION_ID=" + sessionID,
+                "AGENTIDE_SESSION=" + sessionName,
+                "PATH=" + sandboxPath,
+                "GIT_CONFIG_COUNT=1",
+                "GIT_CONFIG_KEY_0=safe.directory",
+                "GIT_CONFIG_VALUE_0=" + sharedWorkspace + "/*",
+                "/usr/bin/sandbox-exec", "-f", sandboxProfile,
+                loginShell, "-c", payload,
+            ]
+        }
     }
-
-    // MARK: Public
-
-    /// The host user the sandbox identity is derived from.
-    public let hostUser: String
-
-    /// The sandbox user, the host user with a `sandvault-` prefix.
-    public var sandboxUser: String {
-        "sandvault-" + hostUser
-    }
-
-    /// The sandbox user's home directory.
-    public var sandboxHome: String {
-        "/Users/" + sandboxUser
-    }
-
-    /// The workspace directory both users read and write.
-    public var sharedWorkspace: String {
-        "/Users/Shared/sv-" + hostUser
-    }
-
-    /// The path of sandvault's generated sandbox-exec profile.
-    public var sandboxProfile: String {
-        "/var/sandvault/sandbox-" + sandboxUser + ".sb"
-    }
-
-    /// The full argv that runs `payload` inside the sandbox through
-    /// `/bin/zsh -c`, with the documented environment injected.
-    public func command(
-        payload: String,
-        initialDirectory: String,
-        sessionID: String,
-        sessionName: String,
-    ) -> [String] {
-        [
-            "sudo", "--login", "--set-home", "--user=" + sandboxUser,
-            "/usr/bin/env", "-i",
-            "HOME=" + sandboxHome,
-            "USER=" + sandboxUser,
-            "SHELL=/bin/zsh",
-            "TERM=xterm-256color",
-            "COLORTERM=truecolor",
-            // Without a UTF-8 locale the multiplexer draws box
-            // characters as ASCII, which made agent panes render
-            // differently from host shells.
-            "LANG=en_US.UTF-8",
-            "INITIAL_DIR=" + initialDirectory,
-            "SHARED_WORKSPACE=" + sharedWorkspace,
-            "SV_SESSION_ID=" + sessionID,
-            "AGENTIDE_SESSION=" + sessionName,
-            // Homebrew first: herdr and the agent CLIs live there,
-            // and env -i wipes whatever PATH the login shell would
-            // build.
-            "PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
-            "GIT_CONFIG_COUNT=1",
-            "GIT_CONFIG_KEY_0=safe.directory",
-            "GIT_CONFIG_VALUE_0=" + sharedWorkspace + "/*",
-            "/usr/bin/sandbox-exec", "-f", sandboxProfile,
-            "/bin/zsh", "-c", payload,
-        ]
-    }
-}
+#endif

--- a/Sources/AgentIDEData/SessionService+Lifecycle.swift
+++ b/Sources/AgentIDEData/SessionService+Lifecycle.swift
@@ -178,7 +178,6 @@ public extension SessionService {
     /// Deletes a path as the sandbox user through the launcher, for
     /// files the host user does not own.
     private func removeAsSandboxUser(path: String) async throws {
-        let launcher = SandvaultLauncher(hostUser: paths.hostUser)
         let command = launcher.command(
             payload: "rm -rf " + path.shellQuoted,
             initialDirectory: launcher.sharedWorkspace,

--- a/Sources/AgentIDEData/SessionService+Sessions.swift
+++ b/Sources/AgentIDEData/SessionService+Sessions.swift
@@ -260,7 +260,6 @@ public extension SessionService {
             return
         }
 
-        let launcher = SandvaultLauncher(hostUser: paths.hostUser)
         let command = launcher.command(
             payload: "rm -f " + past.path.shellQuoted,
             initialDirectory: launcher.sharedWorkspace,

--- a/Sources/AgentIDEData/SessionService.swift
+++ b/Sources/AgentIDEData/SessionService.swift
@@ -40,9 +40,9 @@ public struct SessionService: Sendable {
         spool: EventSpool,
         store: MetadataStore,
         runners: [any AgentRunner],
+        launcher: any SandboxLaunching,
         processes: any ProcessRunner = FoundationProcessRunner(),
-        launcher: SandvaultLauncher? = nil,
-        summariser: FoundationModelClient = FoundationModelClient(),
+        summariser: any OnDeviceSummarising = FoundationModelClient(),
         progress: @escaping LaunchReporter = silentLaunchReporter,
     ) {
         self.paths = paths
@@ -53,8 +53,8 @@ public struct SessionService: Sendable {
         self.spool = spool
         self.store = store
         self.runners = runners
+        self.launcher = launcher
         self.processes = processes
-        self.launcher = launcher ?? SandvaultLauncher(hostUser: paths.hostUser)
         self.summariser = summariser
         self.progress = progress
     }
@@ -77,8 +77,15 @@ public struct SessionService: Sendable {
 
     /// A watcher over the workspace roots whose file-system events
     /// decide when a repository's git is worth reading again.
-    public func makeWorkspaceWatcher() -> WorkspaceWatcher {
-        WorkspaceWatcher(roots: [paths.repositoriesDirectory, paths.worktreesDirectory])
+    public func makeWorkspaceWatcher() -> any FileWatching {
+        let roots = [paths.repositoriesDirectory, paths.worktreesDirectory]
+        #if os(macOS)
+            return WorkspaceWatcher(roots: roots)
+        #elseif os(Linux)
+            return InotifyWorkspaceWatcher(roots: roots)
+        #else
+            fatalError("File watching is only implemented on macOS and Linux")
+        #endif
     }
 
     /// Creates a worktree and branch for a prompt and starts the
@@ -128,7 +135,7 @@ public struct SessionService: Sendable {
     let codexIndex: CodexTranscriptIndex = .init()
 
     /// Names branches from prompts on device.
-    let summariser: FoundationModelClient
+    let summariser: any OnDeviceSummarising
 
     let paths: WorkspacePaths
     let git: GitClient
@@ -140,7 +147,7 @@ public struct SessionService: Sendable {
     let store: MetadataStore
     let runners: [any AgentRunner]
     let processes: any ProcessRunner
-    let launcher: SandvaultLauncher
+    let launcher: any SandboxLaunching
 
     /// Where launches narrate their steps.
     let progress: LaunchReporter

--- a/Sources/AgentIDEData/SessionService.swift
+++ b/Sources/AgentIDEData/SessionService.swift
@@ -42,7 +42,7 @@ public struct SessionService: Sendable {
         runners: [any AgentRunner],
         launcher: any SandboxLaunching,
         processes: any ProcessRunner = FoundationProcessRunner(),
-        summariser: any OnDeviceSummarising = FoundationModelClient(),
+        summariser: any OnDeviceSummarising = NullSummariser(),
         progress: @escaping LaunchReporter = silentLaunchReporter,
     ) {
         self.paths = paths

--- a/Sources/AgentIDEData/WorkspacePaths.swift
+++ b/Sources/AgentIDEData/WorkspacePaths.swift
@@ -99,15 +99,12 @@ public struct WorkspacePaths: Sendable {
     /// Creates paths for the current process, stripping any sandvault
     /// prefix so the same paths work inside and outside the sandbox.
     public static func current() -> Self {
-        let user = NSUserName()
-        let prefix = "sandvault-"
-        let host = user.hasPrefix(prefix) ? String(user.dropFirst(prefix.count)) : user
-        let support = NSHomeDirectory() + "/Library/Application Support/AgentIDE"
+        let roots = PlatformRoots.detect()
         return Self(
-            hostUser: host,
-            sharedWorkspace: "/Users/Shared/sv-" + host,
-            sandboxHome: "/Users/sandvault-" + host,
-            metadataFile: support + "/state.json",
+            hostUser: roots.hostUser,
+            sharedWorkspace: roots.sharedWorkspace,
+            sandboxHome: roots.sandboxHome,
+            metadataFile: roots.metadataFile,
         )
     }
 

--- a/Sources/AgentIDEData/WorkspaceWatcher.swift
+++ b/Sources/AgentIDEData/WorkspaceWatcher.swift
@@ -1,158 +1,160 @@
-import CoreServices
-import Synchronization
+#if os(macOS)
+    import CoreServices
+    import Synchronization
 
-// MARK: - WorkspaceWatcher
+    // MARK: - WorkspaceWatcher
 
-/// One FSEvents stream over the repository and worktree roots,
-/// remembering which top-level directories changed so git is asked
-/// about a repository only when something under it actually moved.
-/// Blind polling read `git status` and `git worktree list` across
-/// the whole workspace every few seconds for rows that never
-/// changed; the file system already knows.
-public final class WorkspaceWatcher: Sendable {
-    // MARK: Lifecycle
-
-    /// Creates a watcher over some root directories.
-    public init(roots: [String]) {
-        box = ChangeBox(roots: roots)
-    }
-
-    deinit {
-        // The stream and its box deliberately outlive the watcher:
-        // stopping a stream from a deinit cannot touch non-Sendable
-        // state, and the one watcher lives for the process anyway.
-    }
-
-    // MARK: Public
-
-    /// Whether the stream is running; false answers every question
-    /// with "assume changed", so a machine where FSEvents fails
-    /// falls back to time-based reads.
-    public var isWatching: Bool {
-        watching.withLock { $0 }
-    }
-
-    /// Starts watching; safe to call more than once, and a failed
-    /// attempt may be retried, since nothing was left half started.
-    public func start() {
-        guard started.withLock({ let was = $0; $0 = true; return was }) == false else {
-            return
-        }
-
-        var context = FSEventStreamContext()
-        // The stream holds the one strong reference the callback
-        // reads; never released, since the stream is never stopped.
-        let info = Unmanaged.passRetained(box)
-        context.info = info.toOpaque()
-        guard let stream = FSEventStreamCreate(
-            nil,
-            workspaceEventsCallback,
-            &context,
-            box.roots as CFArray,
-            // swiftformat:disable:next acronyms
-            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
-            Self.latencySeconds,
-            FSEventStreamCreateFlags(kFSEventStreamCreateFlagUseCFTypes),
-        ) else {
-            info.release()
-            started.withLock { $0 = false }
-            return
-        }
-
-        FSEventStreamSetDispatchQueue(stream, Self.queue)
-        guard FSEventStreamStart(stream) else {
-            FSEventStreamInvalidate(stream)
-            FSEventStreamRelease(stream)
-            info.release()
-            started.withLock { $0 = false }
-            return
-        }
-
-        watching.withLock { $0 = true }
-    }
-
-    /// The directories changed since last asked, trimmed to at most
-    /// two levels under their root (a repository, or a worktree's
-    /// `repository/branch`), and cleared by the asking.
-    public func consumeChangedPaths() -> Set<String> {
-        box.changed.withLock { changed in
-            let consumed = changed
-            changed = []
-            return consumed
-        }
-    }
-
-    // MARK: Internal
-
-    /// What the event callback writes into: separate from the
-    /// watcher so the never-stopped stream can never point at a
-    /// deallocated object.
-    final class ChangeBox: Sendable {
+    /// One FSEvents stream over the repository and worktree roots,
+    /// remembering which top-level directories changed so git is asked
+    /// about a repository only when something under it actually moved.
+    /// Blind polling read `git status` and `git worktree list` across
+    /// the whole workspace every few seconds for rows that never
+    /// changed; the file system already knows.
+    public final class WorkspaceWatcher: FileWatching, Sendable {
         // MARK: Lifecycle
 
-        init(roots: [String]) {
-            self.roots = roots
+        /// Creates a watcher over some root directories.
+        public init(roots: [String]) {
+            box = ChangeBox(roots: roots)
         }
 
         deinit {
-            // Owned by the stream for the life of the process.
+            // The stream and its box deliberately outlive the watcher:
+            // stopping a stream from a deinit cannot touch non-Sendable
+            // state, and the one watcher lives for the process anyway.
+        }
+
+        // MARK: Public
+
+        /// Whether the stream is running; false answers every question
+        /// with "assume changed", so a machine where FSEvents fails
+        /// falls back to time-based reads.
+        public var isWatching: Bool {
+            watching.withLock { $0 }
+        }
+
+        /// Starts watching; safe to call more than once, and a failed
+        /// attempt may be retried, since nothing was left half started.
+        public func start() {
+            guard started.withLock({ let was = $0; $0 = true; return was }) == false else {
+                return
+            }
+
+            var context = FSEventStreamContext()
+            // The stream holds the one strong reference the callback
+            // reads; never released, since the stream is never stopped.
+            let info = Unmanaged.passRetained(box)
+            context.info = info.toOpaque()
+            guard let stream = FSEventStreamCreate(
+                nil,
+                workspaceEventsCallback,
+                &context,
+                box.roots as CFArray,
+                // swiftformat:disable:next acronyms
+                FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+                Self.latencySeconds,
+                FSEventStreamCreateFlags(kFSEventStreamCreateFlagUseCFTypes),
+            ) else {
+                info.release()
+                started.withLock { $0 = false }
+                return
+            }
+
+            FSEventStreamSetDispatchQueue(stream, Self.queue)
+            guard FSEventStreamStart(stream) else {
+                FSEventStreamInvalidate(stream)
+                FSEventStreamRelease(stream)
+                info.release()
+                started.withLock { $0 = false }
+                return
+            }
+
+            watching.withLock { $0 = true }
+        }
+
+        /// The directories changed since last asked, trimmed to at most
+        /// two levels under their root (a repository, or a worktree's
+        /// `repository/branch`), and cleared by the asking.
+        public func consumeChangedPaths() -> Set<String> {
+            box.changed.withLock { changed in
+                let consumed = changed
+                changed = []
+                return consumed
+            }
         }
 
         // MARK: Internal
 
-        let roots: [String]
-        let changed: Mutex<Set<String>> = .init([])
+        /// What the event callback writes into: separate from the
+        /// watcher so the never-stopped stream can never point at a
+        /// deallocated object.
+        final class ChangeBox: Sendable {
+            // MARK: Lifecycle
 
-        /// Records event paths trimmed to their root plus two
-        /// components: deep churn inside one worktree collapses to
-        /// one entry however busy the agent in it is.
-        func record(_ paths: [String]) {
-            changed.withLock { set in
-                for path in paths {
-                    guard let root = roots.first(where: { candidate in
-                        path == candidate || path.hasPrefix(candidate + "/")
-                    }) else {
-                        continue
+            init(roots: [String]) {
+                self.roots = roots
+            }
+
+            deinit {
+                // Owned by the stream for the life of the process.
+            }
+
+            // MARK: Internal
+
+            let roots: [String]
+            let changed: Mutex<Set<String>> = .init([])
+
+            /// Records event paths trimmed to their root plus two
+            /// components: deep churn inside one worktree collapses to
+            /// one entry however busy the agent in it is.
+            func record(_ paths: [String]) {
+                changed.withLock { set in
+                    for path in paths {
+                        guard let root = roots.first(where: { candidate in
+                            path == candidate || path.hasPrefix(candidate + "/")
+                        }) else {
+                            continue
+                        }
+
+                        let suffix = path.dropFirst(root.count)
+                            .split(separator: "/")
+                            .prefix(Self.keptComponents)
+                        set.insert(suffix.isEmpty ? root : root + "/" + suffix.joined(separator: "/"))
                     }
-
-                    let suffix = path.dropFirst(root.count)
-                        .split(separator: "/")
-                        .prefix(Self.keptComponents)
-                    set.insert(suffix.isEmpty ? root : root + "/" + suffix.joined(separator: "/"))
                 }
             }
+
+            // MARK: Private
+
+            /// `repositories/<repo>` is one component under its root,
+            /// `worktrees/<repo>/<branch>` two; nothing needs more.
+            private static let keptComponents = 2
         }
 
         // MARK: Private
 
-        /// `repositories/<repo>` is one component under its root,
-        /// `worktrees/<repo>/<branch>` two; nothing needs more.
-        private static let keptComponents = 2
+        /// How long FSEvents may coalesce a burst before delivering it;
+        /// the poll only reads the answers every few seconds anyway.
+        private static let latencySeconds = 0.5
+
+        private static let queue: DispatchQueue = .init(label: "agentide.workspace-watcher", qos: .utility)
+
+        private let box: ChangeBox
+        private let started: Mutex<Bool> = .init(false)
+        private let watching: Mutex<Bool> = .init(false)
     }
 
-    // MARK: Private
+    // MARK: - Event callback
 
-    /// How long FSEvents may coalesce a burst before delivering it;
-    /// the poll only reads the answers every few seconds anyway.
-    private static let latencySeconds = 0.5
+    /// The C callback FSEvents delivers into; with `UseCFTypes` the
+    /// paths arrive as a `CFArray` of strings.
+    private let workspaceEventsCallback: FSEventStreamCallback = { _, info, _, eventPaths, _, _ in
+        guard let info else {
+            return
+        }
 
-    private static let queue: DispatchQueue = .init(label: "agentide.workspace-watcher", qos: .utility)
-
-    private let box: ChangeBox
-    private let started: Mutex<Bool> = .init(false)
-    private let watching: Mutex<Bool> = .init(false)
-}
-
-// MARK: - Event callback
-
-/// The C callback FSEvents delivers into; with `UseCFTypes` the
-/// paths arrive as a `CFArray` of strings.
-private let workspaceEventsCallback: FSEventStreamCallback = { _, info, _, eventPaths, _, _ in
-    guard let info else {
-        return
+        let box = Unmanaged<WorkspaceWatcher.ChangeBox>.fromOpaque(info).takeUnretainedValue()
+        let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as? [String] ?? []
+        box.record(paths)
     }
-
-    let box = Unmanaged<WorkspaceWatcher.ChangeBox>.fromOpaque(info).takeUnretainedValue()
-    let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as? [String] ?? []
-    box.record(paths)
-}
+#endif

--- a/Sources/AgentIDEData/WorkspaceWatcher.swift
+++ b/Sources/AgentIDEData/WorkspaceWatcher.swift
@@ -24,7 +24,53 @@
             // state, and the one watcher lives for the process anyway.
         }
 
-        // MARK: Public
+        // MARK: Internal
+
+        /// What the event callback writes into: separate from the
+        /// watcher so the never-stopped stream can never point at a
+        /// deallocated object.
+        final class ChangeBox: Sendable {
+            // MARK: Lifecycle
+
+            init(roots: [String]) {
+                self.roots = roots
+            }
+
+            deinit {
+                // Owned by the stream for the life of the process.
+            }
+
+            // MARK: Internal
+
+            let roots: [String]
+            let changed: Mutex<Set<String>> = .init([])
+
+            /// Records event paths trimmed to their root plus two
+            /// components: deep churn inside one worktree collapses to
+            /// one entry however busy the agent in it is.
+            func record(_ paths: [String]) {
+                changed.withLock { set in
+                    for path in paths {
+                        guard let root = roots.first(where: { candidate in
+                            path == candidate || path.hasPrefix(candidate + "/")
+                        }) else {
+                            continue
+                        }
+
+                        let suffix = path.dropFirst(root.count)
+                            .split(separator: "/")
+                            .prefix(Self.keptComponents)
+                        set.insert(suffix.isEmpty ? root : root + "/" + suffix.joined(separator: "/"))
+                    }
+                }
+            }
+
+            // MARK: Private
+
+            /// `repositories/<repo>` is one component under its root,
+            /// `worktrees/<repo>/<branch>` two; nothing needs more.
+            private static let keptComponents = 2
+        }
 
         /// Whether the stream is running; false answers every question
         /// with "assume changed", so a machine where FSEvents fails
@@ -81,54 +127,6 @@
                 changed = []
                 return consumed
             }
-        }
-
-        // MARK: Internal
-
-        /// What the event callback writes into: separate from the
-        /// watcher so the never-stopped stream can never point at a
-        /// deallocated object.
-        final class ChangeBox: Sendable {
-            // MARK: Lifecycle
-
-            init(roots: [String]) {
-                self.roots = roots
-            }
-
-            deinit {
-                // Owned by the stream for the life of the process.
-            }
-
-            // MARK: Internal
-
-            let roots: [String]
-            let changed: Mutex<Set<String>> = .init([])
-
-            /// Records event paths trimmed to their root plus two
-            /// components: deep churn inside one worktree collapses to
-            /// one entry however busy the agent in it is.
-            func record(_ paths: [String]) {
-                changed.withLock { set in
-                    for path in paths {
-                        guard let root = roots.first(where: { candidate in
-                            path == candidate || path.hasPrefix(candidate + "/")
-                        }) else {
-                            continue
-                        }
-
-                        let suffix = path.dropFirst(root.count)
-                            .split(separator: "/")
-                            .prefix(Self.keptComponents)
-                        set.insert(suffix.isEmpty ? root : root + "/" + suffix.joined(separator: "/"))
-                    }
-                }
-            }
-
-            // MARK: Private
-
-            /// `repositories/<repo>` is one component under its root,
-            /// `worktrees/<repo>/<branch>` two; nothing needs more.
-            private static let keptComponents = 2
         }
 
         // MARK: Private

--- a/Sources/AgentIDEData/WorkspaceWatcher.swift
+++ b/Sources/AgentIDEData/WorkspaceWatcher.swift
@@ -10,11 +10,11 @@
     /// Blind polling read `git status` and `git worktree list` across
     /// the whole workspace every few seconds for rows that never
     /// changed; the file system already knows.
-    public final class WorkspaceWatcher: FileWatching, Sendable {
+    final class WorkspaceWatcher: FileWatching, Sendable {
         // MARK: Lifecycle
 
         /// Creates a watcher over some root directories.
-        public init(roots: [String]) {
+        init(roots: [String]) {
             box = ChangeBox(roots: roots)
         }
 
@@ -29,13 +29,13 @@
         /// Whether the stream is running; false answers every question
         /// with "assume changed", so a machine where FSEvents fails
         /// falls back to time-based reads.
-        public var isWatching: Bool {
+        var isWatching: Bool {
             watching.withLock { $0 }
         }
 
         /// Starts watching; safe to call more than once, and a failed
         /// attempt may be retried, since nothing was left half started.
-        public func start() {
+        func start() {
             guard started.withLock({ let was = $0; $0 = true; return was }) == false else {
                 return
             }
@@ -75,7 +75,7 @@
         /// The directories changed since last asked, trimmed to at most
         /// two levels under their root (a repository, or a worktree's
         /// `repository/branch`), and cleared by the asking.
-        public func consumeChangedPaths() -> Set<String> {
+        func consumeChangedPaths() -> Set<String> {
             box.changed.withLock { changed in
                 let consumed = changed
                 changed = []

--- a/Sources/AgentIDEDomain/ModelAnswerParsing.swift
+++ b/Sources/AgentIDEDomain/ModelAnswerParsing.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Pure parsers for on-device model answers. Kept in Domain so they
+/// compile without FoundationModels and so Linux and tests share the
+/// same normalisation.
+public enum ModelAnswerParsing {
+    // MARK: Public
+
+    /// Lays the branch out for the model: its name when given, every
+    /// commit's subject first, so a tight context budget never hides
+    /// later commits entirely, then each commit's whole message while
+    /// the budget allows, so the why in bodies informs the draft too.
+    public static func commitDigest(_ commits: [String], branch: String?, limit: Int) -> String {
+        let subjects = commits.map { commit in
+            commit.split(separator: "\n").first.map(String.init) ?? ""
+        }
+        // Parenthesised: `??` binds looser than `+`, and without
+        // them a named branch lost the whole subject list.
+        let head = (branch.map { "Branch: " + $0 + "\n\n" } ?? "")
+            + "Subjects:\n" + subjects.joined(separator: "\n")
+        var details = ""
+        for (index, commit) in commits.enumerated() where commit.contains("\n") {
+            let block = "\n\nCommit " + String(index + 1) + ":\n" + commit
+            guard head.count + details.count + block.count <= limit else {
+                break
+            }
+
+            details += block
+        }
+        return details.isEmpty ? head : head + "\n\nDetails:" + details
+    }
+
+    /// Splits a model answer into title and body, nil when nothing
+    /// usable came back; models sometimes wrap answers in quotes or
+    /// markdown heading markers despite instructions.
+    public static func pullRequestDescription(fromModelAnswer raw: String) -> (title: String, body: String)? {
+        let lines = strippedCodeFences(raw).trimmingCharacters(in: .whitespacesAndNewlines).split(
+            separator: "\n",
+            omittingEmptySubsequences: false,
+        )
+        let title = String(lines.first ?? "")
+            .trimmingCharacters(in: .whitespaces)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "#*\"'`"))
+            .trimmingCharacters(in: .whitespaces)
+        guard title.isEmpty == false else {
+            return nil
+        }
+
+        let body = lines.dropFirst()
+            .map(collapsedListMarker)
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (capitalisedFirst(title), body)
+    }
+
+    /// Drops Markdown fence lines; models sometimes wrap answers in
+    /// code blocks despite instructions, and a fence line carries no
+    /// content of its own.
+    public static func strippedCodeFences(_ text: String) -> String {
+        text.split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { $0.trimmingCharacters(in: .whitespaces).hasPrefix("```") == false }
+            .joined(separator: "\n")
+    }
+
+    /// Uppercases only the leading character; models sometimes echo
+    /// a lowercase commit subject as the title.
+    public static func capitalisedFirst(_ text: String) -> String {
+        guard let first = text.first else {
+            return text
+        }
+
+        return first.uppercased() + text.dropFirst()
+    }
+
+    /// Collapses repeated list markers like `- - item` to one dash;
+    /// models echo commit bodies that are already dash lists and
+    /// prefix another dash. Lines not starting with `- ` (including
+    /// `--flags` and indented continuations) pass through untouched.
+    public static func collapsedListMarker(_ line: Substring) -> String {
+        let indent = line.prefix { $0 == " " }
+        var rest = line.dropFirst(indent.count)
+        var isListItem = false
+        while rest.first == "-", rest.dropFirst().first == " " {
+            isListItem = true
+            rest = rest.dropFirst().drop { $0 == " " }
+        }
+        return isListItem ? indent + "- " + rest : String(line)
+    }
+
+    /// Normalises a model answer into a safe branch name, nil when
+    /// nothing usable remains; models sometimes answer with quotes,
+    /// punctuation or prose despite instructions.
+    public static func branchName(fromModelAnswer raw: String) -> String? {
+        var cleaned = ""
+        for character in raw.lowercased() {
+            cleaned.append(character.isLetter || character.isNumber ? character : " ")
+        }
+        let words = cleaned.split(separator: " ").map(String.init)
+        var name = ""
+        for word in words {
+            let candidate = name.isEmpty ? word : name + "_" + word
+            guard candidate.count <= nameLimit else {
+                break
+            }
+
+            name = candidate
+        }
+        guard name.isEmpty == false, name.contains(where: \.isLetter) else {
+            return nil
+        }
+
+        return name
+    }
+
+    // MARK: Private
+
+    /// Git and the file system are happier with short branch names.
+    private static let nameLimit = 40
+}

--- a/Sources/AgentIDEDomain/PerformanceLog.swift
+++ b/Sources/AgentIDEDomain/PerformanceLog.swift
@@ -81,6 +81,13 @@ public enum PerformanceLog {
         directory + "/performance.log"
     }
 
+    /// Configured by the app from `PlatformRoots` so Domain never
+    /// hardcodes a host path. Nil until the composition root sets it.
+    public static var sharedTemporaryDirectory: String? {
+        get { sharedTemporaryDirectoryState.withLock { $0 } }
+        set { sharedTemporaryDirectoryState.withLock { $0 = newValue } }
+    }
+
     /// Creates or removes the marker file, the same switch
     /// `script/performance-log` flips, and forgets the cached
     /// answer so the change takes effect now rather than in a few
@@ -165,22 +172,28 @@ public enum PerformanceLog {
     /// The shared temporary directory: readable by the host user and
     /// the sandbox user alike, unlike either one's own home. Tests
     /// point it elsewhere through the environment, since a test
-    /// must never write into the real one.
+    /// must never write into the real one. When neither the
+    /// environment nor `sharedTemporaryDirectory` is set, falls back
+    /// to the process temporary directory.
     static var directory: String {
         if let override = ProcessInfo.processInfo.environment["AGENTIDE_PERFORMANCE_LOG_DIRECTORY"] {
             return override
         }
 
-        let user = NSUserName()
-        let prefix = "sandvault-"
-        let host = user.hasPrefix(prefix) ? String(user.dropFirst(prefix.count)) : user
-        return "/Users/Shared/sv-" + host + "/tmp/agentide"
+        if let shared = sharedTemporaryDirectory {
+            return shared
+        }
+
+        return NSTemporaryDirectory() + "agentide"
     }
 
     // MARK: Private
 
     private static let queue: DispatchQueue = .init(label: "agentide.performance-log", qos: .utility)
     private static let sweepInterval: TimeInterval = 3_600
+
+    /// The shared temporary directory the app configured, if any.
+    private static let sharedTemporaryDirectoryState: Mutex<String?> = .init(nil)
 
     /// The cached enablement answer and how long it holds; the
     /// marker file can be toggled at runtime, so the file is asked

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -336,7 +336,7 @@ public final class DashboardModel {
 
     /// The file-system events that say which repository is worth
     /// asking git about; the git reads extension consumes it.
-    let watcher: WorkspaceWatcher
+    let watcher: any FileWatching
 
     /// Models each CLI reported, seeded from the last launch's answer
     /// by the cache extension; absent agents fall back.

--- a/Tests/AgentIDEDataTests/EditorShimIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/EditorShimIntegrationTests.swift
@@ -99,6 +99,7 @@ struct EditorShimIntegrationTests {
             spool: EventSpool(directory: workspace.eventsDirectory),
             store: MetadataStore(file: root + "/state.json"),
             runners: [],
+            launcher: SandvaultLauncher(hostUser: "test"),
         )
 
         var edits = service.pendingEdits().makeAsyncIterator()

--- a/Tests/AgentIDEDataTests/FakeSandboxLauncherTests.swift
+++ b/Tests/AgentIDEDataTests/FakeSandboxLauncherTests.swift
@@ -1,0 +1,74 @@
+import AgentIDEData
+import Synchronization
+import Testing
+
+// MARK: - FakeSandboxLauncher
+
+/// A minimal `SandboxLaunching` stand-in for call sites that only
+/// need identity and argv capture, not a real sandvault profile.
+final class FakeSandboxLauncher: SandboxLaunching, Sendable {
+    // MARK: Lifecycle
+
+    init(hostUser: String = "tester") {
+        self.hostUser = hostUser
+    }
+
+    deinit {
+        // Test double; nothing to clean up.
+    }
+
+    // MARK: Internal
+
+    let hostUser: String
+    let loginShell = "/bin/zsh"
+    let detachSuffix = "&!"
+    let profileBootstrap = "true; "
+    let sandboxPath = "/usr/bin:/bin"
+
+    var sandboxUser: String {
+        "sandvault-" + hostUser
+    }
+
+    var sandboxHome: String {
+        "/tmp/" + sandboxUser
+    }
+
+    var sharedWorkspace: String {
+        "/tmp/shared-" + hostUser
+    }
+
+    var payloads: [String] {
+        recorded.withLock { $0 }
+    }
+
+    func command(
+        payload: String,
+        initialDirectory _: String,
+        sessionID _: String,
+        sessionName _: String,
+    ) -> [String] {
+        recorded.withLock { $0.append(payload) }
+        return [loginShell, "-c", payload]
+    }
+
+    // MARK: Private
+
+    private let recorded: Mutex<[String]> = .init([])
+}
+
+// MARK: - FakeSandboxLauncherTests
+
+struct FakeSandboxLauncherTests {
+    @Test
+    func `records payloads without building a sandvault argv`() {
+        let launcher = FakeSandboxLauncher()
+        let argv = launcher.command(
+            payload: "echo hi",
+            initialDirectory: "/tmp",
+            sessionID: "id",
+            sessionName: "name",
+        )
+        #expect(argv == ["/bin/zsh", "-c", "echo hi"])
+        #expect(launcher.payloads == ["echo hi"])
+    }
+}

--- a/Tests/AgentIDEDataTests/FileListingTests.swift
+++ b/Tests/AgentIDEDataTests/FileListingTests.swift
@@ -24,6 +24,7 @@ struct FileListingTests {
             spool: EventSpool(directory: world.paths.eventsDirectory),
             store: MetadataStore(file: world.paths.metadataFile),
             runners: [],
+            launcher: SandvaultLauncher(hostUser: "test"),
             processes: runner,
         )
 

--- a/Tests/AgentIDEDataTests/FoundationModelClientTests.swift
+++ b/Tests/AgentIDEDataTests/FoundationModelClientTests.swift
@@ -1,4 +1,5 @@
 @testable import AgentIDEData
+import AgentIDEDomain
 import Testing
 
 /// Exercises the branch-name normalisation over model answers; the
@@ -17,7 +18,7 @@ struct FoundationModelClientTests {
         - Show failures inline
           continuation lines and --flags stay untouched
         """
-        let parsed = FoundationModelClient.pullRequestDescription(fromModelAnswer: doubled)
+        let parsed = ModelAnswerParsing.pullRequestDescription(fromModelAnswer: doubled)
         #expect(parsed?.title == "Attach herdr terminal controllers")
         #expect(parsed?.body == """
         - Fix protocol decoding at the byte level
@@ -25,12 +26,12 @@ struct FoundationModelClientTests {
         - Show failures inline
           continuation lines and --flags stay untouched
         """)
-        #expect(FoundationModelClient.pullRequestDescription(fromModelAnswer: "  \n\n") == nil)
+        #expect(ModelAnswerParsing.pullRequestDescription(fromModelAnswer: "  \n\n") == nil)
 
         // Fence lines carry no content and disappear; the body
         // inside survives untouched.
         let fenced = "Title line\n\n```\n- First point\n- Second point\n```"
-        let unfenced = FoundationModelClient.pullRequestDescription(fromModelAnswer: fenced)
+        let unfenced = ModelAnswerParsing.pullRequestDescription(fromModelAnswer: fenced)
         #expect(unfenced?.title == "Title line")
         #expect(unfenced?.body == "- First point\n- Second point")
     }
@@ -42,7 +43,7 @@ struct FoundationModelClientTests {
             "Second change",
             "Third change\n\nA very long explanation of the third change's why.",
         ]
-        let full = FoundationModelClient.commitDigest(commits, branch: "fix_login", limit: 1_000)
+        let full = ModelAnswerParsing.commitDigest(commits, branch: "fix_login", limit: 1_000)
         #expect(full.hasPrefix("Branch: fix_login\n\nSubjects:\nFirst change\nSecond change\nThird change"))
         #expect(full.contains("Why the first change happened."))
         #expect(full.contains("A very long explanation"))
@@ -51,7 +52,7 @@ struct FoundationModelClientTests {
 
         // A tight budget keeps every subject and drops later bodies
         // rather than truncating the subject list.
-        let tight = FoundationModelClient.commitDigest(commits, branch: nil, limit: 120)
+        let tight = ModelAnswerParsing.commitDigest(commits, branch: nil, limit: 120)
         #expect(tight.contains("Subjects:\nFirst change\nSecond change\nThird change"))
         #expect(tight.contains("Why the first change happened."))
         #expect(tight.contains("A very long explanation") == false)
@@ -59,17 +60,17 @@ struct FoundationModelClientTests {
 
     @Test
     func `model answers normalise into safe branch names`() {
-        #expect(FoundationModelClient.branchName(fromModelAnswer: "Fix Login Crash") == "fix_login_crash")
-        #expect(FoundationModelClient.branchName(fromModelAnswer: "`fix_login`.\n") == "fix_login")
+        #expect(ModelAnswerParsing.branchName(fromModelAnswer: "Fix Login Crash") == "fix_login_crash")
+        #expect(ModelAnswerParsing.branchName(fromModelAnswer: "`fix_login`.\n") == "fix_login")
         #expect(
-            FoundationModelClient.branchName(fromModelAnswer: "fix the crash-on-launch")
+            ModelAnswerParsing.branchName(fromModelAnswer: "fix the crash-on-launch")
                 == "fix_the_crash_on_launch",
         )
     }
 
     @Test
     func `long answers truncate at a word boundary`() throws {
-        let truncated = try #require(FoundationModelClient.branchName(
+        let truncated = try #require(ModelAnswerParsing.branchName(
             fromModelAnswer: "summarise every prompt into a very long branch name indeed",
         ))
         #expect(truncated.count <= 40)
@@ -78,9 +79,9 @@ struct FoundationModelClientTests {
 
     @Test
     func `unusable answers become nil`() {
-        #expect(FoundationModelClient.branchName(fromModelAnswer: "!!!") == nil)
-        #expect(FoundationModelClient.branchName(fromModelAnswer: "12 34") == nil)
-        #expect(FoundationModelClient.branchName(fromModelAnswer: "") == nil)
+        #expect(ModelAnswerParsing.branchName(fromModelAnswer: "!!!") == nil)
+        #expect(ModelAnswerParsing.branchName(fromModelAnswer: "12 34") == nil)
+        #expect(ModelAnswerParsing.branchName(fromModelAnswer: "") == nil)
     }
 
     @Test

--- a/Tests/AgentIDEDataTests/SandvaultLauncherTests.swift
+++ b/Tests/AgentIDEDataTests/SandvaultLauncherTests.swift
@@ -40,6 +40,16 @@ struct SandvaultLauncherTests {
         #expect(path?.contains("/opt/homebrew/bin") == true)
         #expect(path?.contains("/usr/local/bin") == true)
         #expect(path?.contains("/usr/bin") == true)
+        #expect(path == "PATH=" + launcher.sandboxPath)
+    }
+
+    @Test
+    func `exposes shell, detach and profile seams for herdr`() {
+        let launching: any SandboxLaunching = launcher
+        #expect(launching.loginShell == "/bin/zsh")
+        #expect(launching.detachSuffix == "&!")
+        #expect(launching.profileBootstrap.contains("~/.zshrc"))
+        #expect(launching.sandboxPath.contains("/opt/homebrew/bin"))
     }
 
     // MARK: Private

--- a/Tests/AgentIDEDataTests/StaleAgentClaimTests.swift
+++ b/Tests/AgentIDEDataTests/StaleAgentClaimTests.swift
@@ -68,6 +68,7 @@ struct StaleAgentClaimTests {
             spool: EventSpool(directory: world.paths.eventsDirectory),
             store: MetadataStore(file: world.paths.metadataFile),
             runners: [],
+            launcher: SandvaultLauncher(hostUser: "test"),
         )
     }
 }

--- a/Tests/AgentIDEDataTests/TestSupport.swift
+++ b/Tests/AgentIDEDataTests/TestSupport.swift
@@ -221,9 +221,10 @@ struct World {
         try await TestSupport.makeRepository(at: repoPath)
         let runner = FoundationProcessRunner()
         let home = try TestSupport.configHome()
+        let launcher = SandvaultLauncher(hostUser: "test")
         let herdrClient = HerdrClient(
             runner: runner,
-            launcher: SandvaultLauncher(hostUser: "test"),
+            launcher: launcher,
             isInsideSandbox: true,
             configHome: home,
         )
@@ -236,6 +237,7 @@ struct World {
             spool: EventSpool(directory: workspace.eventsDirectory),
             store: MetadataStore(file: workspace.metadataFile),
             runners: [PromptCaptureRunner()],
+            launcher: launcher,
             // Disabled so branch names always come from the
             // deterministic prompt fallback, whatever this machine's
             // Apple Intelligence state.

--- a/Tests/AgentIDEDataTests/TestSupport.swift
+++ b/Tests/AgentIDEDataTests/TestSupport.swift
@@ -241,7 +241,7 @@ struct World {
             // Disabled so branch names always come from the
             // deterministic prompt fallback, whatever this machine's
             // Apple Intelligence state.
-            summariser: FoundationModelClient(isEnabled: false),
+            summariser: NullSummariser(),
         )
         return Self(
             root: base,

--- a/Tests/AgentIDEDataTests/WorkspaceWatcherIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/WorkspaceWatcherIntegrationTests.swift
@@ -1,4 +1,4 @@
-import AgentIDEData
+@testable import AgentIDEData
 import Foundation
 import Testing
 

--- a/Tests/AgentIDEDomainTests/PerformanceLogTests.swift
+++ b/Tests/AgentIDEDomainTests/PerformanceLogTests.swift
@@ -38,12 +38,14 @@ struct PerformanceLogTests {
     @Test
     func `the log lives in the shared temporary directory`() {
         // script/test points the log into the test scratch; run
-        // any other way it is the shared temporary directory.
+        // any other way it is the shared temporary directory the
+        // app configured, or the process temporary directory.
         if let override = ProcessInfo.processInfo.environment["AGENTIDE_PERFORMANCE_LOG_DIRECTORY"] {
             #expect(PerformanceLog.file == override + "/performance.log")
+        } else if let shared = PerformanceLog.sharedTemporaryDirectory {
+            #expect(PerformanceLog.file == shared + "/performance.log")
         } else {
-            #expect(PerformanceLog.file.hasSuffix("/tmp/agentide/performance.log"))
-            #expect(PerformanceLog.file.hasPrefix("/Users/Shared/sv-"))
+            #expect(PerformanceLog.file.hasSuffix("agentide/performance.log"))
         }
     }
 }

--- a/Tests/PRFeatureTests/PullRequestsModelTests+Fixtures.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests+Fixtures.swift
@@ -84,6 +84,7 @@ extension PullRequestsModelTests {
             spool: EventSpool(directory: paths.eventsDirectory),
             store: MetadataStore(file: paths.metadataFile),
             runners: [],
+            launcher: SandvaultLauncher(hostUser: "test"),
         )
         return PullRequestsModel(
             repository: Repository(name: "repo", path: "/repo"),

--- a/Tests/SessionFeatureTests/RepositorySessionsModelTests.swift
+++ b/Tests/SessionFeatureTests/RepositorySessionsModelTests.swift
@@ -106,6 +106,7 @@ struct RepositorySessionsModelTests {
             spool: EventSpool(directory: paths.eventsDirectory),
             store: MetadataStore(file: paths.metadataFile),
             runners: [],
+            launcher: SandvaultLauncher(hostUser: "test"),
         )
         let model = RepositorySessionsModel(
             repository: Repository(name: "repo", path: "/repo"),

--- a/script/performance-log
+++ b/script/performance-log
@@ -6,7 +6,11 @@
 set -euo pipefail
 
 user="${USER#sandvault-}"
-directory="/Users/Shared/sv-${user}/tmp/agentide"
+if [[ "$(uname -s)" == Darwin ]]; then
+  directory="/Users/Shared/sv-${user}/tmp/agentide"
+else
+  directory="/var/lib/agentide/${user}/tmp/agentide"
+fi
 marker="${directory}/performance-log"
 log="${directory}/performance.log"
 


### PR DESCRIPTION
## Summary
- Introduce a `SandboxLaunching` protocol with `SandvaultLauncher` as the macOS implementation, and inject one launcher through `SessionService` / `HerdrClient` instead of reconstructing `SandvaultLauncher` at delete and lifecycle call sites.
- Derive shared-workspace and metadata paths from `PlatformRoots`, and move shell / detach / profile bootstrap onto the launcher so herdr server start stays consistent with the privilege crossing.
- Small companion seams (`FileWatching`, `OnDeviceSummarising`, `PowerObserving`, injectable performance-log directory) so composition stays testable without IOKit or Foundation Models defaults leaking into tests.

## Test plan
- [ ] `script/style --fix`
- [ ] `script/test` (or at least AgentIDEData / Domain unit tests)
- [ ] Confirm deleting a conversation / worktree still uses the injected launcher (no second `SandvaultLauncher(hostUser:)` construction)
- [ ] Confirm herdr server start still works outside the sandbox
