### PR TITLE
Follow default branch change with in-process chime

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -489,17 +489,19 @@ page resumes any past conversation into a fresh worktree.
   conversation that fell back to REST is a recovery that worked, and
   goes only to the messages log.
   Notifications fire for a finished turn and for input
-  needed, each with its own toggle and chime (any audio file, played
-  through `AudioServicesPlayAlertSound` so alert volume and the
-  accessibility flash apply; its completion handler must be formed in a
-  nonisolated context or the executor check traps). A chime sleep
-  interrupted mid-play loses its completion and the audio daemon
-  replays it in a loop after wake, which disposing it afterwards did
-  not cure: nothing is played into a machine that has announced
-  sleep, and what was mid-play is disposed then rather than on the
-  way back. Wake still drains as a backstop; whoever removes a sound
-  from that registry owns its disposal, so a drain and a late
-  completion never dispose one twice. An exit posts nothing. The Dock badge counts worktrees
+  needed, each with its own toggle and chime: any audio file, played
+  in the app's own process through `NSSound`, the way a Mac app plays
+  a sound of its own. The system's alert path
+  (`AudioServicesPlayAlertSound`) handed each chime to the audio
+  daemon, which replayed one whose completion it lost, after a sleep
+  and then for no reason it gave, in a loop until something displaced
+  it; disposing on completion, on sleep and on wake each cured one
+  case and not the next. Other apps either hand the sound to the
+  notification itself, which macOS plays unreliably for custom files,
+  or play it in-process as this now does; the cost is that the alert
+  volume and the accessibility flash no longer apply. Nothing is
+  played into a machine that has announced sleep, and what is
+  mid-play stops then. An exit posts nothing. The Dock badge counts worktrees
   needing attention, each contribution behind a toggle.
 - **Git reads are driven by the file system.** One FSEvents stream
   over the repository and worktree roots (`WorkspaceWatcher`) remembers

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -449,6 +449,14 @@ page resumes any past conversation into a fresh worktree.
   SessionEnd in the defensive `[ -x … ] && … || true` shape. The hook
   appends a JSON line to `agentide/events/<session>.jsonl`, keyed by
   `AGENTIDE_SESSION` with `SV_SESSION_ID` as fallback.
+- **An explicit fetch follows the default branch.** `origin/HEAD` is
+  set at clone time and a fetch never moves it, so a repository whose
+  default branch went from `trunk` to `main` kept reading as `trunk`.
+  Fetch and Fetch and Reset on a row ask origin again (`git remote
+  set-head origin --auto`), and a main checkout sitting on the old
+  default is checked out on the new, made from origin's if there is
+  no local one, before any reset; the note says so. The poll's own
+  fetches never pay that round trip.
 - **Unread.** A worktree is unread when its spool file or transcripts
   are newer than its per-worktree seen time; viewing records that time
   and a context menu marks it unread again. The selected worktree is

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ updates.
   locations.
 - Says what a pull request is doing in GitHub's own icons, one glyph per
   fact, watching checks and queued merges until they settle.
+- Fetch and Fetch and Reset on a repository follow its default branch
+  when it has moved on GitHub, switching the checkout to the new one.
 - Code reviews uncommitted work, the last commit, unpushed commits, the
   whole branch or any single commit, as a syntax-highlighted diff with
   the pull request's conversations inline under their files.

