### PR TITLE
Rebase stack from any layer and shape buttons with branch titles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -869,11 +869,14 @@ selects the worktree holding it, and `agentide new` starts a session.
   ticks every box and writes the AI disclosure from the session's model
   and effort, and only into a template. The template is read from the
   working copy or, for sparse checkouts, from git.
-- **A stack moves as one.** Rebasing any entry restacks the branches
-  above it and pushes the ones the remote already has, since GitHub
-  reads a pull request whose parent moved as no stack at all; pushing
-  any entry pushes every branch of the stack, bottom first, whether or
-  not each has a pull request open yet. A branch nobody has pushed is
+- **A stack moves as one.** Rebase on any layer, the bottom included
+  and the menu bar's Rebase with it, restacks the whole stack and
+  pushes the branches the remote already has, since GitHub reads a
+  pull request whose parent moved as no stack at all. Rebasing one
+  layer on its own rewrote what the layers above fork from, and the
+  stack derived afterwards no longer reached them. Pushing any entry
+  pushes every branch of the stack, bottom first, whether or not each
+  has a pull request open yet. A branch nobody has pushed is
   published by Push and never by a rebase.
 - **Stacks are derived, never recorded**: branches sharing a fork point
   beyond the default branch, ordered by where each forks; two branches
@@ -884,8 +887,8 @@ selects the worktree holding it, and `agentide new` starts a session.
   what a stack is. The Stack popover drops branches by name (remembered
   per worktree) and cuts new ones. Restacking records every tip, then
   rebases bottom up with `--onto <parent> <recorded tip>`, signed,
-  skipping a branch already in place, and carries the branches above
-  the entry rebased. Each pull request opens against the branch below
+  skipping a branch already in place and signed, from whichever entry
+  asked. Each pull request opens against the branch below
   with both `--head` and `--base` named; `gh stack link` links what is
   open (idempotent, additive), and stack merge is
   `gh stack merge <number> --yes --merge-method <method>` after

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -792,12 +792,18 @@ selects the worktree holding it, and `agentide new` starts a session.
   what it opened where the row already looks, GitHub's own listing
   where it has caught up and the bare facts the form knows otherwise,
   which the next fetch replaces.
-- **The default branch is not pushed from here.** Work belongs on a
-  branch of its own, and a push straight to `main` goes round the
-  pull request the rest of the tab is for (a protected branch would
-  refuse it anyway), so Push dims there and says why, and the menu
-  bar's Push, which has no button to dim, declines in the footer.
-  The tab already asks GitHub nothing about the default branch.
+- **A guarded default branch is not pushed from here.** Whether the
+  default branch takes a push is GitHub's to say: the branch's own
+  summary says whether classic protection is on it, and the rules
+  endpoint lists every ruleset rule active on it, both readable with
+  read access. Protection, or a rule wanting a pull request or
+  passing checks, means a push would be refused, so Push dims there
+  and says why and the menu bar's Push declines in the footer; a
+  repository of your own with none of that takes the push and Push
+  runs. Asked once per repository and kept until the tab's refresh
+  button is pressed, since protection changes about as often as a
+  repository's settings do; nothing known counts as guarded. The tab
+  asks GitHub nothing else about the default branch.
 - **Pushing** asks the branch first and GitHub second. A branch checked
   out from someone else's pull request carries that fork's URL in its
   config (all `gh pr checkout` leaves behind), so it is given a remote

