### PR TITLE
Restore message persistence and recovery flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,12 @@ conventional-commit prefixes such as `feat:`, `fix:` or `chore:`.
   system selection colours and greys out when the window is not
   key, text surfaces use `textColor` over `textBackgroundColor`.
   Literal white or black belongs only in terminal palettes.
+- Errors reach the Messages pane only after automatic recovery has
+  been tried and failed. A surface that can recover on its own (a
+  terminal reattaching, a stale target replaced by the next listing)
+  does so silently first, keeping the diagnostic in the performance
+  log's `messages.log`, and reports once, naming both attempts, only
+  when the recovery fails too. A recovery that succeeds says nothing.
 - A shortcut or action that opens a surface with a text field
   focuses that field, and Escape closes or cancels what it opened.
   The window title always names the selection (repository and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,3 +465,8 @@ Hard-won on macOS 27 beta; check before assuming they expired.
    in that user's macOS temporary directory, and test scratch in the
    gitignored `.test-scratch` of the checkout, which each run sweeps.
 10. Keep diffs minimal and follow existing structure.
+11. One branch per session: every change made in a session goes on
+    that session's one branch, cut from `origin/main` and named for
+    the work, so it opens as one pull request; a further change joins
+    that branch rather than starting another. Delete a branch once
+    its pull request is merged.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1111,8 +1111,11 @@ beside it: the pane does not survive a relaunch, and a fault worth
 relaunching for is exactly what needs reading afterwards. One such
 fault is a terminal pane that draws nothing: a control pane with no
 frame five seconds after attaching, its client still running, is
-reported there and discarded and attached afresh once by itself, and
-Reattach in the pane's menu does the same by hand. A size herdr was
+discarded and attached afresh once by itself, silently, and reported
+only if that draws nothing either; a client that exits before drawing
+(a stale pane target after a herdr restart, say) is held the same way
+until the next attach draws or fails. Reattach in the pane's menu does
+the same by hand. A size herdr was
 already told is not sent again: the attach and the terminal's own size
 callback both said the same size, and herdr 0.8.2 dropped the repaint
 after that transient pair (0.9.0 says it repaints after transient

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1112,7 +1112,11 @@ relaunching for is exactly what needs reading afterwards. One such
 fault is a terminal pane that draws nothing: a control pane with no
 frame five seconds after attaching, its client still running, is
 reported there and discarded and attached afresh once by itself, and
-Reattach in the pane's menu does the same by hand.
+Reattach in the pane's menu does the same by hand. A size herdr was
+already told is not sent again: the attach and the terminal's own size
+callback both said the same size, and herdr 0.8.2 dropped the repaint
+after that transient pair (0.9.0 says it repaints after transient
+resizes).
 
 ## Security model
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -883,12 +883,11 @@ selects the worktree holding it, and `agentide new` starts a session.
   working copy or, for sparse checkouts, from git.
 - **A stack moves as one.** Rebase on any layer, the bottom included
   and the menu bar's Rebase with it, restacks the whole stack and
-  pushes the branches the remote already has, since GitHub reads a
-  pull request whose parent moved as no stack at all; the button
-  itself reads Rebase and Push (or Sign and Push) whenever a branch
-  is on the remote, its help says why, the note names what was
-  pushed, and Push then reads Pushed. While that button is live and
-  no branch is still unpublished, Push is not shown at all: two
+  then pushes it, bottom first, since GitHub reads a pull request
+  whose parent moved as no stack at all; the button reads Rebase and
+  Push (or Sign and Push) with what comes down and what goes up, its
+  help says why, the note names what was pushed, and Push then reads
+  Pushed. While that button is live Push is not shown at all: two
   buttons for one job, and Push pressed first pushed branches about
   to be moved.
   Only one branch action runs at a time: while one does, Rebase and
@@ -901,8 +900,8 @@ selects the worktree holding it, and `agentide new` starts a session.
   layer on its own rewrote what the layers above fork from, and the
   stack derived afterwards no longer reached them. Pushing any entry
   pushes every branch of the stack, bottom first, whether or not each
-  has a pull request open yet. A branch nobody has pushed is
-  published by Push and never by a rebase.
+  has a pull request open yet, and Rebase and Push publishes such a
+  branch the same way.
 - **Stacks are derived, never recorded**: branches sharing a fork point
   beyond the default branch, ordered by where each forks; two branches
   at one commit are one entry and the name the remote knows wins.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -884,7 +884,10 @@ selects the worktree holding it, and `agentide new` starts a session.
 - **A stack moves as one.** Rebase on any layer, the bottom included
   and the menu bar's Rebase with it, restacks the whole stack and
   pushes the branches the remote already has, since GitHub reads a
-  pull request whose parent moved as no stack at all. Merge on any
+  pull request whose parent moved as no stack at all; its help says
+  so, the note names what was pushed, and Push then reads Pushed.
+  Only one branch action runs at a time: while one does, Rebase and
+  Push both dim, since a push pressed mid-rebase failed. Merge on any
   layer, the bottom included, is the stack's merge of that layer and
   everything below it: a stacked pull request merged as a lone one
   fails on a merge queue, which `gh pr merge` joins through

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1105,7 +1105,14 @@ Owner avatars cache per owner under `Application Support/AgentIDE/Avatars`;
 a failed fetch is silent. The performance log
 (`<workspace>/tmp/agentide/performance.log`, off by default, on with
 `script/performance-log on`) records every process, `gh` call and cache
-hit or miss; tests point it into the scratch directory.
+hit or miss; tests point it into the scratch directory. While it is on, every
+message the Messages pane shows is also appended to `messages.log`
+beside it: the pane does not survive a relaunch, and a fault worth
+relaunching for is exactly what needs reading afterwards. One such
+fault is a terminal pane that draws nothing: a control pane with no
+frame five seconds after attaching, its client still running, is
+reported there and discarded and attached afresh once by itself, and
+Reattach in the pane's menu does the same by hand.
 
 ## Security model
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -471,7 +471,12 @@ page resumes any past conversation into a fresh worktree.
   `OfflineError`, which `GitHubOutage` reads as an outage, so it is
   pooled rather than repeated. `ServiceStatus`
   keeps that apart from GitHub itself being down, and reports nothing
-  at all while the machine is off the network.
+  at all while the machine is off the network. Any other read failure
+  (a branch's pull requests, a conversation, the review pane's diff)
+  is held until the same read fails again on its next poll or reload,
+  then reported once naming both; a success in between makes the
+  first not news. A conversation that fell back to REST is a recovery
+  that worked, and goes only to the messages log.
   Notifications fire for a finished turn and for input
   needed, each with its own toggle and chime (any audio file, played
   through `AudioServicesPlayAlertSound` so alert volume and the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -885,9 +885,12 @@ selects the worktree holding it, and `agentide new` starts a session.
   and the menu bar's Rebase with it, restacks the whole stack and
   pushes the branches the remote already has, since GitHub reads a
   pull request whose parent moved as no stack at all; the button
-  itself reads Rebase and push (or Sign and push) whenever a branch
+  itself reads Rebase and Push (or Sign and Push) whenever a branch
   is on the remote, its help says why, the note names what was
-  pushed, and Push then reads Pushed.
+  pushed, and Push then reads Pushed. While that button is live and
+  no branch is still unpublished, Push is not shown at all: two
+  buttons for one job, and Push pressed first pushed branches about
+  to be moved.
   Only one branch action runs at a time: while one does, Rebase and
   Push both dim, since a push pressed mid-rebase failed. Merge on any
   layer, the bottom included, is the stack's merge of that layer and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -884,8 +884,10 @@ selects the worktree holding it, and `agentide new` starts a session.
 - **A stack moves as one.** Rebase on any layer, the bottom included
   and the menu bar's Rebase with it, restacks the whole stack and
   pushes the branches the remote already has, since GitHub reads a
-  pull request whose parent moved as no stack at all; its help says
-  so, the note names what was pushed, and Push then reads Pushed.
+  pull request whose parent moved as no stack at all; the button
+  itself reads Rebase and push (or Sign and push) whenever a branch
+  is on the remote, its help says why, the note names what was
+  pushed, and Push then reads Pushed.
   Only one branch action runs at a time: while one does, Rebase and
   Push both dim, since a push pressed mid-rebase failed. Merge on any
   layer, the bottom included, is the stack's merge of that layer and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -475,8 +475,11 @@ page resumes any past conversation into a fresh worktree.
   (a branch's pull requests, a conversation, the review pane's diff)
   is held until the same read fails again on its next poll or reload,
   then reported once naming both; a success in between makes the
-  first not news. A conversation that fell back to REST is a recovery
-  that worked, and goes only to the messages log.
+  first not news, and one nobody reads again within a minute and a
+  half is reported as it stands, saying so. Resuming a session is
+  tried twice the same way (`ErrorLog.attemptingTwice`). A
+  conversation that fell back to REST is a recovery that worked, and
+  goes only to the messages log.
   Notifications fire for a finished turn and for input
   needed, each with its own toggle and chime (any audio file, played
   through `AudioServicesPlayAlertSound` so alert volume and the

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -144,7 +144,9 @@ extension RootView {
             return
         }
 
-        do {
+        // Tried twice before a failure is reported: a launch that
+        // fails once mostly launches the second time.
+        _ = await ErrorLog.shared.attemptingTwice("Resuming " + item.worktree.branch) {
             try await PerformanceLog.time(.process, "resume: launch", context: context) {
                 if let past = item.pastSessions.first {
                     let name = try await dependencies.service.resumePast(past, worktree: item.worktree)
@@ -155,8 +157,6 @@ extension RootView {
                     try await dependencies.service.resumeWorktree(item.worktree)
                 }
             }
-        } catch {
-            dependencies.dashboard.report(error.localizedDescription)
         }
         await PerformanceLog.time(.process, "resume: list until running", context: context) {
             await sessionStarted(in: item.worktree.path)

--- a/Sources/AgentIDEData/SessionService+Stack.swift
+++ b/Sources/AgentIDEData/SessionService+Stack.swift
@@ -271,7 +271,7 @@ public extension SessionService {
     /// request's base is on the remote before the branch that points
     /// at it. Each push carries the lease and the includes check the
     /// single-branch push does.
-    func pushStack(worktree: Worktree, publishedOnly: Bool = false) async throws -> [String] {
+    func pushStack(worktree: Worktree) async throws -> [String] {
         let stack = await stack(for: worktree)
         var pushed = [String]()
         for branch in stack.branches {
@@ -279,16 +279,6 @@ public extension SessionService {
             // to that fork, and pushing it to origin would open a
             // branch in the repository the pull request is against.
             let remote = await forkRemote(worktreePath: worktree.path, branch: branch)?.remote ?? "origin"
-            // A rebase moves what is already on the remote out from
-            // under GitHub, which then reads the stack as broken;
-            // putting it back is not the moment to publish a branch
-            // nobody has pushed yet.
-            if publishedOnly,
-               await git.refExists(worktreePath: worktree.path, ref: remote + "/" + branch) == false
-            {
-                continue
-            }
-
             // What the single-branch push refuses, this refuses:
             // unsigned commits are turned away by the hook, and the
             // stack must not be left half pushed to learn that;

--- a/Sources/AgentIDEDomain/PerformanceLog.swift
+++ b/Sources/AgentIDEDomain/PerformanceLog.swift
@@ -81,6 +81,11 @@ public enum PerformanceLog {
         directory + "/performance.log"
     }
 
+    /// The messages pane's own file, beside the performance log.
+    public static var messagesFile: String {
+        directory + "/messages.log"
+    }
+
     /// Creates or removes the marker file, the same switch
     /// `script/performance-log` flips, and forgets the cached
     /// answer so the change takes effect now rather than in a few
@@ -136,6 +141,25 @@ public enum PerformanceLog {
             sweepIfDue()
             trimIfHuge()
             append(line)
+        }
+    }
+
+    /// Keeps every message the messages pane shows, beside the
+    /// performance log and under its switch: the pane does not
+    /// survive a relaunch, and a fault worth relaunching for is
+    /// exactly what needs reading afterwards. One line a message,
+    /// newlines folded, the oldest half dropped once the file is
+    /// as large as the performance log is allowed to be.
+    public static func recordMessage(_ text: String, isError: Bool, enabled: Bool = isEnabled) {
+        guard enabled else {
+            return
+        }
+
+        let line = Date().formatted(Self.stampStyle) + "\t" + (isError ? "error" : "note") + "\t"
+            + text.replacing("\n", with: " \u{23CE} ") + "\n"
+        queue.async {
+            trimIfHuge(at: messagesFile)
+            append(line, to: messagesFile)
         }
     }
 
@@ -229,21 +253,21 @@ public enum PerformanceLog {
     /// Drops the oldest half of the file once it passes the cap.
     /// The size is one stat; reading the file only happens on the
     /// rare write that finds it over.
-    private static func trimIfHuge() {
-        let attributes = try? FileManager.default.attributesOfItem(atPath: file)
+    private static func trimIfHuge(at path: String = file) {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: path)
         guard let size = attributes?[.size] as? Int, size > sizeCap,
-              let text = try? String(contentsOfFile: file, encoding: .utf8)
+              let text = try? String(contentsOfFile: path, encoding: .utf8)
         else {
             return
         }
 
-        try? newest(of: text, within: sizeFloor).write(toFile: file, atomically: true, encoding: .utf8)
+        try? newest(of: text, within: sizeFloor).write(toFile: path, atomically: true, encoding: .utf8)
     }
 
-    private static func append(_ line: String) {
+    private static func append(_ line: String, to path: String = file) {
         try? FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
-        guard let handle = FileHandle(forWritingAtPath: file) else {
-            try? line.write(toFile: file, atomically: true, encoding: .utf8)
+        guard let handle = FileHandle(forWritingAtPath: path) else {
+            try? line.write(toFile: path, atomically: true, encoding: .utf8)
             return
         }
 

--- a/Sources/DashboardFeature/DashboardModel+PullRequests.swift
+++ b/Sources/DashboardFeature/DashboardModel+PullRequests.swift
@@ -148,7 +148,7 @@ extension DashboardModel {
                         branch: item.worktree.branch,
                     )
                     await cleanUpIfMerged(item, previous: previous, fresh: summaries)
-                    ServiceStatus.shared.recordSuccess()
+                    ServiceStatus.shared.recordSuccess(doing: "Pull requests for " + group.repository.name)
                 } catch {
                     ServiceStatus.shared.record(
                         failure: error,

--- a/Sources/PRFeature/BranchOutcome.swift
+++ b/Sources/PRFeature/BranchOutcome.swift
@@ -35,32 +35,32 @@ extension PullRequestsModel {
             return nil
         }
 
-        return switch finished.outcome {
-        case .rebased:
-            "Rebased"
-
-        case .signed:
-            "Signed"
-
-        case .pushed:
-            nil
+        if finished.outcomes.contains(.rebased) {
+            return "Rebased"
         }
+
+        return finished.outcomes.contains(.signed) ? "Signed" : nil
     }
 
-    /// The same for the push button.
+    /// The same for the push button; a stack's rebase pushes back
+    /// the branches the remote already had, and says so here.
     var pushDoneTitle: String? {
-        guard let finished, finished.branch == actedBranch, finished.outcome == .pushed else {
+        guard let finished, finished.branch == actedBranch, finished.outcomes.contains(.pushed) else {
             return nil
         }
 
         return "Pushed"
     }
 
-    /// Records what an action finished, for the button that did it.
+    /// Records what an action finished, for the buttons that did it.
     /// The line in the middle of the bar is for what went wrong, so
     /// a success clears whatever refusal is still standing there.
-    func recordFinished(_ outcome: BranchOutcome, branch: String) {
-        finished = (outcome, branch)
+    func recordFinished(_ outcomes: Set<BranchOutcome>, branch: String) {
+        finished = (outcomes, branch)
         status = nil
+    }
+
+    func recordFinished(_ outcome: BranchOutcome, branch: String) {
+        recordFinished([outcome], branch: branch)
     }
 }

--- a/Sources/PRFeature/PullRequestConversationView.swift
+++ b/Sources/PRFeature/PullRequestConversationView.swift
@@ -235,6 +235,12 @@ struct PullRequestConversationView: View {
         PullRequestStore(github: github, store: store)
     }
 
+    /// What this read is, for holding its failures apart from every
+    /// other repository's #n.
+    private var readingWhat: String {
+        "Conversation of #" + String(number) + " in " + URL(fileURLWithPath: repositoryPath).lastPathComponent
+    }
+
     @ViewBuilder private var content: some View {
         if description.isEmpty == false {
             MarkdownText(description)
@@ -319,13 +325,19 @@ struct PullRequestConversationView: View {
             }
 
             if let failure = answer.graphQLFailure {
-                ErrorLog.shared.report("Conversations fell back to REST (no resolve buttons): " + failure)
+                PerformanceLog.recordMessage(
+                    "Conversations fell back to REST (no resolve buttons): " + failure,
+                    isError: false,
+                )
             }
             description = answer.body
             events = answer.events
             threads = answer.threads
+            ServiceStatus.shared.recordSuccess(doing: readingWhat)
         } catch {
-            ErrorLog.shared.report(error.localizedDescription)
+            // The painted cache stays, and the next refresh is the
+            // recovery: only a read that fails again is news.
+            ServiceStatus.shared.record(failure: error, doing: readingWhat)
         }
     }
 

--- a/Sources/PRFeature/PullRequestFooterView+Stack.swift
+++ b/Sources/PRFeature/PullRequestFooterView+Stack.swift
@@ -29,13 +29,13 @@ extension PullRequestFooterView {
     private var restackButton: some View {
         BusyButton(
             actionTitle(
-                stackSignsOnly ? "Sign" : "Rebase",
+                (stackSignsOnly ? "Sign" : "Rebase") + (stackPushesToo ? " and push" : ""),
                 arrow: Self.downArrow,
                 count: stackSignsOnly ? "" : rebaseCount,
                 active: model.canRestack,
                 done: model.rebaseDoneTitle,
             ),
-            busy: stackSignsOnly ? "Signing" : "Rebasing",
+            busy: (stackSignsOnly ? "Signing" : "Rebasing") + (stackPushesToo ? " and pushing" : ""),
             disabled: model.canRestack == false,
         ) {
             if await model.restack() == false {
@@ -57,6 +57,13 @@ extension PullRequestFooterView {
     /// on the one below it and a tip is unsigned.
     private var stackSignsOnly: Bool {
         model.stacking.needsRestack == false
+    }
+
+    /// Whether the stack's rebase would push as well: any branch the
+    /// remote already has goes back up after it moves, and the
+    /// button says so rather than leaving the push to the help.
+    private var stackPushesToo: Bool {
+        model.stacking.stack.branches.contains { model.stacking.unpushedBranches.contains($0) == false }
     }
 
     private var pushStackButton: some View {

--- a/Sources/PRFeature/PullRequestFooterView+Stack.swift
+++ b/Sources/PRFeature/PullRequestFooterView+Stack.swift
@@ -45,8 +45,9 @@ extension PullRequestFooterView {
         .hoverHelp(
             model.canRestack
                 ? "Fetch, then rebase every branch onto the one below it, signing every commit it "
-                + "replays and leaving alone any branch already in place and signed; a conflict "
-                + "aborts and reports to Messages"
+                + "replays and leaving alone any branch already in place and signed, then push back "
+                + "every branch the remote already has, since GitHub reads a moved stack as no stack "
+                + "until then; a conflict aborts and reports to Messages"
                 : "Every branch is already on the one below it, with its tip signed",
             shortcut: "⌥⌘R",
         )

--- a/Sources/PRFeature/PullRequestFooterView+Stack.swift
+++ b/Sources/PRFeature/PullRequestFooterView+Stack.swift
@@ -15,7 +15,12 @@ extension PullRequestFooterView {
         } else {
             rebaseButton
         }
-        if model.isStackedEntry {
+        // No Push beside a Rebase and Push that would push everything
+        // there is to push: two buttons for one job, and the second
+        // pressed first pushed branches about to be moved.
+        if restackPushesEverything {
+            EmptyView()
+        } else if model.isStackedEntry {
             pushStackButton
         } else {
             pushButton
@@ -29,13 +34,13 @@ extension PullRequestFooterView {
     private var restackButton: some View {
         BusyButton(
             actionTitle(
-                (stackSignsOnly ? "Sign" : "Rebase") + (stackPushesToo ? " and push" : ""),
+                (stackSignsOnly ? "Sign" : "Rebase") + (stackPushesToo ? " and Push" : ""),
                 arrow: Self.downArrow,
                 count: stackSignsOnly ? "" : rebaseCount,
                 active: model.canRestack,
                 done: model.rebaseDoneTitle,
             ),
-            busy: (stackSignsOnly ? "Signing" : "Rebasing") + (stackPushesToo ? " and pushing" : ""),
+            busy: (stackSignsOnly ? "Signing" : "Rebasing") + (stackPushesToo ? " and Pushing" : ""),
             disabled: model.canRestack == false,
         ) {
             if await model.restack() == false {
@@ -64,6 +69,12 @@ extension PullRequestFooterView {
     /// button says so rather than leaving the push to the help.
     private var stackPushesToo: Bool {
         model.stacking.stack.branches.contains { model.stacking.unpushedBranches.contains($0) == false }
+    }
+
+    /// Whether Rebase and Push would leave nothing for Push to do:
+    /// it is live, it pushes, and no branch is still unpublished.
+    private var restackPushesEverything: Bool {
+        model.isInStack && model.canRestack && stackPushesToo && model.stacking.unpushedBranches.isEmpty
     }
 
     private var pushStackButton: some View {

--- a/Sources/PRFeature/PullRequestFooterView+Stack.swift
+++ b/Sources/PRFeature/PullRequestFooterView+Stack.swift
@@ -15,10 +15,10 @@ extension PullRequestFooterView {
         } else {
             rebaseButton
         }
-        // No Push beside a Rebase and Push that would push everything
-        // there is to push: two buttons for one job, and the second
-        // pressed first pushed branches about to be moved.
-        if restackPushesEverything {
+        // No Push beside a live Rebase and Push: two buttons for one
+        // job, and the second pressed first pushed branches about to
+        // be moved.
+        if model.isInStack, model.canRestack {
             EmptyView()
         } else if model.isStackedEntry {
             pushStackButton
@@ -33,14 +33,8 @@ extension PullRequestFooterView {
     /// past tense while dim, doing the stack's version of the work.
     private var restackButton: some View {
         BusyButton(
-            actionTitle(
-                (stackSignsOnly ? "Sign" : "Rebase") + (stackPushesToo ? " and Push" : ""),
-                arrow: Self.downArrow,
-                count: stackSignsOnly ? "" : rebaseCount,
-                active: model.canRestack,
-                done: model.rebaseDoneTitle,
-            ),
-            busy: (stackSignsOnly ? "Signing" : "Rebasing") + (stackPushesToo ? " and Pushing" : ""),
+            restackTitle,
+            busy: (stackSignsOnly ? "Signing" : "Rebasing") + " and Pushing",
             disabled: model.canRestack == false,
         ) {
             if await model.restack() == false {
@@ -50,9 +44,9 @@ extension PullRequestFooterView {
         .hoverHelp(
             model.canRestack
                 ? "Fetch, then rebase every branch onto the one below it, signing every commit it "
-                + "replays and leaving alone any branch already in place and signed, then push back "
-                + "every branch the remote already has, since GitHub reads a moved stack as no stack "
-                + "until then; a conflict aborts and reports to Messages"
+                + "replays and leaving alone any branch already in place and signed, then push the whole "
+                + "stack bottom first, publishing any branch nobody has pushed yet; a conflict aborts and "
+                + "reports to Messages"
                 : "Every branch is already on the one below it, with its tip signed",
             shortcut: "⌥⌘R",
         )
@@ -64,17 +58,21 @@ extension PullRequestFooterView {
         model.stacking.needsRestack == false
     }
 
-    /// Whether the stack's rebase would push as well: any branch the
-    /// remote already has goes back up after it moves, and the
-    /// button says so rather than leaving the push to the help.
-    private var stackPushesToo: Bool {
-        model.stacking.stack.branches.contains { model.stacking.unpushedBranches.contains($0) == false }
-    }
+    /// The rebase's title with the push it ends in: the branch pair's
+    /// shape for each half, what comes down and what goes up.
+    private var restackTitle: String {
+        let title = actionTitle(
+            stackSignsOnly ? "Sign" : "Rebase",
+            arrow: Self.downArrow,
+            count: stackSignsOnly ? "" : rebaseCount,
+            active: model.canRestack,
+            done: model.rebaseDoneTitle,
+        )
+        guard model.canRestack else {
+            return title
+        }
 
-    /// Whether Rebase and Push would leave nothing for Push to do:
-    /// it is live, it pushes, and no branch is still unpublished.
-    private var restackPushesEverything: Bool {
-        model.isInStack && model.canRestack && stackPushesToo && model.stacking.unpushedBranches.isEmpty
+        return title + " and Push" + (stackPushCount.isEmpty ? "" : " " + Self.upArrow + stackPushCount)
     }
 
     private var pushStackButton: some View {

--- a/Sources/PRFeature/PullRequestsModel+Branch.swift
+++ b/Sources/PRFeature/PullRequestsModel+Branch.swift
@@ -98,7 +98,7 @@ extension PullRequestsModel {
     /// otherwise never be pushed, since Push waits for the signature
     /// only this can give it.
     var canRebase: Bool {
-        branchItem != nil && rebaseNeed != SessionService.RebaseNeed.nothing
+        branchItem != nil && isBranchActionRunning == false && rebaseNeed != SessionService.RebaseNeed.nothing
     }
 
     func rebaseSigned() async -> Bool {
@@ -267,8 +267,10 @@ extension PullRequestsModel {
     /// worktree's counts describe whichever branch it has checked
     /// out.
     var canPush: Bool {
-        guard branchItem != nil, isGuardedDefaultBranch == false, isPushed == false,
-              tipSignature == .signed
+        // One branch action at a time: a push pressed while a rebase
+        // still runs failed against the branch mid-move.
+        guard branchItem != nil, isBranchActionRunning == false, isGuardedDefaultBranch == false,
+              isPushed == false, tipSignature == .signed
         else {
             return false
         }

--- a/Sources/PRFeature/PullRequestsModel+Reload.swift
+++ b/Sources/PRFeature/PullRequestsModel+Reload.swift
@@ -88,7 +88,7 @@ extension PullRequestsModel {
             if let chosen {
                 select(chosen)
             }
-            ServiceStatus.shared.recordSuccess()
+            ServiceStatus.shared.recordSuccess(doing: "Pull requests for " + repository.name)
             prefetchStack()
         } catch {
             ServiceStatus.shared.record(failure: error, doing: "Pull requests for " + repository.name)

--- a/Sources/PRFeature/PullRequestsModel+Seams.swift
+++ b/Sources/PRFeature/PullRequestsModel+Seams.swift
@@ -37,6 +37,19 @@ extension PullRequestsModel {
         return await gate.acceptsDefaultPushes(repositoryPath: repository.path, branch: defaultBranch)
     }
 
+    /// A pull request's conversations. One that fell back to REST is
+    /// a recovery that worked, so it goes only to the messages log.
+    static func threads(of number: Int, gate: PullRequestStore, repository: Repository) async -> [ReviewThread] {
+        let answer = try? await gate.conversation(repositoryPath: repository.path, number: number, seededBody: nil)
+        if let failure = answer?.graphQLFailure {
+            PerformanceLog.recordMessage(
+                "Conversations fell back to REST (no resolve buttons): " + failure,
+                isError: false,
+            )
+        }
+        return answer?.threads ?? []
+    }
+
     /// Tidies up after a merge and says what it did and could not.
     static func cleanUpAfterMerge(worktree: Worktree, mergedBranch: String, service: SessionService) async {
         let report = await service.cleanUpAfterMerge(worktree: worktree, mergedBranch: mergedBranch)

--- a/Sources/PRFeature/PullRequestsModel+Stack.swift
+++ b/Sources/PRFeature/PullRequestsModel+Stack.swift
@@ -71,13 +71,13 @@ extension PullRequestsModel {
     /// second half an in-place stack with unsigned commits greyed
     /// this button while Push waited on exactly this.
     var canRestack: Bool {
-        stacking.needsRestack || stacking.unsignedBranches.isEmpty == false
+        isBranchActionRunning == false && (stacking.needsRestack || stacking.unsignedBranches.isEmpty == false)
     }
 
     /// Whether any branch of the stack has commits the remote does
     /// not carry.
     var canPushStack: Bool {
-        stacking.needsPush && stacking.unsignedBranches.isEmpty
+        isBranchActionRunning == false && stacking.needsPush && stacking.unsignedBranches.isEmpty
     }
 
     /// Why the stack's push is in its current state, said the way a

--- a/Sources/PRFeature/PullRequestsModel+Stack.swift
+++ b/Sources/PRFeature/PullRequestsModel+Stack.swift
@@ -18,9 +18,6 @@ extension PullRequestsModel {
         stacking.push = { worktree in
             try await service.pushStack(worktree: worktree)
         }
-        stacking.pushPublished = { worktree in
-            try await service.pushStack(worktree: worktree, publishedOnly: true)
-        }
         stacking.pending = { worktree in
             await service.branchesOutOfPlace(worktree: worktree).isEmpty == false
         }

--- a/Sources/PRFeature/PullRequestsModel+StackActions.swift
+++ b/Sources/PRFeature/PullRequestsModel+StackActions.swift
@@ -19,7 +19,7 @@ extension PullRequestsModel {
         // and leaves nothing to read it from.
         let onlySigns = stacking.needsRestack == false
         do {
-            let moved = try await restackUntilSigned(worktree)
+            let (moved, pushed) = try await restackUntilSigned(worktree)
             // Done means Push agrees; reporting success with the
             // stack still unsigned took a second press to notice.
             if let unsigned = stacking.unsignedBranches.first {
@@ -41,8 +41,13 @@ extension PullRequestsModel {
                 return true
             }
 
-            recordFinished(onlySigns ? .signed : .rebased, branch: actedBranch ?? worktree.branch)
-            note(verb + " " + Self.named(moved) + ".")
+            let acted = actedBranch ?? worktree.branch
+            var outcomes: Set<BranchOutcome> = [onlySigns ? .signed : .rebased]
+            if pushed.contains(acted) {
+                outcomes.insert(.pushed)
+            }
+            recordFinished(outcomes, branch: acted)
+            note(verb + " " + Self.named(moved) + (pushed.isEmpty ? "." : "; pushed " + Self.named(pushed) + "."))
             Self.requestSidebarRefresh()
             return true
         } catch {
@@ -55,32 +60,35 @@ extension PullRequestsModel {
     /// tip that reads unsigned is read again after a moment, and one
     /// that still does gets one more restack before the signing key
     /// is questioned. The branches moved, each named once.
-    private func restackUntilSigned(_ worktree: Worktree) async throws -> [String] {
-        var moved = try await restackAndPushPublished(worktree)
+    private func restackUntilSigned(_ worktree: Worktree) async throws -> (moved: [String], pushed: [String]) {
+        var (moved, pushed) = try await restackAndPushPublished(worktree)
         await readStack()
         if stacking.unsignedBranches.isEmpty == false {
             try? await Task.sleep(for: .milliseconds(Self.signatureSettleMilliseconds))
             await readStack()
         }
         if stacking.unsignedBranches.isEmpty == false {
-            for branch in try await restackAndPushPublished(worktree) where moved.contains(branch) == false {
-                moved.append(branch)
-            }
+            let again = try await restackAndPushPublished(worktree)
+            moved += again.moved.filter { moved.contains($0) == false }
+            pushed += again.pushed.filter { pushed.contains($0) == false }
             await readStack()
         }
-        return moved
+        return (moved, pushed)
     }
 
     /// One restack. Every branch it moved is behind what the remote
     /// has, and GitHub reads a stack whose parents moved as no stack
     /// at all, so the published ones go back up at once; a branch
     /// nobody has pushed stays unpushed, which Push is for.
-    private func restackAndPushPublished(_ worktree: Worktree) async throws -> [String] {
+    private func restackAndPushPublished(_ worktree: Worktree) async throws -> (moved: [String], pushed: [String]) {
         let moved = try await stacking.restack(worktree)
-        if moved.isEmpty == false {
-            try await markChecksPending(for: stacking.pushPublished(worktree))
+        guard moved.isEmpty == false else {
+            return (moved, [])
         }
-        return moved
+
+        let pushed = try await stacking.pushPublished(worktree)
+        markChecksPending(for: pushed)
+        return (moved, pushed)
     }
 
     private func readStack() async {

--- a/Sources/PRFeature/PullRequestsModel+StackActions.swift
+++ b/Sources/PRFeature/PullRequestsModel+StackActions.swift
@@ -61,14 +61,14 @@ extension PullRequestsModel {
     /// that still does gets one more restack before the signing key
     /// is questioned. The branches moved, each named once.
     private func restackUntilSigned(_ worktree: Worktree) async throws -> (moved: [String], pushed: [String]) {
-        var (moved, pushed) = try await restackAndPushPublished(worktree)
+        var (moved, pushed) = try await restackAndPush(worktree)
         await readStack()
         if stacking.unsignedBranches.isEmpty == false {
             try? await Task.sleep(for: .milliseconds(Self.signatureSettleMilliseconds))
             await readStack()
         }
         if stacking.unsignedBranches.isEmpty == false {
-            let again = try await restackAndPushPublished(worktree)
+            let again = try await restackAndPush(worktree)
             moved += again.moved.filter { moved.contains($0) == false }
             pushed += again.pushed.filter { pushed.contains($0) == false }
             await readStack()
@@ -76,17 +76,17 @@ extension PullRequestsModel {
         return (moved, pushed)
     }
 
-    /// One restack. Every branch it moved is behind what the remote
-    /// has, and GitHub reads a stack whose parents moved as no stack
-    /// at all, so the published ones go back up at once; a branch
-    /// nobody has pushed stays unpushed, which Push is for.
-    private func restackAndPushPublished(_ worktree: Worktree) async throws -> (moved: [String], pushed: [String]) {
+    /// One restack, then the whole stack pushed bottom first, a
+    /// branch nobody has pushed included: every branch that moved is
+    /// behind what the remote has, GitHub reads a stack whose parents
+    /// moved as no stack at all, and the button says and Push.
+    private func restackAndPush(_ worktree: Worktree) async throws -> (moved: [String], pushed: [String]) {
         let moved = try await stacking.restack(worktree)
         guard moved.isEmpty == false else {
             return (moved, [])
         }
 
-        let pushed = try await stacking.pushPublished(worktree)
+        let pushed = try await stacking.push(worktree)
         markChecksPending(for: pushed)
         return (moved, pushed)
     }

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -204,7 +204,7 @@ final class PullRequestsModel {
     /// What the last branch action finished here, and on which
     /// branch: its button reads it in the past tense while it stays
     /// dim, so the work says so where the click was.
-    var finished: (outcome: BranchOutcome, branch: String)?
+    var finished: (outcomes: Set<BranchOutcome>, branch: String)?
 
     /// What a signed rebase would change right now, refreshed on
     /// reload; the button dims and names its work from this.

--- a/Sources/PRFeature/PullRequestsModel.swift
+++ b/Sources/PRFeature/PullRequestsModel.swift
@@ -2,7 +2,6 @@ import AgentIDEData
 import AgentIDEDomain
 import Foundation
 import Observation
-import TerminalUI
 
 /// The pull request tab's state and actions: listing, pagination,
 /// selection enrichment, caching and the branch actions, kept out of
@@ -59,15 +58,7 @@ final class PullRequestsModel {
             await Self.acceptsDefaultPushes(gate: gate, repository: repository, defaultBranch: defaultBranch)
         }
         fetchThreads = { number in
-            let answer = try? await gate.conversation(
-                repositoryPath: repository.path,
-                number: number,
-                seededBody: nil,
-            )
-            if let failure = answer?.graphQLFailure {
-                ErrorLog.shared.report("Conversations fell back to REST (no resolve buttons): " + failure)
-            }
-            return answer?.threads ?? []
+            await Self.threads(of: number, gate: gate, repository: repository)
         }
         performCreate = { worktree, title, body, labels, isDraft in
             try await service.createPullRequest(

--- a/Sources/PRFeature/StackWork.swift
+++ b/Sources/PRFeature/StackWork.swift
@@ -41,10 +41,6 @@ struct StackWork {
 
     var restack: (Worktree) async throws -> [String] = { _ in [] }
     var push: (Worktree) async throws -> [String] = { _ in [] }
-
-    /// Pushes only the stack's branches the remote already has, for
-    /// putting a rebase back where GitHub can still read it.
-    var pushPublished: (Worktree) async throws -> [String] = { _ in [] }
     var pending: (Worktree) async -> Bool = { _ in false }
     var unpushed: (Worktree) async -> [String] = { _ in [] }
     var unsigned: (Worktree) async -> [String] = { _ in [] }

--- a/Sources/ReviewFeature/ReviewModel+Status.swift
+++ b/Sources/ReviewFeature/ReviewModel+Status.swift
@@ -25,4 +25,22 @@ extension ReviewModel {
     static let generatedFragments = [
         ".pbxproj", "Package.resolved", ".lock", "Gemfile.lock", ".xcassets",
     ]
+
+    /// What a reload's reads came to. A failure is held for the next
+    /// reload, which is the recovery a read has, unless the worktree
+    /// itself has gone: one can vanish between the poll that mounted
+    /// this pane and the reload that reads it (a branch renamed away,
+    /// cleanup after a merge), which is the workspace changing, not
+    /// a failure, and the sidebar drops the row on its own.
+    func recordReload(_ error: (any Error)?) {
+        let what = "Review of " + repositoryName
+        guard let error else {
+            ServiceStatus.shared.recordSuccess(doing: what)
+            return
+        }
+
+        if worktreeExists(worktreePath) {
+            ServiceStatus.shared.record(failure: error, doing: what)
+        }
+    }
 }

--- a/Sources/ReviewFeature/ReviewModel.swift
+++ b/Sources/ReviewFeature/ReviewModel.swift
@@ -200,15 +200,9 @@ final class ReviewModel {
                 originalMessage = commitMessage
             }
             threads = await fetchThreads()
+            recordReload(nil)
         } catch {
-            // A worktree can vanish between the poll that mounted
-            // this pane and the reload that reads it (a branch
-            // renamed away, cleanup after a merge): that is the
-            // workspace changing, not a failure, and the sidebar
-            // drops the row on its own.
-            if worktreeExists(worktreePath) {
-                report(error.localizedDescription)
-            }
+            recordReload(error)
         }
         hasLoaded = true
     }

--- a/Sources/ReviewFeature/ReviewView.swift
+++ b/Sources/ReviewFeature/ReviewView.swift
@@ -33,7 +33,10 @@ public struct ReviewView: View {
                 seededBody: nil,
             )
             if let failure = answer?.graphQLFailure {
-                ErrorLog.shared.report("Conversations fell back to REST (no resolve buttons): " + failure)
+                PerformanceLog.recordMessage(
+                    "Conversations fell back to REST (no resolve buttons): " + failure,
+                    isError: false,
+                )
             }
             return answer?.threads ?? []
         }

--- a/Sources/SessionFeature/RepositorySessionsModel.swift
+++ b/Sources/SessionFeature/RepositorySessionsModel.swift
@@ -120,15 +120,10 @@ final class RepositorySessionsModel {
 
         isResuming = true
         progress?.begin("Resuming into a fresh worktree")
-        Task {
-            do {
-                _ = try await service.resumeInNewWorktree(selected, repository: repository)
-                await onResumed()
-            } catch {
-                ErrorLog.shared.report(error.localizedDescription)
-            }
-            isResuming = false
+        let work: () async throws -> Void = { [service, repository] in
+            _ = try await service.resumeInNewWorktree(selected, repository: repository)
         }
+        Task { await resume(Self.name(of: selected), work, onResumed: onResumed) }
     }
 
     /// Resumes the selected conversation in the worktree it ran in;
@@ -141,15 +136,11 @@ final class RepositorySessionsModel {
 
         isResuming = true
         progress?.begin("Resuming here")
-        Task {
-            do {
-                _ = try await service.resumePast(selected, worktree: resumeWorktree(at: path))
-                await onResumed()
-            } catch {
-                ErrorLog.shared.report(error.localizedDescription)
-            }
-            isResuming = false
+        let worktree = resumeWorktree(at: path)
+        let work: () async throws -> Void = { [service] in
+            _ = try await service.resumePast(selected, worktree: worktree)
         }
+        Task { await resume(Self.name(of: selected), work, onResumed: onResumed) }
     }
 
     /// The worktree shape a here-resume launches into: the path's
@@ -166,4 +157,27 @@ final class RepositorySessionsModel {
     // MARK: Private
 
     private static let locationComponents = 2
+
+    /// A conversation's name for a report: its title, or that it
+    /// has none.
+    private static func name(of session: TranscriptSession) -> String {
+        if session.title.isEmpty {
+            "an untitled conversation"
+        } else {
+            session.title
+        }
+    }
+
+    /// One resume, tried twice before its failure is reported, then
+    /// what follows a success; the button stays busy throughout.
+    private func resume(
+        _ name: String,
+        _ work: () async throws -> Void,
+        onResumed: @MainActor () async -> Void,
+    ) async {
+        if await ErrorLog.shared.attemptingTwice("Resuming " + name, work) {
+            await onResumed()
+        }
+        isResuming = false
+    }
 }

--- a/Sources/TerminalUI/ErrorLog.swift
+++ b/Sources/TerminalUI/ErrorLog.swift
@@ -88,6 +88,28 @@ public final class ErrorLog {
         )
     }
 
+    /// Runs work that can simply be tried again, once more before
+    /// its failure is reported: the second try is the recovery, so
+    /// the first failure goes only to the messages log, and a second
+    /// reports both. Whether either try succeeded.
+    public func attemptingTwice(_ what: String, _ work: () async throws -> Void) async -> Bool {
+        let first: String
+        do {
+            try await work()
+            return true
+        } catch {
+            first = error.localizedDescription
+        }
+        PerformanceLog.recordMessage(what + ": " + first + " (trying once more)", isError: true)
+        do {
+            try await work()
+            return true
+        } catch {
+            report(what + ": " + first + "; then again: " + error.localizedDescription)
+            return false
+        }
+    }
+
     /// Empties the log; the messages tab stays either way.
     public func clear() {
         entries = []

--- a/Sources/TerminalUI/ErrorLog.swift
+++ b/Sources/TerminalUI/ErrorLog.swift
@@ -1,3 +1,4 @@
+import AgentIDEDomain
 import Foundation
 import Observation
 
@@ -115,6 +116,7 @@ public final class ErrorLog {
     }
 
     private func append(_ message: String, isError: Bool, repository: String? = nil) {
+        PerformanceLog.recordMessage(message, isError: isError)
         nextID += 1
         entries.append(Entry(
             id: nextID,

--- a/Sources/TerminalUI/PaneTerminalView.swift
+++ b/Sources/TerminalUI/PaneTerminalView.swift
@@ -43,6 +43,10 @@ final class PaneTerminalView: LocalProcessTerminalView {
     /// menu item.
     var onCopyAllOutput: (() async -> String?)?
 
+    /// Discards the herdr client and attaches afresh, for a pane
+    /// that stopped drawing; nil on a local shell, which has none.
+    var onReattach: (() -> Void)?
+
     /// Keeps a selection while output arrives. SwiftTerm drops the
     /// selection on every line feed whenever mouse reporting is on,
     /// which it always is here so that an agent's own scrolling and
@@ -90,6 +94,12 @@ final class PaneTerminalView: LocalProcessTerminalView {
             let allItem = NSMenuItem(title: "Copy All Output", action: #selector(copyAllOutput(_:)), keyEquivalent: "")
             allItem.target = self
             menu.addItem(allItem)
+        }
+        if onReattach != nil {
+            menu.addItem(.separator())
+            let reattachItem = NSMenuItem(title: "Reattach", action: #selector(reattach(_:)), keyEquivalent: "")
+            reattachItem.target = self
+            menu.addItem(reattachItem)
         }
         return menu
     }
@@ -299,6 +309,11 @@ final class PaneTerminalView: LocalProcessTerminalView {
 
         lastWheel = identity
         return true
+    }
+
+    @objc
+    private func reattach(_: Any?) {
+        onReattach?()
     }
 
     /// See `mouseDragged`: the end column SwiftTerm chose, moved on

--- a/Sources/TerminalUI/PaneTerminalView.swift
+++ b/Sources/TerminalUI/PaneTerminalView.swift
@@ -69,8 +69,22 @@ final class PaneTerminalView: LocalProcessTerminalView {
     /// word dropped its last letter unless it carried on into the
     /// next one. A word or line drag (`clickCount` above one) picks
     /// its own boundaries and is left alone.
+    override func mouseDown(with event: NSEvent) {
+        pressPoint = convert(event.locationInWindow, from: nil)
+        super.mouseDown(with: event)
+    }
+
+    /// The first drag is where SwiftTerm anchors the selection, at
+    /// the cell the pointer went down in; the start moves to the
+    /// boundary nearest the press the way the end moves to the
+    /// boundary nearest the pointer, so a drag begun past the middle
+    /// of a character does not take that character with it.
     override func mouseDragged(with event: NSEvent) {
+        let wasActive = selection?.active ?? false
         super.mouseDragged(with: event)
+        if wasActive == false {
+            roundSelectionStart()
+        }
         roundSelectionEnd(at: event)
     }
 
@@ -272,6 +286,9 @@ final class PaneTerminalView: LocalProcessTerminalView {
     /// seeing the same event does nothing with it.
     private static var lastWheel: (timestamp: TimeInterval, window: Int)?
 
+    /// Where the mouse went down, for the selection's start.
+    private var pressPoint: CGPoint?
+
     /// The wheel's fractional line carry between events.
     private var wheelRemainder: CGFloat = 0
 
@@ -314,6 +331,25 @@ final class PaneTerminalView: LocalProcessTerminalView {
     @objc
     private func reattach(_: Any?) {
         onReattach?()
+    }
+
+    /// See `mouseDragged`: the start column SwiftTerm chose, moved
+    /// on to the boundary nearest the press. The soft start resets
+    /// the end with it, and the end rounding that follows puts the
+    /// end back under the pointer.
+    private func roundSelectionStart() {
+        guard let pressPoint, let selection, selection.active,
+              let column = TerminalSelection.endColumn(
+                  across: pressPoint.x,
+                  cellWidth: Self.cellSize(of: self).width,
+                  columns: getTerminal().cols,
+              ), column != selection.start.col
+        else {
+            return
+        }
+
+        selection.setSoftStart(bufferPosition: Position(col: column, row: selection.start.row))
+        selection.startSelection()
     }
 
     /// See `mouseDragged`: the end column SwiftTerm chose, moved on

--- a/Sources/TerminalUI/ServiceStatus.swift
+++ b/Sources/TerminalUI/ServiceStatus.swift
@@ -1,4 +1,5 @@
 import AgentIDEData
+import AgentIDEDomain
 import Foundation
 import Observation
 
@@ -43,9 +44,11 @@ public final class ServiceStatus {
     public private(set) var hasNetwork = true
 
     /// Records a failure. An outage is announced once and then kept
-    /// quiet; anything else is a real failure and always reported,
-    /// since a broken request the user could fix must not be
-    /// swallowed by an outage's silence.
+    /// quiet. Anything else is held until the same read fails again
+    /// on the next poll, which is the recovery every read has, and
+    /// then reported once naming both; a success in between makes
+    /// the first not news. Held or reported, it is never swallowed
+    /// by an outage's silence.
     public func record(failure error: any Error, doing what: String) {
         // A machine with no route explains every failure at once and
         // has said so already: repeating it per branch per poll is
@@ -54,7 +57,17 @@ public final class ServiceStatus {
             return
         }
         guard GitHubOutage.isLikely(error) else {
-            ErrorLog.shared.report(what + ": " + error.localizedDescription)
+            let description = error.localizedDescription
+            guard let earlier = held.removeValue(forKey: what) else {
+                held[what] = description
+                PerformanceLog.recordMessage(
+                    what + ": " + description + " (held while the next read is tried)",
+                    isError: true,
+                )
+                return
+            }
+
+            ErrorLog.shared.report(what + ": " + earlier + "; then again: " + description)
             return
         }
         guard isUnavailable == false else {
@@ -96,8 +109,10 @@ public final class ServiceStatus {
         ErrorLog.shared.note("The network is back" + waited + "; pull request state is refreshing.")
     }
 
-    /// Records a success, which ends an outage and says so once.
-    public func recordSuccess() {
+    /// Records a success, which makes a failure held for what was
+    /// done not news, and ends an outage, saying so once.
+    public func recordSuccess(doing what: String) {
+        held.removeValue(forKey: what)
         guard isUnavailable else {
             return
         }
@@ -112,6 +127,10 @@ public final class ServiceStatus {
     // MARK: Private
 
     private static let secondsPerMinute = 60.0
+
+    /// Failures held while the next read has its go, by what was
+    /// being done.
+    private var held: [String: String] = [:]
 
     /// A rough human duration; the exact seconds of an outage are
     /// nobody's business.

--- a/Sources/TerminalUI/ServiceStatus.swift
+++ b/Sources/TerminalUI/ServiceStatus.swift
@@ -30,6 +30,11 @@ public final class ServiceStatus {
     /// The one status every GitHub caller reports through.
     public static let shared: ServiceStatus = .init()
 
+    /// How long a held failure waits for the read to run again
+    /// before it is reported anyway: longer than any poll tier but
+    /// short enough that a read nobody repeats is not lost.
+    public static let holdSeconds = 90
+
     /// Whether GitHub last failed in a way that reads as an outage;
     /// callers poll far less while this holds.
     public private(set) var isUnavailable = false
@@ -49,7 +54,11 @@ public final class ServiceStatus {
     /// then reported once naming both; a success in between makes
     /// the first not news. Held or reported, it is never swallowed
     /// by an outage's silence.
-    public func record(failure error: any Error, doing what: String) {
+    public func record(
+        failure error: any Error,
+        doing what: String,
+        holdingFor hold: Duration = .seconds(holdSeconds),
+    ) {
         // A machine with no route explains every failure at once and
         // has said so already: repeating it per branch per poll is
         // what buried the pane.
@@ -58,12 +67,22 @@ public final class ServiceStatus {
         }
         guard GitHubOutage.isLikely(error) else {
             let description = error.localizedDescription
-            guard let earlier = held.removeValue(forKey: what) else {
+            guard let earlier = release(what) else {
                 held[what] = description
                 PerformanceLog.recordMessage(
                     what + ": " + description + " (held while the next read is tried)",
                     isError: true,
                 )
+                // A read that never runs again would never be news:
+                // one nobody has repeated by then is reported as it
+                // stands.
+                deadlines[what] = Task { [weak self] in
+                    guard await (try? Task.sleep(for: hold)) != nil, let unconfirmed = self?.release(what) else {
+                        return
+                    }
+
+                    ErrorLog.shared.report(what + ": " + unconfirmed + " (not read again since)")
+                }
                 return
             }
 
@@ -112,7 +131,7 @@ public final class ServiceStatus {
     /// Records a success, which makes a failure held for what was
     /// done not news, and ends an outage, saying so once.
     public func recordSuccess(doing what: String) {
-        held.removeValue(forKey: what)
+        _ = release(what)
         guard isUnavailable else {
             return
         }
@@ -129,8 +148,9 @@ public final class ServiceStatus {
     private static let secondsPerMinute = 60.0
 
     /// Failures held while the next read has its go, by what was
-    /// being done.
+    /// being done, and the deadline each is reported at regardless.
     private var held: [String: String] = [:]
+    private var deadlines: [String: Task<Void, Never>] = [:]
 
     /// A rough human duration; the exact seconds of an outage are
     /// nobody's business.
@@ -146,5 +166,11 @@ public final class ServiceStatus {
         default:
             return String(minutes) + " minutes"
         }
+    }
+
+    /// Takes a held failure out, deadline and all.
+    private func release(_ what: String) -> String? {
+        deadlines.removeValue(forKey: what)?.cancel()
+        return held.removeValue(forKey: what)
     }
 }

--- a/Sources/TerminalUI/TerminalPaneView.swift
+++ b/Sources/TerminalUI/TerminalPaneView.swift
@@ -148,6 +148,11 @@ struct TerminalRepresentable: NSViewRepresentable {
             view.hideScroller()
             view.dropLocalScrollback()
             view.bracketsPastes = true
+            view.onReattach = { [weak coordinator = context.coordinator, weak view] in
+                if let view {
+                    coordinator?.reattach(in: view)
+                }
+            }
         } else {
             view.processDelegate = context.coordinator
         }

--- a/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
+++ b/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
@@ -42,6 +42,14 @@ extension TerminalRepresentable {
         var framesSeen = 0
         var frameDeadline: Task<Void, Never>?
 
+        /// The size herdr was last told, so the same size is never
+        /// sent twice in a row: the attach sends the view's size and
+        /// the terminal's own size callback fires straight after with
+        /// the same numbers, and herdr 0.8.2 dropped the repaint that
+        /// should follow such a transient resize, leaving the pane
+        /// blank with a cursor.
+        var sentSize: (columns: Int, rows: Int)?
+
         /// How many times the client was discarded and attached
         /// afresh; the blank-pane deadline does it once by itself.
         var reattachments = 0
@@ -178,7 +186,7 @@ extension TerminalRepresentable {
                 return
             }
 
-            channel?.send(HerdrTerminal.resizeCommand(columns: newCols, rows: newRows))
+            sendResize(columns: newCols, rows: newRows)
         }
 
         /// Bytes for the pane. A bracketed paste arrives as three
@@ -286,6 +294,7 @@ extension TerminalRepresentable {
             }
             channel = nil
             framesSeen = 0
+            sentSize = nil
             exitReason = nil
             started = false
             view.feed(text: "\u{1B}c")

--- a/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
+++ b/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
@@ -54,6 +54,12 @@ extension TerminalRepresentable {
         /// afresh; the blank-pane deadline does it once by itself.
         var reattachments = 0
 
+        /// A client's failure kept back while recovery has its go:
+        /// the next attach drawing a frame discards it, the next
+        /// failure reports both. Nothing reaches the messages pane
+        /// until recovery has been tried and failed.
+        var heldFailure: String?
+
         /// The Option-drag selector, owned by its event monitor.
         weak var blockSelector: BlockSelector?
 

--- a/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
+++ b/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
@@ -28,6 +28,8 @@ extension TerminalRepresentable {
         /// afterwards, so a slow attach recovers by itself.
         static let frameTimeoutSeconds = 5
 
+        static let automaticReattachments = 1
+
         /// The last applied appearance; re-applying identical colours
         /// on every SwiftUI update forces needless full redraws.
         var appliedScheme: ColorScheme?
@@ -39,6 +41,10 @@ extension TerminalRepresentable {
         var channel: HerdrTerminalChannel?
         var framesSeen = 0
         var frameDeadline: Task<Void, Never>?
+
+        /// How many times the client was discarded and attached
+        /// afresh; the blank-pane deadline does it once by itself.
+        var reattachments = 0
 
         /// The Option-drag selector, owned by its event monitor.
         weak var blockSelector: BlockSelector?
@@ -115,6 +121,21 @@ extension TerminalRepresentable {
             } else {
                 observeFrame(transport, in: view)
             }
+        }
+
+        /// Discards the client and attaches afresh: by hand from the
+        /// pane's menu, and once by itself when no frame arrived
+        /// within the deadline while the client was still running,
+        /// which is a pane that would otherwise sit blank with a
+        /// cursor until the app was relaunched.
+        func reattach(in view: PaneTerminalView) {
+            guard let transport = startedTransport, tornDown == false else {
+                return
+            }
+
+            reattachments += 1
+            discardClient(of: view)
+            startWhenSized(transport, in: view)
         }
 
         /// Cmd-K on the shell: a full terminal reset wipes the screen

--- a/Sources/TerminalUI/TerminalRepresentable.Coordinator+Conversation.swift
+++ b/Sources/TerminalUI/TerminalRepresentable.Coordinator+Conversation.swift
@@ -14,8 +14,18 @@ extension TerminalRepresentable.Coordinator {
     /// there is nothing to seed and pastes bracket themselves.
     func requestInitialState(of view: PaneTerminalView) {
         let terminal = view.getTerminal()
-        channel?.send(HerdrTerminal.resizeCommand(columns: terminal.cols, rows: terminal.rows))
+        sendResize(columns: terminal.cols, rows: terminal.rows)
         armFrameDeadline()
+    }
+
+    /// Tells herdr the pane's size, once per size: see `sentSize`.
+    func sendResize(columns: Int, rows: Int) {
+        guard sentSize?.columns != columns || sentSize?.rows != rows else {
+            return
+        }
+
+        sentSize = (columns, rows)
+        channel?.send(HerdrTerminal.resizeCommand(columns: columns, rows: rows))
     }
 
     /// A stream that never renders must not hold the pane blank

--- a/Sources/TerminalUI/TerminalRepresentable.Coordinator+Conversation.swift
+++ b/Sources/TerminalUI/TerminalRepresentable.Coordinator+Conversation.swift
@@ -96,21 +96,29 @@ extension TerminalRepresentable.Coordinator {
     }
 
     /// The deadline fired before any frame. A slow sudo or sandbox
-    /// launch renders late rather than never, so this only reports;
-    /// the report carries enough state to name the failing layer.
+    /// launch renders late rather than never, so this reports, with
+    /// enough state to name the failing layer, and a client that is
+    /// running yet drew nothing is discarded and attached afresh,
+    /// once: every pane once went blank at the same time with its
+    /// sessions running on, and only a relaunch brought them back.
     private func reportIfBlank() {
         guard framesSeen == 0, tornDown == false else {
             return
         }
 
         let ended = channel
-        Task {
+        Task { [weak self] in
             let running = await ended?.isRunning() ?? false
             let chain = await ended?.launchChainSnapshot() ?? "gone"
+            let reattaches = running && (self?.reattachments ?? 0) < Self.automaticReattachments
             ErrorLog.shared.report(
                 "Terminal: no frames after \(Self.frameTimeoutSeconds)s"
-                    + " (client running: \(running); chain: \(chain))",
+                    + " (client running: \(running); chain: \(chain))"
+                    + (reattaches ? "; reattaching" : ""),
             )
+            if reattaches, let self, let view {
+                reattach(in: view)
+            }
         }
     }
 }

--- a/Sources/TerminalUI/TerminalRepresentable.Coordinator+Conversation.swift
+++ b/Sources/TerminalUI/TerminalRepresentable.Coordinator+Conversation.swift
@@ -34,7 +34,12 @@ extension TerminalRepresentable.Coordinator {
     /// retry: a slow sudo or sandbox launch recovers by itself.
     func armFrameDeadline() {
         frameDeadline = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(Self.frameTimeoutSeconds))
+            // A deadline cut short was cancelled for a fresh client,
+            // whose own deadline is the one that counts.
+            guard await (try? Task.sleep(for: .seconds(Self.frameTimeoutSeconds))) != nil else {
+                return
+            }
+
             self?.reportIfBlank()
         }
     }
@@ -49,6 +54,9 @@ extension TerminalRepresentable.Coordinator {
         switch event {
         case let .frame(bytes):
             framesSeen += 1
+            // The first frame is recovery succeeding: whatever the
+            // attempt before it did wrong is not news.
+            heldFailure = nil
             view?.feed(byteArray: bytes[...])
             blockSelector?.follow()
 
@@ -83,8 +91,7 @@ extension TerminalRepresentable.Coordinator {
             let expected = Self.isExpectedExit(reason)
             if (detail.isEmpty == false && expected == false) || sawFrames == false {
                 let message = detail.isEmpty ? "the herdr client exited before attaching" : detail
-                ErrorLog.shared.report("Terminal: " + message)
-                self?.view?.feed(text: "\r\n[herdr client exited: " + message + "]\r\n")
+                self?.failed(message)
             } else if let reason, expected {
                 ErrorLog.shared.note("Terminal: " + reason)
             }
@@ -92,7 +99,32 @@ extension TerminalRepresentable.Coordinator {
         }
     }
 
+    /// A client that ended without drawing. Held while recovery has
+    /// yet to be tried: a stale pane target is replaced by the next
+    /// listing's transport, and a running client that draws nothing
+    /// is reattached, and either drawing a frame makes the failure
+    /// not news. Once recovery has been tried, reported at once with
+    /// what was held.
+    func failed(_ message: String) {
+        guard reattachments >= Self.automaticReattachments || heldFailure != nil else {
+            heldFailure = message
+            PerformanceLog.recordMessage("Terminal: " + message + " (held while recovery is tried)", isError: true)
+            return
+        }
+
+        report(message)
+    }
+
     // MARK: Private
+
+    /// Reports a failure and whatever was held before it, and says
+    /// so in the pane.
+    private func report(_ message: String) {
+        let whole = heldFailure.map { $0 + "; then " + message } ?? message
+        heldFailure = nil
+        ErrorLog.shared.report("Terminal: " + whole)
+        view?.feed(text: "\r\n[herdr client exited: " + whole + "]\r\n")
+    }
 
     /// Whether the client's reason for ending is the terminal simply
     /// being gone: herdr words a closed target as the session having
@@ -105,12 +137,12 @@ extension TerminalRepresentable.Coordinator {
         return reason.contains(" exited") || reason.contains("not found")
     }
 
-    /// The deadline fired before any frame. A slow sudo or sandbox
-    /// launch renders late rather than never, so this reports, with
-    /// enough state to name the failing layer, and a client that is
-    /// running yet drew nothing is discarded and attached afresh,
-    /// once: every pane once went blank at the same time with its
-    /// sessions running on, and only a relaunch brought them back.
+    /// The deadline fired before any frame. A client that is running
+    /// yet drew nothing is discarded and attached afresh, once and
+    /// silently: every pane once went blank at the same time with
+    /// its sessions running on, and only a relaunch brought them
+    /// back. Only a pane still blank after that is reported, with
+    /// enough state to name the failing layer.
     private func reportIfBlank() {
         guard framesSeen == 0, tornDown == false else {
             return
@@ -120,15 +152,22 @@ extension TerminalRepresentable.Coordinator {
         Task { [weak self] in
             let running = await ended?.isRunning() ?? false
             let chain = await ended?.launchChainSnapshot() ?? "gone"
-            let reattaches = running && (self?.reattachments ?? 0) < Self.automaticReattachments
-            ErrorLog.shared.report(
-                "Terminal: no frames after \(Self.frameTimeoutSeconds)s"
-                    + " (client running: \(running); chain: \(chain))"
-                    + (reattaches ? "; reattaching" : ""),
-            )
-            if reattaches, let self, let view {
-                reattach(in: view)
+            let state = " (client running: \(running); chain: \(chain))"
+            guard let self else {
+                return
             }
+
+            if running, reattachments < Self.automaticReattachments, let view {
+                PerformanceLog.recordMessage(
+                    "Terminal: no frames after \(Self.frameTimeoutSeconds)s" + state + "; reattaching",
+                    isError: false,
+                )
+                reattach(in: view)
+                return
+            }
+
+            report("no frames after \(Self.frameTimeoutSeconds)s"
+                + (reattachments > 0 ? " and none after reattaching" : "") + state)
         }
     }
 }

--- a/Tests/AgentIDEDomainTests/PerformanceLogTests.swift
+++ b/Tests/AgentIDEDomainTests/PerformanceLogTests.swift
@@ -5,6 +5,8 @@ import Testing
 /// The performance log is off unless asked for, lives where both
 /// users can read it, keeps a day and never grows past its cap.
 struct PerformanceLogTests {
+    // MARK: Internal
+
     @Test
     func `a line older than a day is not kept`() {
         let now = Date()
@@ -46,4 +48,35 @@ struct PerformanceLogTests {
             #expect(PerformanceLog.file.hasPrefix("/Users/Shared/sv-"))
         }
     }
+
+    @Test
+    func `every message is kept beside the performance log while it is on`() async throws {
+        // Only where script/test pointed the log: the real shared
+        // file must never take a test's line.
+        let override = try #require(ProcessInfo.processInfo.environment["AGENTIDE_PERFORMANCE_LOG_DIRECTORY"])
+
+        #expect(PerformanceLog.messagesFile == override + "/messages.log")
+        let marker = "kept-" + UUID().uuidString
+        let quiet = "quiet-" + UUID().uuidString
+        PerformanceLog.recordMessage("nothing to see " + quiet, isError: false, enabled: false)
+        PerformanceLog.recordMessage("first line\nsecond line " + marker, isError: true, enabled: true)
+        // The write is queued; the file has it within a moment.
+        var text = ""
+        for _ in 0 ..< Self.readAttempts where text.contains(marker) == false {
+            try await Task.sleep(for: .milliseconds(Self.readWaitMilliseconds))
+            text = (try? String(contentsOfFile: PerformanceLog.messagesFile, encoding: .utf8)) ?? ""
+        }
+        let line = try #require(text.split(separator: "\n").first { $0.contains(marker) })
+        // Stamp, kind, message: newlines folded so a message stays
+        // one line of the file; and off, nothing is written at all.
+        #expect(line.split(separator: "\t").count == 3)
+        #expect(line.contains("\terror\t"))
+        #expect(line.contains("first line \u{23CE} second line"))
+        #expect(text.contains(quiet) == false)
+    }
+
+    // MARK: Private
+
+    private static let readAttempts = 20
+    private static let readWaitMilliseconds = 50
 }

--- a/Tests/PRFeatureTests/PullRequestStackTests+Signing.swift
+++ b/Tests/PRFeatureTests/PullRequestStackTests+Signing.swift
@@ -20,6 +20,8 @@ extension PullRequestStackTests {
             restacks.withLock { $0 += 1 }
             return ["upper"]
         }
+        // The rebase pushes the stack after; nothing real to push here.
+        model.stacking.push = { _ in [] }
         model.stacking.unsigned = { _ in
             guard restacks.withLock({ $0 }) > 0 else {
                 return []
@@ -49,6 +51,8 @@ extension PullRequestStackTests {
             restacks.withLock { $0 += 1 }
             return ["upper"]
         }
+        // The rebase pushes the stack after; nothing real to push here.
+        model.stacking.push = { _ in [] }
         model.stacking.unsigned = { _ in restacks.withLock { $0 } >= 2 ? [] : ["lower"] }
         await model.reload()
 

--- a/Tests/PRFeatureTests/PullRequestStackTests.swift
+++ b/Tests/PRFeatureTests/PullRequestStackTests.swift
@@ -288,8 +288,9 @@ struct PullRequestStackTests {
         }
         model.stacking.pushPublished = { _ in
             done.withLock { $0.append("push published") }
-            return ["upper"]
+            return ["lower", "upper"]
         }
+        model.stacking.pending = { _ in true }
         model.stacking.unsigned = { _ in [] }
         await model.reload()
 
@@ -297,8 +298,11 @@ struct PullRequestStackTests {
 
         // A branch the restack moved is behind what the remote has,
         // and GitHub reads a stack whose parents moved as no stack
-        // at all until the remote copies catch up.
+        // at all until the remote copies catch up. Both buttons say
+        // what happened to the entry in view.
         #expect(done.withLock { $0 } == ["restack", "push published"])
+        #expect(model.rebaseDoneTitle == "Rebased")
+        #expect(model.pushDoneTitle == "Pushed")
     }
 
     @Test

--- a/Tests/PRFeatureTests/PullRequestStackTests.swift
+++ b/Tests/PRFeatureTests/PullRequestStackTests.swift
@@ -203,6 +203,8 @@ struct PullRequestStackTests {
             done.withLock { $0.append("restack") }
             return ["upper"]
         }
+        // The rebase pushes the stack after; nothing real to push here.
+        model.stacking.push = { _ in [] }
         // Done means Push agrees: the stack is read as signed after.
         model.stacking.unsigned = { _ in [] }
         await model.reload()
@@ -270,7 +272,7 @@ struct PullRequestStackTests {
     }
 
     @Test
-    func `a rebase anywhere in a stack puts the published branches back`() async {
+    func `a rebase anywhere in a stack pushes the stack back`() async {
         let fixtures = PullRequestsModelTests()
         let model = fixtures.makeModel(items: [fixtures.item(branch: "feature", ahead: 1)])
         model.fetchCurrentBranch = { _ in "upper" }
@@ -286,8 +288,8 @@ struct PullRequestStackTests {
             done.withLock { $0.append("restack") }
             return ["upper"]
         }
-        model.stacking.pushPublished = { _ in
-            done.withLock { $0.append("push published") }
+        model.stacking.push = { _ in
+            done.withLock { $0.append("push") }
             return ["lower", "upper"]
         }
         model.stacking.pending = { _ in true }
@@ -298,9 +300,10 @@ struct PullRequestStackTests {
 
         // A branch the restack moved is behind what the remote has,
         // and GitHub reads a stack whose parents moved as no stack
-        // at all until the remote copies catch up. Both buttons say
-        // what happened to the entry in view.
-        #expect(done.withLock { $0 } == ["restack", "push published"])
+        // at all until the remote copies catch up; the whole stack
+        // goes, a branch nobody has pushed included, as the button
+        // says. Both buttons say what happened to the entry in view.
+        #expect(done.withLock { $0 } == ["restack", "push"])
         #expect(model.rebaseDoneTitle == "Rebased")
         #expect(model.pushDoneTitle == "Pushed")
     }

--- a/Tests/PRFeatureTests/PullRequestsModelTests+Busy.swift
+++ b/Tests/PRFeatureTests/PullRequestsModelTests+Busy.swift
@@ -1,0 +1,19 @@
+@testable import PRFeature
+import Testing
+
+/// One branch action at a time: the other button dims while one
+/// runs, since a push pressed mid-rebase failed.
+extension PullRequestsModelTests {
+    @Test
+    func `no branch action is offered while one runs`() async {
+        let model = makeModel(items: [item(branch: "feature", ahead: 2)])
+        model.fetchRebaseNeed = { _ in .sign }
+        await model.reload()
+        #expect(model.canPush)
+        #expect(model.canRebase)
+
+        model.isBranchActionRunning = true
+        #expect(model.canPush == false)
+        #expect(model.canRebase == false)
+    }
+}

--- a/Tests/ReviewFeatureTests/ReviewModelVanishedTests.swift
+++ b/Tests/ReviewFeatureTests/ReviewModelVanishedTests.swift
@@ -26,11 +26,15 @@ struct ReviewModelVanishedTests {
     }
 
     @Test
-    func `a reload failing in a worktree still there reports`() async {
+    func `a reload failing in a worktree still there reports once it fails again`() async {
         let marker = "held-" + UUID().uuidString
         let model = makeModel(marker: marker)
         model.worktreeExists = { _ in true }
 
+        // The next reload is the recovery a read has: the first
+        // failure is held, the second reports both.
+        await model.reload()
+        #expect(ErrorLog.shared.entries.contains { $0.message.contains(marker) } == false)
         await model.reload()
         #expect(ErrorLog.shared.entries.contains { $0.message.contains(marker) })
     }
@@ -40,7 +44,9 @@ struct ReviewModelVanishedTests {
     private func makeModel(marker: String) -> ReviewModel {
         ReviewModel(
             worktreePath: "/worktrees/repo/renamed-away",
-            repositoryName: "repo",
+            // Its own name, so no other test's success clears what
+            // this one holds.
+            repositoryName: marker,
             git: GitClient(runner: FailingRunner(marker: marker)),
         )
     }

--- a/Tests/TerminalUITests/ErrorLogRetryTests.swift
+++ b/Tests/TerminalUITests/ErrorLogRetryTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+@testable import TerminalUI
+import Testing
+
+/// Work that can simply be tried again is, once, before its failure
+/// is reported.
+@MainActor
+struct ErrorLogRetryTests {
+    // MARK: Internal
+
+    @Test
+    func `a second try that succeeds reports nothing`() async {
+        let what = "Trying " + UUID().uuidString
+        var tries = 0
+        let succeeded = await ErrorLog.shared.attemptingTwice(what) {
+            tries += 1
+            if tries == 1 {
+                throw Failure(errorDescription: "first")
+            }
+        }
+        #expect(succeeded)
+        #expect(tries == 2)
+        #expect(ErrorLog.shared.entries.contains { $0.message.contains(what) } == false)
+    }
+
+    @Test
+    func `two failures report once, naming both`() async {
+        let what = "Trying " + UUID().uuidString
+        var tries = 0
+        let succeeded = await ErrorLog.shared.attemptingTwice(what) {
+            tries += 1
+            throw Failure(errorDescription: "try " + String(tries))
+        }
+        #expect(succeeded == false)
+        #expect(tries == 2)
+        let about = ErrorLog.shared.entries.filter { $0.message.contains(what) }
+        #expect(about.count == 1)
+        #expect(about.first?.message.contains("try 1") == true)
+        #expect(about.first?.message.contains("try 2") == true)
+    }
+
+    // MARK: Private
+
+    private struct Failure: LocalizedError {
+        let errorDescription: String?
+    }
+}

--- a/Tests/TerminalUITests/ServiceStatusTests.swift
+++ b/Tests/TerminalUITests/ServiceStatusTests.swift
@@ -12,28 +12,52 @@ struct ServiceStatusTests {
     func `a read failure is reported only when it repeats`() {
         let status = ServiceStatus.shared
         let what = "Reading " + UUID().uuidString
-        let before = ErrorLog.shared.entries.count
 
         status.record(failure: Failure(errorDescription: "first"), doing: what)
-        #expect(ErrorLog.shared.entries.count == before)
+        #expect(reported(what) == nil)
 
         // A success in between makes the first not news.
         status.recordSuccess(doing: what)
         status.record(failure: Failure(errorDescription: "second"), doing: what)
-        #expect(ErrorLog.shared.entries.count == before)
+        #expect(reported(what) == nil)
 
         status.record(failure: Failure(errorDescription: "third"), doing: what)
-        #expect(ErrorLog.shared.entries.count == before + 1)
-        let reported = ErrorLog.shared.entries.last?.message ?? ""
-        #expect(reported.contains(what))
-        #expect(reported.contains("second"))
-        #expect(reported.contains("third"))
-        #expect(reported.contains("first") == false)
+        let message = reported(what) ?? ""
+        #expect(message.contains("second"))
+        #expect(message.contains("third"))
+        #expect(message.contains("first") == false)
+    }
+
+    @Test
+    func `a held failure nobody reads again is reported anyway`() async throws {
+        let what = "Reading " + UUID().uuidString
+        ServiceStatus.shared.record(
+            failure: Failure(errorDescription: "once"),
+            doing: what,
+            holdingFor: .milliseconds(50),
+        )
+        #expect(reported(what) == nil)
+
+        // The deadline is a task on a loaded test run; give it a
+        // moment, then a few more.
+        for _ in 0 ..< Self.readAttempts where reported(what) == nil {
+            try await Task.sleep(for: .milliseconds(Self.readWaitMilliseconds))
+        }
+        #expect(reported(what)?.contains("not read again") == true)
     }
 
     // MARK: Private
 
     private struct Failure: LocalizedError {
         let errorDescription: String?
+    }
+
+    private static let readAttempts = 40
+    private static let readWaitMilliseconds = 100
+
+    /// The log's message about one read, if any; other suites write
+    /// to the same log beside this one.
+    private func reported(_ what: String) -> String? {
+        ErrorLog.shared.entries.last { $0.message.contains(what) }?.message
     }
 }

--- a/Tests/TerminalUITests/ServiceStatusTests.swift
+++ b/Tests/TerminalUITests/ServiceStatusTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+@testable import TerminalUI
+import Testing
+
+/// A read that failed once is not news until it fails again: the
+/// next poll is the recovery every read has.
+@MainActor
+struct ServiceStatusTests {
+    // MARK: Internal
+
+    @Test
+    func `a read failure is reported only when it repeats`() {
+        let status = ServiceStatus.shared
+        let what = "Reading " + UUID().uuidString
+        let before = ErrorLog.shared.entries.count
+
+        status.record(failure: Failure(errorDescription: "first"), doing: what)
+        #expect(ErrorLog.shared.entries.count == before)
+
+        // A success in between makes the first not news.
+        status.recordSuccess(doing: what)
+        status.record(failure: Failure(errorDescription: "second"), doing: what)
+        #expect(ErrorLog.shared.entries.count == before)
+
+        status.record(failure: Failure(errorDescription: "third"), doing: what)
+        #expect(ErrorLog.shared.entries.count == before + 1)
+        let reported = ErrorLog.shared.entries.last?.message ?? ""
+        #expect(reported.contains(what))
+        #expect(reported.contains("second"))
+        #expect(reported.contains("third"))
+        #expect(reported.contains("first") == false)
+    }
+
+    // MARK: Private
+
+    private struct Failure: LocalizedError {
+        let errorDescription: String?
+    }
+}


### PR DESCRIPTION
- Messages survive relaunch with logs and blank pane reattachment
- Pane size sent once to herdr, not duplicated on attach
- Terminal failure held until recovery attempt fails
- Read failure held until next read fails too
- Held read reported in time with retry on resume
- Stack rebase action clearly stated and executed sequentially
- Work per session with unified branch naming and merging
- Hide standalone Push when Rebase or Sign controls the flow