--- a/Sources/AgentIDEData/GitClient+DefaultBranch.swift
+++ b/Sources/AgentIDEData/GitClient+DefaultBranch.swift
@@ -1,0 +1,63 @@
+import AgentIDEDomain
+
+/// Following a default branch that moved on the remote. Split from
+/// the client body for length.
+public extension GitClient {
+    /// A default branch that moved: the branch it was and the one
+    /// it is now.
+    struct DefaultBranchMove: Equatable, Sendable {
+        // MARK: Lifecycle
+
+        public init(previous: String, current: String) {
+            self.previous = previous
+            self.current = current
+        }
+
+        // MARK: Public
+
+        public let previous: String
+        public let current: String
+    }
+
+    /// Where origin's HEAD points now, then what the default branch
+    /// is read from. `origin/HEAD` is set once at clone time and a
+    /// fetch never moves it, so a repository whose default branch
+    /// went from `trunk` to `main` on GitHub kept reading as `trunk`
+    /// here; only an explicit fetch pays for this extra round trip.
+    /// When the default branch has moved, a main checkout sitting
+    /// on the old one is checked out on the new, made from origin's
+    /// if there is no local one, and the move is returned. Origin is
+    /// fetched first, so the branch its HEAD now names has a tracking
+    /// ref here to be checked out from; a remote that will not say
+    /// where its HEAD points is left as it was, since the fetch that
+    /// was asked for has already happened.
+    func followDefaultBranch(of repository: Repository) async throws -> DefaultBranchMove? {
+        let before = await defaultBaseRef(of: repository).map { Self.branchName(of: $0) }
+        try await git(["fetch", "origin"], in: repository.path)
+        let asked = try await git(["remote", "set-head", "origin", "--auto"], in: repository.path, allowFailure: true)
+        guard asked.succeeded else {
+            return nil
+        }
+
+        await RepositoryFacts.shared.forget(repository.path)
+        let after = await defaultBaseRef(of: repository).map { Self.branchName(of: $0) }
+        guard let before, let after, before != after else {
+            return nil
+        }
+
+        let move = DefaultBranchMove(previous: before, current: after)
+        if await currentBranch(worktreePath: repository.path) == move.previous {
+            try await checkout(branch: move.current, worktreePath: repository.path)
+        }
+        return move
+    }
+
+    /// A base ref's branch: `origin/main` is `main`.
+    private static func branchName(of baseRef: String) -> String {
+        if baseRef.hasPrefix("origin/") {
+            String(baseRef.dropFirst("origin/".count))
+        } else {
+            baseRef
+        }
+    }
+}

--- a/Sources/AgentIDEData/GitClient.swift
+++ b/Sources/AgentIDEData/GitClient.swift
@@ -215,13 +215,12 @@ public struct GitClient: Sendable {
         try await git(["fetch", "--all", "--prune"], in: repositoryPath)
     }
 