--- a/Sources/AgentIDEData/AppMetadata.swift
+++ b/Sources/AgentIDEData/AppMetadata.swift
@@ -131,6 +131,8 @@ public struct AppMetadata: Codable, Equatable, Sendable {
         queuedCache = try container.decodeIfPresent([String: [Int]].self, forKey: .queuedCache) ?? [:]
         mergeQueueCapability = try container
             .decodeIfPresent([String: Bool].self, forKey: .mergeQueueCapability) ?? [:]
+        directPushCapability = try container
+            .decodeIfPresent([String: Bool].self, forKey: .directPushCapability) ?? [:]
         // The newer ledgers decode as one value from the same
         // decoder, which keeps this initialiser within its length.
         let ledgers = try Ledgers(from: decoder)
@@ -155,8 +157,10 @@ public struct AppMetadata: Codable, Equatable, Sendable {
     /// relaunch shows the queue it knew rather than asking at once.
     public var queuedCache: [String: [Int]] = [:]
 
-    /// Whether each repository merges through a queue at all.
+    /// Whether each repository merges through a queue at all, and
+    /// whether its default branch takes a push.
     public var mergeQueueCapability: [String: Bool] = [:]
+    public var directPushCapability: [String: Bool] = [:]
 
     /// The models each CLI last reported, by agent raw value, so the
     /// pickers open on a relaunch with the real list while the CLI
@@ -175,11 +179,9 @@ public struct AppMetadata: Codable, Equatable, Sendable {
     /// limit, which is most polls.
     public var etags: [String: String] = [:]
 
-    /// The head commit GitHub last reported for each pushed branch,
-    /// keyed like `pullRequestCache`, held from a push until GitHub
-    /// reports another: until then a fetched summary is painted as
-    /// awaiting its checks, since what GitHub says is about commits
-    /// that are gone. Empty when the cache held no commit to compare.
+    /// The head GitHub last reported for each pushed branch, keyed
+    /// like `pullRequestCache`, until it reports another; see
+    /// `PullRequestStore+Pending`. Empty when none was known.
     public var pendingChecks: [String: String] = [:]
 
     /// When each pull request's checks were first seen still running,

--- a/Sources/AgentIDEData/GitHubClient+Protection.swift
+++ b/Sources/AgentIDEData/GitHubClient+Protection.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Whether a repository's default branch takes a push at all. A
+/// repository of your own usually does; a shared one guards its
+/// default branch with classic protection or a ruleset that wants a
+/// pull request, and a push straight to it is refused.
+public extension GitHubClient {
+    /// What a branch does with a push: takes it when neither classic
+    /// protection nor an active rule that wants a pull request or
+    /// passing checks stands in the way, refuses it otherwise, and
+    /// nobody knows when GitHub cannot be asked.
+    enum PushPolicy: Equatable, Sendable {
+        case takesPushes
+        case guarded
+        case unknown
+    }
+
+    /// What GitHub says the branch does with a push.
+    func pushPolicy(repositoryPath: String, branch: String) async -> PushPolicy {
+        // Both reads take read access alone: the branch's own summary
+        // says whether classic protection is on it, and the rules
+        // endpoint lists every ruleset rule active on it.
+        let branchResult = try? await gh(
+            ["api", "repos/{owner}/{repo}/branches/" + branch, "--jq", ".protected"],
+            in: repositoryPath,
+            allowFailure: true,
+        )
+        guard let branchResult, branchResult.succeeded else {
+            return .unknown
+        }
+
+        // A rules read that fails is not an empty list of rules: read
+        // as one it would open Push on a guarded branch.
+        let rules = try? await gh(
+            ["api", "repos/{owner}/{repo}/rules/branches/" + branch],
+            in: repositoryPath,
+            allowFailure: true,
+        )
+        guard let rules, rules.succeeded else {
+            return .unknown
+        }
+
+        let takes = Self.acceptsPushes(protectedFlag: branchResult.standardOutput, rulesJSON: rules.standardOutput)
+        return takes ? .takesPushes : .guarded
+    }
+
+    /// The decision from what GitHub said; separated for tests.
+    static func acceptsPushes(protectedFlag: String, rulesJSON: String) -> Bool {
+        guard protectedFlag.trimmingCharacters(in: .whitespacesAndNewlines) != "true" else {
+            return false
+        }
+
+        let rules = (try? JSONSerialization.jsonObject(with: Data(rulesJSON.utf8))) as? [[String: Any]] ?? []
+        let types = Set(rules.compactMap { $0["type"] as? String })
+        return types.isDisjoint(with: Self.pushRefusingRules)
+    }
+
+    // MARK: Internal
+
+    /// The ruleset rules under which a push straight to the branch
+    /// is refused: one wants a pull request, the other wants checks
+    /// that only a pull request runs.
+    internal static let pushRefusingRules: Set<String> = ["pull_request", "required_status_checks"]
+}

--- a/Sources/AgentIDEData/PullRequestStore.swift
+++ b/Sources/AgentIDEData/PullRequestStore.swift
@@ -40,8 +40,9 @@ public struct PullRequestStore: Sendable {
     /// The floor for a single pull request's summary.
     public static let inFlightFloor: TimeInterval = 30
 
-    /// How long a repository's settings are taken at their word.
-    public static let capabilityInterval: TimeInterval = 3_600
+    /// How long a repository's settings are taken at their word:
+    /// a day, since they change about as often as its settings do.
+    public static let capabilityInterval: TimeInterval = 86_400
 
     /// How often a listing nobody is looking at is asked for.
     public static let backgroundInterval: TimeInterval = 300
@@ -208,7 +209,7 @@ public struct PullRequestStore: Sendable {
     }
 
     /// Whether the repository merges through a queue, which changes
-    /// about as often as its settings do; asked once an hour rather
+    /// about as often as its settings do; asked once a day rather
     /// than on every visit to the tab.
     public func hasMergeQueue(
         repositoryPath: String,

--- a/Sources/AgentIDEData/PullRequestStore.swift
+++ b/Sources/AgentIDEData/PullRequestStore.swift
@@ -227,6 +227,42 @@ public struct PullRequestStore: Sendable {
         return answer
     }
 
+    /// Whether the repository's default branch takes a push. Asked
+    /// once per repository and kept until `forgetDefaultPushPolicy`,
+    /// which the tab's refresh button is for: protection changes
+    /// about as often as a repository's settings do. A GitHub that
+    /// cannot be asked stores nothing, so the next visit asks again,
+    /// and nothing known is a no.
+    public func acceptsDefaultPushes(repositoryPath: String, branch: String) async -> Bool {
+        let key = "push-capability#" + repositoryPath
+        if let known = store.load().directPushCapability[repositoryPath] {
+            PerformanceLog.record(cacheHit: true, key)
+            return known
+        }
+
+        PerformanceLog.record(cacheHit: false, key)
+
+        let answer: Bool
+        switch await github.pushPolicy(repositoryPath: repositoryPath, branch: branch) {
+        case .unknown:
+            return false
+
+        case .takesPushes:
+            answer = true
+
+        case .guarded:
+            answer = false
+        }
+        store.update { $0.directPushCapability[repositoryPath] = answer }
+        return answer
+    }
+
+    /// Forgets whether the default branch takes a push, so the next
+    /// reading asks GitHub again.
+    public func forgetDefaultPushPolicy(repositoryPath: String) {
+        store.update { $0.directPushCapability[repositoryPath] = nil }
+    }
+
     /// Every repository's merge queue, those due asked for in one
     /// query and the rest answered from what they last said.
     public func queuedNumbers(

--- a/Sources/PRFeature/PullRequestFooterView+Stack.swift
+++ b/Sources/PRFeature/PullRequestFooterView+Stack.swift
@@ -5,20 +5,25 @@ import TerminalUI
 /// the same titles in the same places as a lone branch's, doing the
 /// stack's version of each. Split from the footer for length.
 extension PullRequestFooterView {
-    /// The branch actions: a stacked entry's stand where a lone
-    /// branch's do, so the flow does not move about.
+    /// The branch actions: a stacked entry's buttons stand where a
+    /// lone branch's buttons do, so the flow does not move about. Rebase is the
+    /// stack's from any layer, its bottom included, since rebasing
+    /// one layer alone is what loses the layers above it.
     @ViewBuilder var branchActions: some View {
-        if model.isStackedEntry {
+        if model.stacking.stack.isStacked {
             restackButton
-            pushStackButton
         } else {
             rebaseButton
+        }
+        if model.isStackedEntry {
+            pushStackButton
+        } else {
             pushButton
         }
     }
 
-    /// A stack's own pair, in the place and dress of the branch
-    /// pair they stand in for: the same titles through
+    /// A stack's own pair of buttons, in the place and dress of the
+    /// branch pair it stands in for: the same titles through
     /// `actionTitle`, the same order, the same counts and the same
     /// past tense while dim, doing the stack's version of the work.
     private var restackButton: some View {
@@ -43,6 +48,7 @@ extension PullRequestFooterView {
                 + "replays and leaving alone any branch already in place and signed; a conflict "
                 + "aborts and reports to Messages"
                 : "Every branch is already on the one below it, with its tip signed",
+            shortcut: "⌥⌘R",
         )
     }
 

--- a/Sources/PRFeature/PullRequestFooterView+Stack.swift
+++ b/Sources/PRFeature/PullRequestFooterView+Stack.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import TerminalUI
 
 /// The footer's actions when the entry on screen is stacked work:
-/// the same icons in the same places as a lone branch's, doing the
+/// the same titles in the same places as a lone branch's, doing the
 /// stack's version of each. Split from the footer for length.
 extension PullRequestFooterView {
     /// The branch actions: a stacked entry's stand where a lone
@@ -18,15 +18,19 @@ extension PullRequestFooterView {
     }
 
     /// A stack's own pair, in the place and dress of the branch
-    /// pair they stand in for: the same icons, the same order, the
-    /// same counts, doing the stack's version of the work. Both dim
-    /// when there is nothing to do.
+    /// pair they stand in for: the same titles through
+    /// `actionTitle`, the same order, the same counts and the same
+    /// past tense while dim, doing the stack's version of the work.
     private var restackButton: some View {
         BusyButton(
-            model.canRestack ? rebaseCount : model.rebaseDoneTitle ?? "",
-            busy: "Rebasing",
-            systemImage: "arrow.triangle.2.circlepath",
-            accessibilityLabel: "Rebase the stack",
+            actionTitle(
+                stackSignsOnly ? "Sign" : "Rebase",
+                arrow: Self.downArrow,
+                count: stackSignsOnly ? "" : rebaseCount,
+                active: model.canRestack,
+                done: model.rebaseDoneTitle,
+            ),
+            busy: stackSignsOnly ? "Signing" : "Rebasing",
             disabled: model.canRestack == false,
         ) {
             if await model.restack() == false {
@@ -42,12 +46,22 @@ extension PullRequestFooterView {
         )
     }
 
+    /// Whether the stack's rebase would only sign: every branch is
+    /// on the one below it and a tip is unsigned.
+    private var stackSignsOnly: Bool {
+        model.stacking.needsRestack == false
+    }
+
     private var pushStackButton: some View {
         BusyButton(
-            model.canPushStack ? stackPushCount : model.pushDoneTitle ?? "",
+            actionTitle(
+                "Push",
+                arrow: Self.upArrow,
+                count: stackPushCount,
+                active: model.canPushStack,
+                done: model.pushDoneTitle,
+            ),
             busy: "Pushing",
-            systemImage: "arrow.up",
-            accessibilityLabel: "Push stack",
             disabled: model.canPushStack == false,
         ) {
             if await model.pushStack() == false {

--- a/Sources/PRFeature/PullRequestListView.swift
+++ b/Sources/PRFeature/PullRequestListView.swift
@@ -120,6 +120,13 @@ struct PullRequestListView: View {
 struct PullRequestFooterView: View {
     // MARK: Internal
 
+    /// The arrows the sidebar's own counts use, so a number means
+    /// the same thing in both places: up is what has yet to go to
+    /// the remote, down what has yet to come from it. A button draws
+    /// one of them at most, beside one count.
+    static let upArrow = "\u{2191}"
+    static let downArrow = "\u{2193}"
+
     @Bindable var model: PullRequestsModel
 
     /// The cross-module signal that switches the utility pane's tab.
@@ -260,16 +267,20 @@ struct PullRequestFooterView: View {
         .hoverHelp(model.pushHelp, shortcut: "⇧⌘P")
     }
 
+    /// One shape for every branch action's title, lone or stacked:
+    /// what a click is about to do and the count it is about to
+    /// send, or what the last click did while the button stays dim.
+    func actionTitle(_ verb: String, arrow: String, count: String, active: Bool, done: String?) -> String {
+        if active == false, let done {
+            return done
+        }
+
+        return count.isEmpty ? verb : verb + " " + arrow + count
+    }
+
     // MARK: Private
 
     private static let padding: CGFloat = 8
-
-    /// The arrows the sidebar's own counts use, so a number means
-    /// the same thing in both places: up is what has yet to go to
-    /// the remote, down what has yet to come from it. A button draws
-    /// one of them at most, beside one count.
-    private static let upArrow = "\u{2191}"
-    private static let downArrow = "\u{2193}"
 
     /// Whether the button would only sign: the base has not moved,
     /// so nothing is being rebased onto anything.
@@ -286,24 +297,19 @@ struct PullRequestFooterView: View {
     /// rebasing in it, otherwise the rebase and how far behind the
     /// branch is.
     private var rebaseLabel: String {
-        if model.canRebase == false, let done = model.rebaseDoneTitle {
-            return done
-        }
-        guard signsOnly == false else {
-            return "Sign"
-        }
-
-        return rebaseCount.isEmpty ? "Rebase" : "Rebase " + Self.downArrow + rebaseCount
+        actionTitle(
+            signsOnly ? "Sign" : "Rebase",
+            arrow: Self.downArrow,
+            count: signsOnly ? "" : rebaseCount,
+            active: model.canRebase,
+            done: model.rebaseDoneTitle,
+        )
     }
 
     /// The same for the push: what it would send, or that it sent
     /// it, while it stays dim.
     private var pushLabel: String {
-        if model.canPush == false, let done = model.pushDoneTitle {
-            return done
-        }
-
-        return pushCount.isEmpty ? "Push" : "Push " + Self.upArrow + pushCount
+        actionTitle("Push", arrow: Self.upArrow, count: pushCount, active: model.canPush, done: model.pushDoneTitle)
     }
 
     /// The commits this branch has above the base it was rebased

--- a/Sources/PRFeature/PullRequestsModel+Actions.swift
+++ b/Sources/PRFeature/PullRequestsModel+Actions.swift
@@ -348,12 +348,14 @@ extension PullRequestsModel {
         // click, so the listing, the pull request in view and its
         // conversation are all forgotten before the reading.
         pullRequests.invalidateListings(repositoryPath: repository.path)
+        pullRequests.forgetDefaultPushPolicy(repositoryPath: repository.path)
         if let number = selected?.number {
             pullRequests.invalidate(repositoryPath: repository.path, number: number)
         }
         conversationRefreshes += 1
         await reload(keepingSelection: true)
         await loadMergeQueue()
+        await loadDefaultBranchPolicy()
     }
 
     static func requestSidebarRefresh() {

--- a/Sources/PRFeature/PullRequestsModel+Branch.swift
+++ b/Sources/PRFeature/PullRequestsModel+Branch.swift
@@ -102,6 +102,14 @@ extension PullRequestsModel {
     }
 
     func rebaseSigned() async -> Bool {
+        // Any layer of a stack rebases the whole of it. Rebasing one
+        // entry on its own rewrites what the branches above fork
+        // from, and a stack derived afterwards no longer reaches
+        // them: signing the bottom of an unopened stack lost the
+        // rest of it.
+        guard stacking.stack.isStacked == false else {
+            return await restack()
+        }
         guard let worktree = listedWorktree else {
             return true
         }
@@ -113,27 +121,6 @@ extension PullRequestsModel {
         let onlySigns = rebaseNeed == SessionService.RebaseNeed.sign
         do {
             let target = try await performRebase(worktree)
-            // A stack member that moves takes the branches above it
-            // with it. Left where they were, they fork from the
-            // default branch instead of from it, which is not a
-            // stack at all: the tab lost the entry that had just
-            // moved and showed whichever branch was checked out, so
-            // the next press rebased that one instead.
-            if stacking.stack.isStacked {
-                do {
-                    _ = try await stacking.restack(worktree)
-                    // Every branch the restack moved is now behind
-                    // what the remote has, and GitHub reads a stack
-                    // whose parents moved as no stack at all: the
-                    // published ones go back up at once. A branch
-                    // nobody has pushed stays unpushed, which Push
-                    // is for.
-                    try await markChecksPending(for: stacking.pushPublished(worktree))
-                } catch {
-                    report("Rebasing the branches above `" + worktree.branch + "` failed: "
-                        + error.localizedDescription)
-                }
-            }
             await reload(keepingSelection: true)
             // Done means Push agrees; reporting success with the tip
             // still unsigned took a second press to notice.

--- a/Sources/PRFeature/PullRequestsModel+Branch.swift
+++ b/Sources/PRFeature/PullRequestsModel+Branch.swift
@@ -259,7 +259,7 @@ extension PullRequestsModel {
     /// worktree's counts describe whichever branch it has checked
     /// out.
     var canPush: Bool {
-        guard branchItem != nil, isDefaultBranch == false, isPushed == false,
+        guard branchItem != nil, isGuardedDefaultBranch == false, isPushed == false,
               tipSignature == .signed
         else {
             return false
@@ -269,12 +269,17 @@ extension PullRequestsModel {
     }
 
     /// Whether the entry in view is the repository's own default
-    /// branch. Work belongs on a branch of its own: pushing to the
-    /// default branch straight from here goes round the pull
-    /// request the rest of this tab is for, and a repository that
-    /// protects it would refuse the push anyway.
+    /// branch.
     var isDefaultBranch: Bool {
         listedBranch != nil && listedBranch == defaultBranch
+    }
+
+    /// Whether the entry in view is a default branch that refuses a
+    /// push: one GitHub protects, or wants a pull request or passing
+    /// checks on, which is most shared repositories. A repository of
+    /// your own with none of that takes the push, and Push runs.
+    var isGuardedDefaultBranch: Bool {
+        isDefaultBranch && acceptsDefaultPushes == false
     }
 
     /// Whether the listed branch has commits the remote lacks: the
@@ -292,8 +297,8 @@ extension PullRequestsModel {
     /// with nothing to push that is the whole story, and signing
     /// only matters once commits are waiting.
     var pushHelp: String {
-        guard isDefaultBranch == false else {
-            return "This is the repository's default branch: put the work on a branch of its own "
+        guard isGuardedDefaultBranch == false else {
+            return "This repository guards its default branch: put the work on a branch of its own "
                 + "and open a pull request for it"
         }
         guard branchItem != nil, isPushed == false, hasUnpushedCommits else {

--- a/Sources/PRFeature/PullRequestsModel+Create.swift
+++ b/Sources/PRFeature/PullRequestsModel+Create.swift
@@ -121,11 +121,11 @@ extension PullRequestsModel {
         // The menu bar's Push reaches this without a button to dim,
         // and a push to the default branch goes round the pull
         // request the rest of this tab is for.
-        guard isDefaultBranch == false else {
+        guard isGuardedDefaultBranch == false else {
             setStatus(
-                "Not pushed: this is the default branch.",
-                detail: "work belongs on a branch of its own; the default branch is what a pull "
-                    + "request merges into",
+                "Not pushed: the default branch is guarded.",
+                detail: "the default branch is protected or wants a pull request; work belongs "
+                    + "on a branch of its own",
             )
             return true
         }

--- a/Sources/PRFeature/PullRequestsModel+Reload.swift
+++ b/Sources/PRFeature/PullRequestsModel+Reload.swift
@@ -11,6 +11,13 @@ extension PullRequestsModel {
         hasMergeQueue = await fetchHasMergeQueue()
     }
 
+    /// Whether the default branch takes a push, which is the one
+    /// thing that lets Push run on it: a repository of your own
+    /// usually does, a shared one guards it and refuses.
+    func loadDefaultBranchPolicy() async {
+        acceptsDefaultPushes = await fetchAcceptsDefaultPushes()
+    }
+
     /// The cached listing paints instantly while the fetch runs; a
     /// kept selection is re-selected once the fetch answers, and a
     /// single result opens its conversation directly. Extending

--- a/Sources/PRFeature/PullRequestsModel+Seams.swift
+++ b/Sources/PRFeature/PullRequestsModel+Seams.swift
@@ -25,6 +25,18 @@ extension PullRequestsModel {
         }
     }
 
+    /// Whether the default branch takes a push, a no when there is
+    /// no default branch to ask about.
+    static func acceptsDefaultPushes(gate: PullRequestStore, repository: Repository, defaultBranch: String?) async
+        -> Bool
+    {
+        guard let defaultBranch else {
+            return false
+        }
+
+        return await gate.acceptsDefaultPushes(repositoryPath: repository.path, branch: defaultBranch)
+    }
+
     /// Tidies up after a merge and says what it did and could not.
     static func cleanUpAfterMerge(worktree: Worktree, mergedBranch: String, service: SessionService) async {
         let report = await service.cleanUpAfterMerge(worktree: worktree, mergedBranch: mergedBranch)

--- a/Sources/PRFeature/PullRequestsModel+Stack.swift
+++ b/Sources/PRFeature/PullRequestsModel+Stack.swift
@@ -2,8 +2,9 @@ import AgentIDEData
 import AgentIDEDomain
 
 /// A stack of branches in one worktree, as the pull request tab sees
-/// it: which branch is listed, and the two things a stack is asked
-/// to do as a whole.
+/// it: which branch is listed and what it would take to put the
+/// stack in order; the two things a stack is asked to do as a whole
+/// are in `+StackActions`.
 extension PullRequestsModel {
     /// Points the stack's work at the service; kept here so the
     /// model's own initialiser stays about pull requests.
@@ -322,70 +323,5 @@ extension PullRequestsModel {
         }
 
         return stacking.stack.branches[..<index].last { isBlocking($0) }
-    }
-
-    /// Puts every branch back on the one below it and says what
-    /// moved; a branch already there is left alone, so no commit is
-    /// renamed for nothing.
-    func restack() async -> Bool {
-        guard let worktree = branchItem?.worktree else {
-            return true
-        }
-
-        isBranchActionRunning = true
-        defer { isBranchActionRunning = false }
-        do {
-            let moved = try await stacking.restack(worktree)
-            await loadStack()
-            await reload(keepingSelection: true)
-            // Done means Push agrees; reporting success with the
-            // stack still unsigned took a second press to notice.
-            if let unsigned = stacking.unsignedBranches.first {
-                report("Restacked, but `" + unsigned + "`'s tip still reads unsigned; "
-                    + "check the signing key and hit Rebase again")
-                return false
-            }
-            let verb = AppSettings.requiresSignedCommits ? "Rebased and signed" : "Rebased"
-            guard moved.isEmpty == false else {
-                // Nothing moved, so nothing was done: the button
-                // must not claim otherwise.
-                setStatus("Already in order.", detail: "The stack was already in order.")
-                Self.requestSidebarRefresh()
-                return true
-            }
-
-            recordFinished(.rebased, branch: actedBranch ?? worktree.branch)
-            note(verb + " " + Self.named(moved) + ".")
-            Self.requestSidebarRefresh()
-            return true
-        } catch {
-            report(error.localizedDescription)
-            return false
-        }
-    }
-
-    /// Pushes the stack bottom up, so each pull request's base is on
-    /// the remote before the branch that points at it.
-    func pushStack() async -> Bool {
-        guard let worktree = branchItem?.worktree else {
-            return true
-        }
-
-        isBranchActionRunning = true
-        defer { isBranchActionRunning = false }
-        do {
-            let pushed = try await stacking.push(worktree)
-            pullRequests.invalidateListings(repositoryPath: repository.path)
-            markChecksPending(for: pushed)
-            recordFinished(.pushed, branch: actedBranch ?? worktree.branch)
-            note("Pushed " + Self.named(pushed) + ".")
-            Self.requestSidebarRefresh()
-            await reload(keepingSelection: true)
-            refreshAfterPush()
-            return true
-        } catch {
-            report(error.localizedDescription)
-            return false
-        }
     }
 }

--- a/Sources/PRFeature/PullRequestsModel+StackActions.swift
+++ b/Sources/PRFeature/PullRequestsModel+StackActions.swift
@@ -1,0 +1,88 @@
+import AgentIDEData
+import AgentIDEDomain
+
+/// The two things a stack is asked to do as a whole: rebase every
+/// branch onto the one below it and push them bottom first. Split
+/// from `+Stack` for length.
+extension PullRequestsModel {
+    /// Puts every branch back on the one below it, from whichever
+    /// layer asked, and says what moved; a branch already there is
+    /// left alone, so no commit is renamed for nothing.
+    func restack() async -> Bool {
+        guard let worktree = branchItem?.worktree else {
+            return true
+        }
+
+        isBranchActionRunning = true
+        defer { isBranchActionRunning = false }
+        // What it is about to do, before doing it moves the stack
+        // and leaves nothing to read it from.
+        let onlySigns = stacking.needsRestack == false
+        do {
+            let moved = try await stacking.restack(worktree)
+            // Every branch the restack moved is now behind what the
+            // remote has, and GitHub reads a stack whose parents
+            // moved as no stack at all: the published ones go back
+            // up at once. A branch nobody has pushed stays unpushed,
+            // which Push is for.
+            if moved.isEmpty == false {
+                try await markChecksPending(for: stacking.pushPublished(worktree))
+            }
+            await loadStack()
+            await reload(keepingSelection: true)
+            // Done means Push agrees; reporting success with the
+            // stack still unsigned took a second press to notice.
+            if let unsigned = stacking.unsignedBranches.first {
+                report("Restacked, but `" + unsigned + "`'s tip still reads unsigned; "
+                    + "check the signing key and hit Rebase again")
+                return false
+            }
+            let verb =
+                if onlySigns {
+                    "Signed"
+                } else {
+                    AppSettings.requiresSignedCommits ? "Rebased and signed" : "Rebased"
+                }
+            guard moved.isEmpty == false else {
+                // Nothing moved, so nothing was done: the button
+                // must not claim otherwise.
+                setStatus("Already in order.", detail: "The stack was already in order.")
+                Self.requestSidebarRefresh()
+                return true
+            }
+
+            recordFinished(onlySigns ? .signed : .rebased, branch: actedBranch ?? worktree.branch)
+            note(verb + " " + Self.named(moved) + ".")
+            Self.requestSidebarRefresh()
+            return true
+        } catch {
+            report(error.localizedDescription)
+            return false
+        }
+    }
+
+    /// Pushes the stack bottom up, so each pull request's base is on
+    /// the remote before the branch that points at it.
+    func pushStack() async -> Bool {
+        guard let worktree = branchItem?.worktree else {
+            return true
+        }
+
+        isBranchActionRunning = true
+        defer { isBranchActionRunning = false }
+        do {
+            let pushed = try await stacking.push(worktree)
+            pullRequests.invalidateListings(repositoryPath: repository.path)
+            markChecksPending(for: pushed)
+            recordFinished(.pushed, branch: actedBranch ?? worktree.branch)
+            note("Pushed " + Self.named(pushed) + ".")
+            Self.requestSidebarRefresh()
+            await reload(keepingSelection: true)
+            refreshAfterPush()
+            return true
+        } catch {
+            report(error.localizedDescription)
+            return false
+        }
+    }
+}

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -55,6 +55,9 @@ final class PullRequestsModel {
         fetchHasMergeQueue = {
             await gate.hasMergeQueue(repositoryPath: repository.path)
         }
+        fetchAcceptsDefaultPushes = {
+            await Self.acceptsDefaultPushes(gate: gate, repository: repository, defaultBranch: defaultBranch)
+        }
         fetchThreads = { number in
             let answer = try? await gate.conversation(
                 repositoryPath: repository.path,
@@ -273,6 +276,9 @@ final class PullRequestsModel {
     var fetchList: (GitHubClient.ListScope, Int) async throws -> [PullRequestSummary]
     var fetchSummary: (Int) async throws -> PullRequestSummary?
     var fetchHasMergeQueue: () async -> Bool
+
+    var fetchAcceptsDefaultPushes: () async -> Bool
+    var acceptsDefaultPushes = false
     var fetchThreads: (Int) async -> [ReviewThread]
     var performCreate: (Worktree, String, String, [String], Bool) async throws -> String
 

--- a/Sources/PRFeature/PullRequestsView.swift
+++ b/Sources/PRFeature/PullRequestsView.swift
@@ -99,6 +99,7 @@ public struct PullRequestsView: View {
                 loadedIdentity = identity
                 await model.reload()
                 await model.loadMergeQueue()
+                await model.loadDefaultBranchPolicy()
             } else if model.needsCreateForm == false {
                 await model.reload(keepingSelection: true)
             }

--- a/Tests/AgentIDEDataTests/GitHubClientTests+Protection.swift
+++ b/Tests/AgentIDEDataTests/GitHubClientTests+Protection.swift
@@ -1,0 +1,51 @@
+@testable import AgentIDEData
+import Testing
+
+// MARK: - RulesFailingRunner
+
+/// A `gh` whose branch read says unprotected and whose rules read
+/// fails, the shape of an outage or an endpoint a plan lacks.
+private struct RulesFailingRunner: ProcessRunner {
+    func run(_ arguments: [String], workingDirectory _: String?, environment _: [String: String]) -> ProcessResult {
+        if arguments.first == "git" || arguments.contains("remote") {
+            return ProcessResult(status: 0, standardOutput: "git@github.com:mike/repo.git\n", standardError: "")
+        }
+        if arguments.contains(where: { $0.hasPrefix("repos/{owner}/{repo}/rules/") }) {
+            return ProcessResult(status: 1, standardOutput: "", standardError: "gh: Not Found (HTTP 404)")
+        }
+
+        return ProcessResult(status: 0, standardOutput: "false\n", standardError: "")
+    }
+}
+
+// MARK: - GitHubClientTests
+
+/// Whether a default branch takes a push, from what GitHub says of it.
+extension GitHubClientTests {
+    @Test
+    func `a rules read that fails is no answer, not an empty rule list`() async {
+        // Read as no rules the branch would have taken pushes, which
+        // is the one answer a failed read must never give.
+        let policy = await GitHubClient(runner: RulesFailingRunner())
+            .pushPolicy(repositoryPath: "/repo", branch: "main")
+        #expect(policy == .unknown)
+    }
+
+    @Test
+    func `protection and pull request rules refuse a push, nothing else does`() {
+        // A repository of your own: unprotected, no rules.
+        #expect(GitHubClient.acceptsPushes(protectedFlag: "false\n", rulesJSON: "[]"))
+        // Classic protection alone refuses.
+        #expect(GitHubClient.acceptsPushes(protectedFlag: "true\n", rulesJSON: "[]") == false)
+        // A ruleset wanting a pull request, or checks only a pull
+        // request runs, refuses; one that only forbids deleting the
+        // branch does not.
+        let wantsPullRequest = #"[{"type": "deletion"}, {"type": "pull_request", "parameters": {}}]"#
+        #expect(GitHubClient.acceptsPushes(protectedFlag: "false", rulesJSON: wantsPullRequest) == false)
+        let wantsChecks = #"[{"type": "required_status_checks"}]"#
+        #expect(GitHubClient.acceptsPushes(protectedFlag: "false", rulesJSON: wantsChecks) == false)
+        #expect(GitHubClient.acceptsPushes(protectedFlag: "false", rulesJSON: #"[{"type": "deletion"}]"#))
+        // An answer that is not JSON is no rule at all.
+        #expect(GitHubClient.acceptsPushes(protectedFlag: "false", rulesJSON: "nonsense"))
+    }
+}

--- a/Tests/AgentIDEDataTests/PullRequestStoreTests.swift
+++ b/Tests/AgentIDEDataTests/PullRequestStoreTests.swift
@@ -246,4 +246,32 @@ struct PullRequestStoreTests {
 
         #expect(runner.calls == 1)
     }
+
+    @Test
+    func `the default branch policy is asked once and again after a refresh forgets it`() async throws {
+        let file = try TestSupport.temporaryDirectory("pr-store-policy") + "/state.json"
+        let runner = CountingRunner()
+        let store = PullRequestStore(github: GitHubClient(runner: runner), store: MetadataStore(file: file)) { false }
+
+        // The runner protects nothing: the branch and its rules are
+        // one question each, and a second look asks nothing.
+        let first = await store.acceptsDefaultPushes(repositoryPath: "/repo", branch: "main")
+        let second = await store.acceptsDefaultPushes(repositoryPath: "/repo", branch: "main")
+        #expect(first)
+        #expect(second)
+        #expect(runner.calls == 2)
+
+        // Relaunched, it still knows; forgotten, it asks again.
+        let relaunched = PullRequestStore(
+            github: GitHubClient(runner: runner),
+            store: MetadataStore(file: file),
+        ) { false }
+        let remembered = await relaunched.acceptsDefaultPushes(repositoryPath: "/repo", branch: "main")
+        #expect(remembered)
+        #expect(runner.calls == 2)
+        relaunched.forgetDefaultPushPolicy(repositoryPath: "/repo")
+        let reasked = await relaunched.acceptsDefaultPushes(repositoryPath: "/repo", branch: "main")
+        #expect(reasked)
+        #expect(runner.calls == 4)
+    }
 }

--- a/Tests/PRFeatureTests/PullRequestStackTests.swift
+++ b/Tests/PRFeatureTests/PullRequestStackTests.swift
@@ -183,7 +183,7 @@ struct PullRequestStackTests {
     }
 
     @Test
-    func `rebasing one entry carries the branches above it`() async {
+    func `rebasing any entry rebases the whole stack`() async {
         let fixtures = PullRequestsModelTests()
         let model = fixtures.makeModel(items: [fixtures.item(branch: "feature", ahead: 1)])
         model.fetchCurrentBranch = { _ in "upper" }
@@ -199,15 +199,18 @@ struct PullRequestStackTests {
             done.withLock { $0.append("restack") }
             return ["upper"]
         }
+        // Done means Push agrees: the stack is read as signed after.
+        model.stacking.unsigned = { _ in [] }
         await model.reload()
 
         #expect(await model.rebaseSigned())
 
-        // Left where they were, the branches above fork from the
-        // default branch instead of from the one that moved, and the
-        // stack stops being one: the tab then lost the entry that
-        // had just moved and showed whatever was checked out.
-        #expect(done.withLock { $0 } == ["rebase", "restack"])
+        // Rebasing the entry on its own first rewrote what the
+        // branches above fork from, and the stack derived after it
+        // no longer reached them: signing the bottom of an unopened
+        // stack lost the rest. The stack's restack records every
+        // tip before anything moves, so it is the only rebase.
+        #expect(done.withLock { $0 } == ["restack"])
     }
 
     @Test
@@ -283,6 +286,7 @@ struct PullRequestStackTests {
             done.withLock { $0.append("push published") }
             return ["upper"]
         }
+        model.stacking.unsigned = { _ in [] }
         await model.reload()
 
         #expect(await model.rebaseSigned())
@@ -290,7 +294,7 @@ struct PullRequestStackTests {
         // A branch the restack moved is behind what the remote has,
         // and GitHub reads a stack whose parents moved as no stack
         // at all until the remote copies catch up.
-        #expect(done.withLock { $0 } == ["rebase", "restack", "push published"])
+        #expect(done.withLock { $0 } == ["restack", "push published"])
     }
 
     @Test

--- a/Tests/PRFeatureTests/PullRequestsModelTests+Fixtures.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests+Fixtures.swift
@@ -25,6 +25,7 @@ extension PullRequestsModelTests {
         model.fetchList = { _, _ in [] }
         model.fetchSummary = { _ in nil }
         model.fetchHasMergeQueue = { false }
+        model.fetchAcceptsDefaultPushes = { false }
         model.fetchThreads = { _ in [] }
         model.performCreate = { _, _, _, _, _ in "" }
         model.performLinkStack = { _ in

--- a/Tests/PRFeatureTests/PullRequestsModelTests+Push.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests+Push.swift
@@ -335,18 +335,26 @@ extension PullRequestsModelTests {
     }
 
     @Test
-    func `the default branch is not pushed from here`() async {
+    func `a guarded default branch is not pushed from here, an open one is`() async {
         // The fixture's model calls `main` the default branch, and
-        // the sidebar's own checkout sits on it: commits made there
-        // belong on a branch of their own, and pushing them from
-        // here goes round the pull request this tab is for.
+        // the sidebar's own checkout sits on it. GitHub guards it
+        // (classic protection, or a rule wanting a pull request), so
+        // a push would be refused and the button says so.
         let model = makeModel(items: [item(branch: "main", ahead: 2)])
         model.currentBranch = "main"
         await model.reload()
+        await model.loadDefaultBranchPolicy()
 
         #expect(model.isDefaultBranch)
         #expect(model.canPush == false)
         #expect(model.pushHelp.contains("branch of its own"))
+
+        // A repository of your own guards nothing, and takes it.
+        model.fetchAcceptsDefaultPushes = { true }
+        await model.loadDefaultBranchPolicy()
+        #expect(model.canPush)
+        model.fetchAcceptsDefaultPushes = { false }
+        await model.loadDefaultBranchPolicy()
 
         // The menu bar's Push reaches the model without a button to
         // dim, and declines in the footer rather than pushing.


### PR DESCRIPTION
- GitHub now reveals whether the default branch allows pushes based on protection rules, with settings refreshed per repo and read-only state tracking
- Stack actions now use consistent titles derived from branch pair names, eliminating inconsistent icons and phrasing
- Merge queue configuration is queried once daily, aligning with setting frequency and reducing unnecessary checks
- Entire stack is rebased from any layer, preserving history and base alignment while restoring proper restacking and signing context