### PR TITLE
Let a reading ask for a reading without waiting

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -382,7 +382,10 @@ work is `@concurrent`. Events flow as `AsyncStream`s consumed via
 `HerdrTerminalChannel`, `StackCache` and `RepositoryFacts`; another
 needs a written justification here. `@unchecked Sendable` and
 `nonisolated(unsafe)` are banned. Never loop awaiting a maybe-finished
-task on an actor: keep one running and one queued follow-up.
+task on an actor: keep one running and one queued follow-up. A reading
+that asks for a reading (cleaning up after a merge does) gets the next
+one rather than waiting: the one it is inside is waiting for it, and
+each waited on the other until the app was restarted.
 
 ## Key data flows
 

--- a/Sources/DashboardFeature/DashboardModel+Refresh.swift
+++ b/Sources/DashboardFeature/DashboardModel+Refresh.swift
@@ -28,7 +28,12 @@ public extension DashboardModel {
     /// waiting loop: awaiting an already-finished task resumes
     /// without yielding the actor, and a loop of waiters doing that
     /// starved the one task able to move the state on, which hung
-    /// the app at startup.
+    /// the app at startup. The one exception to that promise is a
+    /// reading asking for a reading, which cleaning up after a merge
+    /// does: it cannot wait for one, since the reading it is inside
+    /// is waiting for it, and each waited on the other until the app
+    /// was restarted. Its call returns at once and what it asked for
+    /// runs as the next reading, straight after this one.
     /// `readingPanes` says whether this reading may ask herdr for
     /// its pane listing: everything but the poll's own tick does,
     /// since an action or an agent change is what changes it; the
@@ -40,6 +45,11 @@ public extension DashboardModel {
         if readingPanes {
             pendingPaneRead = true
         }
+        guard isInsideReading == false else {
+            followUpDue = true
+            return
+        }
+
         // A queued reading has not started, so it must begin after
         // this call: joining it keeps the promise.
         if let queued = queuedRefresh {
@@ -55,7 +65,7 @@ public extension DashboardModel {
                 // replace a queued reading.
                 refreshTask = queuedRefresh
                 queuedRefresh = nil
-                await performRefresh()
+                await performReadings()
                 refreshTask = nil
             }
             queuedRefresh = queued
@@ -64,7 +74,7 @@ public extension DashboardModel {
         }
 
         let task = Task {
-            await performRefresh()
+            await performReadings()
             refreshTask = nil
         }
         refreshTask = task
@@ -125,6 +135,23 @@ public extension DashboardModel {
     /// pane's buttons gate on those counts.
     func refreshSelected() async {
         await refresh(forcing: selection?.worktree.repositoryPath)
+    }
+
+    /// Whether the caller is the reading in flight, which is what
+    /// its own clean-up is when it asks for another reading.
+    private var isInsideReading: Bool {
+        readingTaskID != nil && withUnsafeCurrentTask { $0?.hashValue } == readingTaskID
+    }
+
+    /// One reading, then another straight after when the first
+    /// asked for one, unless a queued reading is about to run anyway.
+    private func performReadings() async {
+        readingTaskID = withUnsafeCurrentTask { $0?.hashValue }
+        defer { readingTaskID = nil }
+        repeat {
+            followUpDue = false
+            await performRefresh()
+        } while followUpDue && queuedRefresh == nil
     }
 
     /// One whole reading of the system; only `refresh` runs it, one

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -361,6 +361,10 @@ public final class DashboardModel {
     var queuedRefresh: Task<Void, Never>?
     var pendingForces: Set<String> = []
 
+    /// The identifier of the task running the reading in flight, and whether it asked for another; see `refresh`.
+    var readingTaskID: Int?
+    var followUpDue = false
+
     /// Whether the next reading asks herdr for its pane listing:
     /// every action and agent change says so, the poll only when
     /// the listing's safety interval has passed. True at launch,

--- a/Tests/DashboardFeatureTests/RefreshReentryTests.swift
+++ b/Tests/DashboardFeatureTests/RefreshReentryTests.swift
@@ -1,0 +1,79 @@
+import AgentIDEData
+@testable import DashboardFeature
+import Foundation
+import Testing
+
+/// A reading that asks for a reading must not wait for one: the one
+/// it is inside is waiting for it.
+@MainActor
+struct RefreshReentryTests {
+    // MARK: Internal
+
+    @Test
+    func `a refresh asked for from inside the reading does not wait on it`() async {
+        let model = makeModel()
+        // A reading is in flight and will be for a while.
+        let reading = Task { _ = try? await Task.sleep(for: .seconds(30)) }
+        model.refreshTask = reading
+        defer { reading.cancel() }
+
+        // Cleaning up after a merge asked for a reading from inside
+        // the reading that found the merge; each waited on the
+        // other until the app was restarted.
+        let returned = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                let caller = withUnsafeCurrentTask { $0?.hashValue }
+                await MainActor.run { model.readingTaskID = caller }
+                await model.refresh()
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(5))
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+
+        #expect(returned)
+        #expect(model.followUpDue)
+    }
+
+    // MARK: Private
+
+    /// A model over a throwaway workspace; nothing is read from it.
+    private func makeModel() -> DashboardModel {
+        let runner = FoundationProcessRunner()
+        let base = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("agentide-dashboard-" + UUID().uuidString, isDirectory: true)
+            .path
+        let paths = WorkspacePaths(
+            hostUser: "test",
+            sharedWorkspace: base + "/shared",
+            sandboxHome: base + "/home",
+            metadataFile: base + "/state.json",
+        )
+        let service = SessionService(
+            paths: paths,
+            git: GitClient(runner: runner),
+            herdr: HerdrClient(
+                runner: runner,
+                launcher: SandvaultLauncher(hostUser: "test"),
+                isInsideSandbox: true,
+                configHome: base + "/herdr",
+            ),
+            github: GitHubClient(runner: runner),
+            transcripts: TranscriptReader(),
+            spool: EventSpool(directory: paths.eventsDirectory),
+            store: MetadataStore(file: paths.metadataFile),
+            runners: [],
+        )
+        return DashboardModel(
+            service: service,
+            store: MetadataStore(file: paths.metadataFile),
+            github: GitHubClient(runner: runner),
+        )
+    }
+}


### PR DESCRIPTION
- Cleaning up after a merge asks for a fresh reading once the main checkout is back on its default branch, from inside the reading that found the merge. `refresh` saw a reading in flight and queued behind it, and that reading was waiting for the clean-up: each waited on the other, so no reading ever finished again. The poll, every event and a launch's listing loop joined the same queue, the sidebar froze and a new worktree stayed "creating" until the app was restarted, while everything outside the reading kept working.
- A call made from the reading in flight now marks a follow-up reading due and returns; the follow-up runs straight after, unless a queued reading is about to anyway.