-    /// Fetches origin and hard-resets the checkout to a ref, for
-    /// main checkouts that should mirror the remote. The caller
-    /// resolves the ref: `origin/HEAD` is a symbolic name a clone
-    /// need never have been given, and resetting to one git cannot
-    /// resolve fails where naming the branch works.
-    public func fetchAndReset(repositoryPath: String, onto ref: String) async throws {
-        try await git(["fetch", "origin"], in: repositoryPath)
+    /// Hard-resets the checkout to a ref, for main checkouts that
+    /// should mirror the remote; the caller has fetched. The caller
+    /// resolves the ref too: `origin/HEAD` is a symbolic name a clone
+    /// need never have been given, and resetting to one the clone
+    /// cannot resolve fails where naming the branch works.
+    public func resetHard(repositoryPath: String, onto ref: String) async throws {
         try await git(["reset", "--hard", ref], in: repositoryPath)
     }
 

--- a/Sources/AgentIDEData/SessionService+Lifecycle.swift
+++ b/Sources/AgentIDEData/SessionService+Lifecycle.swift
@@ -111,9 +111,14 @@ public extension SessionService {
     }
 
     /// Fetches and prunes the repository's remotes.
-    func fetch(repository: Repository) async throws {
+    /// An explicit fetch, which also follows the default branch when
+    /// GitHub has moved it; the poll's fetches never do, since a
+    /// move is rare and the check is a round trip.
+    @discardableResult
+    func fetch(repository: Repository) async throws -> GitClient.DefaultBranchMove? {
         try await git.fetch(repositoryPath: repository.path)
         rememberFetch(repositoryPath: repository.path)
+        return try await git.followDefaultBranch(of: repository)
     }
 
     /// A tracked file's committed content; see `GitClient`.

--- a/Sources/AgentIDEData/SessionService+Sources.swift
+++ b/Sources/AgentIDEData/SessionService+Sources.swift
@@ -177,16 +177,19 @@ public extension SessionService {
     }
 
     /// Fetches origin and hard-resets the main checkout to its
-    /// default branch.
-    @discardableResult
-    func fetchAndReset(repository: Repository) async throws -> String {
+    /// default branch, following that branch first when GitHub has
+    /// moved it, so the reset lands on the branch that is now the
+    /// default rather than the one that was. The follow is the
+    /// fetch: it asks origin before anything else.
+    func fetchAndReset(repository: Repository) async throws -> (ref: String, move: GitClient.DefaultBranchMove?) {
+        let move = try await git.followDefaultBranch(of: repository)
         guard let ref = await git.defaultBaseRef(of: repository) else {
             throw SessionServiceError("\(repository.name) has no default branch to reset to.")
         }
 
-        try await git.fetchAndReset(repositoryPath: repository.path, onto: ref)
+        try await git.resetHard(repositoryPath: repository.path, onto: ref)
         rememberFetch(repositoryPath: repository.path)
-        return ref
+        return (ref, move)
     }
 
     /// Fetches, then rebases the worktree onto the signed-rebase

--- a/Sources/DashboardFeature/DashboardModel+Fetching.swift
+++ b/Sources/DashboardFeature/DashboardModel+Fetching.swift
@@ -1,0 +1,45 @@
+import AgentIDEData
+import AgentIDEDomain
+import TerminalUI
+
+/// The explicit fetches a repository row offers. Split from the
+/// model body for length.
+public extension DashboardModel {
+    /// Fetches the item's repository and refreshes, saying so when
+    /// the default branch moved and the checkout followed it.
+    func fetch(item: WorktreeItem) async {
+        let repository = Repository(name: item.worktree.repositoryName, path: item.worktree.repositoryPath)
+        do {
+            let move = try await service.fetch(repository: repository)
+            ErrorLog.shared.note("fetched" + Self.moved(move), about: repository.name)
+            await refresh()
+        } catch {
+            ErrorLog.shared.report(error.localizedDescription)
+        }
+    }
+
+    /// Fetches origin and hard-resets the main checkout to its
+    /// default branch, following a moved default branch first, then
+    /// refreshes.
+    func fetchAndReset(item: WorktreeItem) async {
+        let repository = Repository(name: item.worktree.repositoryName, path: item.worktree.repositoryPath)
+        do {
+            let (ref, move) = try await service.fetchAndReset(repository: repository)
+            ErrorLog.shared.note("reset the checkout to `" + ref + "`" + Self.moved(move), about: repository.name)
+            await refresh()
+        } catch {
+            ErrorLog.shared.report(error.localizedDescription)
+        }
+    }
+
+    /// What a note says about a default branch that moved, or
+    /// nothing when it did not.
+    private static func moved(_ move: GitClient.DefaultBranchMove?) -> String {
+        guard let move else {
+            return ""
+        }
+
+        return "; the default branch moved from `" + move.previous + "` to `" + move.current
+            + "`, and the checkout followed it"
+    }
+}

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -261,37 +261,6 @@ public final class DashboardModel {
         await (try? service.openPullRequests(repository: repository)) ?? []
     }
 
-    /// Fetches the item's repository and refreshes.
-    public func fetch(item: WorktreeItem) async {
-        do {
-            let repository = Repository(
-                name: item.worktree.repositoryName,
-                path: item.worktree.repositoryPath,
-            )
-            try await service.fetch(repository: repository)
-            ErrorLog.shared.note("fetched", about: repository.name)
-            await refresh()
-        } catch {
-            ErrorLog.shared.report(error.localizedDescription)
-        }
-    }
-
-    /// Fetches origin and hard-resets the main checkout to its
-    /// default branch, then refreshes.
-    public func fetchAndReset(item: WorktreeItem) async {
-        do {
-            let repository = Repository(
-                name: item.worktree.repositoryName,
-                path: item.worktree.repositoryPath,
-            )
-            let ref = try await service.fetchAndReset(repository: repository)
-            ErrorLog.shared.note("reset the checkout to `" + ref + "`", about: repository.name)
-            await refresh()
-        } catch {
-            ErrorLog.shared.report(error.localizedDescription)
-        }
-    }
-
     // MARK: Internal
 
     static let selectedWorktreeKey = "selectedWorktreePath"

--- a/Sources/TerminalUI/CompletionSound.swift
+++ b/Sources/TerminalUI/CompletionSound.swift
@@ -1,5 +1,4 @@
 import AppKit
-import AudioToolbox
 import Synchronization
 import UniformTypeIdentifiers
 
@@ -44,71 +43,57 @@ public enum CompletionSound {
         return sounds
     }
 
-    /// Plays a sound file as an alert, so the system's alert volume
-    /// and accessibility flash apply. The empty path is silence by
-    /// choice, and a file that no longer plays is silence rather
-    /// than an error: a missing sound must never break the
-    /// notification it rode.
-    public static func play(path: String) {
-        // A chime started as the machine suspends is the one that
-        // gets stuck: its completion never runs, the audio daemon
-        // holds it across the sleep, and it comes back looping until
-        // some other alert displaces it. Nobody is there to hear it
-        // either, so a sleeping machine is played nothing at all.
-        guard path.isEmpty == false, isSleeping.withLock({ $0 == false }) else {
-            return
+    /// Plays a sound file in the app's own process, through
+    /// `NSSound`, the way a Mac app plays a sound of its own, and off
+    /// the main thread: the system's alert path handed a sound to
+    /// the audio daemon, which replayed one whose completion it lost
+    /// in a loop, and the same daemon can stall the first play for
+    /// seconds, which on the main thread was the app hanging at
+    /// launch with its "done" chimes. One at a time on a queue of
+    /// its own, held there until it finishes. The empty path is
+    /// silence by choice, a file that no longer plays is silence
+    /// rather than an error, and a machine that has announced sleep
+    /// is played nothing, since nobody is there to hear it. Whether
+    /// a sound was handed to the queue.
+    @discardableResult
+    public static func play(path: String) -> Bool {
+        guard path.isEmpty == false, FileManager.default.isReadableFile(atPath: path),
+              isSleeping.withLock({ $0 == false })
+        else {
+            return false
         }
 
-        var sound: SystemSoundID = 0
-        let made = AudioServicesCreateSystemSoundID(URL(fileURLWithPath: path) as CFURL, &sound)
-        guard made == kAudioServicesNoError else {
-            NSSound(contentsOfFile: path, byReference: true)?.play()
-            return
-        }
+        queue.async {
+            guard let sound = NSSound(contentsOfFile: path, byReference: true) else {
+                return
+            }
 
-        lingering.withLock { _ = $0.insert(sound) }
-        AudioServicesPlayAlertSoundWithCompletion(sound, Self.disposal(of: sound))
+            sound.play()
+            // Held here for as long as it plays, and cut off should
+            // the machine announce sleep while it does.
+            while sound.isPlaying {
+                if isSleeping.withLock({ $0 }) {
+                    sound.stop()
+                    return
+                }
+                Thread.sleep(forTimeInterval: Self.pollSeconds)
+            }
+        }
+        return true
     }
 
-    /// Stops chiming and disposes whatever is mid-play, called when
-    /// the machine announces sleep: what is not playing as the
-    /// machine suspends cannot be stuck across it, which curing
-    /// afterwards proved unable to do on its own.
+    /// Stops chiming, called when the machine announces sleep: a
+    /// sound cut off then is silent, never stuck.
     public static func beginSleeping() {
         isSleeping.withLock { $0 = true }
-        stopLingering()
     }
 
-    /// Chimes again on wake, disposing anything the sleep left
-    /// behind as a backstop.
+    /// Chimes again on wake.
     public static func endSleeping() {
         isSleeping.withLock { $0 = false }
-        stopLingering()
-    }
-
-    /// Disposes every sound whose completion never ran, called on
-    /// wake: sleep can interrupt an alert mid-play and swallow its
-    /// completion, and the audio daemon then replays the undisposed
-    /// sound in a loop until something disposes it (playing any
-    /// other alert did too, which is why a Settings preview used to
-    /// stop the noise).
-    public static func stopLingering() {
-        let stuck = lingering.withLock { sounds in
-            let all = sounds
-            sounds = []
-            return all
-        }
-        for sound in stuck {
-            AudioServicesDisposeSystemSoundID(sound)
-        }
     }
 
     // MARK: Internal
-
-    /// The sounds playing right now, each removed by whoever
-    /// disposes it, so a drain and a late completion can never
-    /// dispose one sound twice.
-    nonisolated static let lingering: Mutex<Set<SystemSoundID>> = .init([])
 
     /// Whether the machine is asleep or on its way there, which is
     /// the one time nothing is played.
@@ -128,19 +113,9 @@ public enum CompletionSound {
 
     // MARK: Private
 
-    /// The completion runs on the sound service's own queue, so it
-    /// must not be a main-actor closure: the runtime's executor
-    /// check traps there. Formed in a nonisolated context it stays
-    /// free of any actor. Only the closure that still finds its
-    /// sound registered disposes it; a wake drain may have got
-    /// there first.
-    private nonisolated static func disposal(of sound: SystemSoundID) -> @Sendable () -> Void {
-        {
-            guard lingering.withLock({ $0.remove(sound) != nil }) else {
-                return
-            }
+    /// How often a playing sound is checked for the sleep flag.
+    private static let pollSeconds: TimeInterval = 0.05
 
-            AudioServicesDisposeSystemSoundID(sound)
-        }
-    }
+    /// One sound at a time, away from the main thread.
+    private static let queue: DispatchQueue = .init(label: "agentide.chime", qos: .userInitiated)
 }

--- a/Tests/AgentIDEDataTests/DefaultBranchMoveTests.swift
+++ b/Tests/AgentIDEDataTests/DefaultBranchMoveTests.swift
@@ -1,0 +1,36 @@
+import AgentIDEData
+import AgentIDEDomain
+import Foundation
+import Testing
+
+/// A default branch that moved on the remote is followed by an
+/// explicit fetch: origin's HEAD is asked again and a checkout on
+/// the old default moves to the new.
+struct DefaultBranchMoveTests {
+    @Test
+    func `the checkout follows a default branch that moved from trunk to main`() async throws {
+        let base = try TestSupport.temporaryDirectory("default-move")
+        let origin = base + "/origin.git"
+        let path = base + "/repo"
+        try await TestSupport.runGit(["init", "-q", "--bare", "-b", "trunk", origin], in: base)
+        try await TestSupport.makeRepository(at: path)
+        try await TestSupport.runGit(["branch", "-m", "main", "trunk"], in: path)
+        try await TestSupport.runGit(["remote", "add", "origin", origin], in: path)
+        try await TestSupport.runGit(["push", "-q", "-u", "origin", "trunk"], in: path)
+        try await TestSupport.runGit(["remote", "set-head", "origin", "--auto"], in: path)
+        let git = GitClient(runner: FoundationProcessRunner())
+        let repository = Repository(name: "repo", path: path)
+        #expect(await git.defaultBaseRef(of: repository) == "origin/trunk")
+
+        // GitHub renames the default branch: main appears, HEAD moves.
+        try await TestSupport.runGit(["push", "-q", "origin", "trunk:main"], in: path)
+        try await TestSupport.runGit(["symbolic-ref", "HEAD", "refs/heads/main"], in: origin)
+
+        let move = try await git.followDefaultBranch(of: repository)
+        #expect(move == GitClient.DefaultBranchMove(previous: "trunk", current: "main"))
+        #expect(await git.defaultBaseRef(of: repository) == "origin/main")
+        #expect(await git.currentBranch(worktreePath: path) == "main")
+        // Nothing moved is nothing to follow.
+        #expect(try await git.followDefaultBranch(of: repository) == nil)
+    }
+}

--- a/Tests/AgentIDEDataTests/DirectoryWakeTests.swift
+++ b/Tests/AgentIDEDataTests/DirectoryWakeTests.swift
@@ -56,17 +56,21 @@ struct DirectoryWakeTests {
         // The check for a pending ring and the installing of the
         // waiter were once two lock takes, and a ring between them
         // waited out the whole timeout. Raced two hundred times with
-        // a two-second timeout, that version overran on some; every
-        // wait here has to return well inside it.
+        // a two-second timeout, that version overran on some. Each
+        // round is bounded on its own: a lost ring costs one round
+        // the whole timeout, where a loaded runner only spreads a
+        // few seconds thinly over all of them.
         let wake = DirectoryWake()
         let timeout = Duration.seconds(2)
         let rounds = 200
-        let started = ContinuousClock.now
+        var slowest = Duration.zero
         for _ in 0 ..< rounds {
             let ringing = Task { wake.ring() }
+            let started = ContinuousClock.now
             await wake.wait(timeout: timeout)
+            slowest = max(slowest, ContinuousClock.now - started)
             await ringing.value
         }
-        #expect(ContinuousClock.now - started < timeout)
+        #expect(slowest < timeout)
     }
 }

--- a/Tests/AgentIDEDataTests/WorkspaceWatcherIntegrationTests.swift
+++ b/Tests/AgentIDEDataTests/WorkspaceWatcherIntegrationTests.swift
@@ -40,8 +40,15 @@ struct WorkspaceWatcherIntegrationTests {
         #expect(changed.isEmpty == false)
         #expect(changed.allSatisfy { $0.hasPrefix(root + "/brew") })
 
-        // Consuming clears; quiet directories stay quiet.
-        #expect(watcher.consumeChangedPaths().isEmpty)
+        // Consuming clears. An atomic write is a file and a rename,
+        // which FSEvents may deliver in two batches, so what trickles
+        // in after belongs to the same directory and nothing else.
+        var late = Set<String>()
+        for _ in 0 ..< Self.drainAttempts {
+            late.formUnion(watcher.consumeChangedPaths())
+            try await Task.sleep(for: .milliseconds(Self.pollMilliseconds))
+        }
+        #expect(late.allSatisfy { $0.hasPrefix(root + "/brew") })
     }
 
     // MARK: Private
@@ -49,6 +56,7 @@ struct WorkspaceWatcherIntegrationTests {
     /// Generous: FSEvents delivery on a loaded CI runner can lag
     /// far behind the half-second latency asked for.
     private static let waitAttempts = 240
+    private static let drainAttempts = 10
     private static let pollMilliseconds = 50
     private static let settleSeconds = 2
 }

--- a/Tests/TerminalUITests/CompletionSoundTests.swift
+++ b/Tests/TerminalUITests/CompletionSoundTests.swift
@@ -1,7 +1,8 @@
 @testable import TerminalUI
 import Testing
 
-/// The completion chime's sound listing and its audio-only filter.
+/// The completion chime's sound listing, its audio-only filter and
+/// its silence through sleep.
 struct CompletionSoundTests {
     @Test
     func `the system listing offers the default chime`() {
@@ -30,50 +31,16 @@ struct CompletionSoundTests {
 
     @Test
     func `a machine going to sleep is played nothing at all`() {
-        CompletionSound.lingering.withLock { $0.removeAll() }
         // Sleep is announced before it happens: a chime started now
-        // is the one that gets stuck across it, and nobody is there
-        // to hear it anyway.
+        // is the one nobody hears, and the one the old alert path
+        // brought back looping.
         CompletionSound.beginSleeping()
-        CompletionSound.play(path: CompletionSound.defaultPath)
-        let whileAsleep = CompletionSound.lingering.withLock(\.isEmpty)
-        #expect(whileAsleep)
+        #expect(CompletionSound.play(path: CompletionSound.defaultPath) == false)
 
         // Waking gives the chimes back.
         CompletionSound.endSleeping()
-        CompletionSound.play(path: CompletionSound.defaultPath)
-        let awake = CompletionSound.lingering.withLock(\.isEmpty)
-        #expect(awake == false)
-        CompletionSound.stopLingering()
-    }
-
-    @Test
-    func `sleep disposes whatever was mid-play`() {
-        CompletionSound.lingering.withLock { _ = $0.insert(9_999_998) }
-        CompletionSound.beginSleeping()
-        let drained = CompletionSound.lingering.withLock(\.isEmpty)
-        #expect(drained)
-        CompletionSound.endSleeping()
-    }
-
-    @Test
-    func `waking disposes sounds whose completion never came`() {
-        // A sound sleep interrupted mid-play: its completion never
-        // ran, so its id is still registered. The stray id stands in
-        // for one the audio daemon holds; disposing an unknown id is
-        // a harmless error.
-        CompletionSound.lingering.withLock { _ = $0.insert(9_999_999) }
-        CompletionSound.play(path: CompletionSound.defaultPath)
-
-        CompletionSound.stopLingering()
-        // Read outside the macro: the expansion cannot carry the
-        // non-copyable mutex.
-        let drained = CompletionSound.lingering.withLock(\.isEmpty)
-        #expect(drained)
-
-        // A drain with nothing playing is a quiet no-op.
-        CompletionSound.stopLingering()
-        let still = CompletionSound.lingering.withLock(\.isEmpty)
-        #expect(still)
+        #expect(CompletionSound.play(path: CompletionSound.defaultPath))
+        #expect(CompletionSound.play(path: "") == false)
+        #expect(CompletionSound.play(path: "/nowhere/missing.aiff") == false)
     }
 }


### PR DESCRIPTION
- Handle default branch migration during explicit fetch by checking old checkout before reset
- Replace system alert loop with in-process NSSound playback to prevent infinite replay