### PR TITLE
Reattach blank screens and read herdr clients via readability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,15 @@ Hard-won on macOS 27 beta; check before assuming they expired.
   `HerdrSlowReaderIntegrationTests` reproduces it under load, and
   `HerdrLargeInputIntegrationTests` meets it whenever the run is
   contended; both stay disabled until herdr waits or retries.
+- `FileHandle.bytes` serialises its reads across every handle in
+  the process: with one reader waiting on a silent pipe, a fresh
+  reader on another pipe received nothing (reproduced with plain
+  pipes, no herdr involved). Every mounted agent pane keeps a herdr
+  client, and an idle agent's client is silent, so a new pane sat
+  blank with a cursor until some other pane's agent drew, and a
+  relaunch, which dropped every reader, was the only sure fix.
+  Read pipes through `readabilityHandler` (`HerdrTerminalChannel`);
+  `HerdrTerminalChannelReaderTests` pins it.
 - SwiftTerm encodes Option and an arrow the way the kitty keyboard
   protocol does (`ESC [ 1 ; 3 D`) whether or not anything turned that
   protocol on, so a shell read as far as `ESC [ 1`, found nothing

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1147,12 +1147,14 @@ message the Messages pane shows is also appended to `messages.log`
 beside it: the pane does not survive a relaunch, and a fault worth
 relaunching for is exactly what needs reading afterwards. One such
 fault is a terminal pane that draws nothing: a control pane with no
-frame five seconds after attaching, its client still running, is
-discarded and attached afresh once by itself, silently, and reported
-only if that draws nothing either; a client that exits before drawing
+frame, or only a blank screen, five seconds after attaching, its
+client still running, is discarded and attached afresh once by
+itself, silently, and reported only if that draws nothing either,
+when the pane draws Reattach over itself (`StalledPaneOverlay`) so a
+relaunch is never the only way back; a client that exits before drawing
 (a stale pane target after a herdr restart, say) is held the same way
-until the next attach draws or fails. Reattach in the pane's menu does
-the same by hand. A size herdr was
+until the next attach draws or fails. Reattach in the pane's menu, or
+the session strip's, does the same by hand. A size herdr was
 already told is not sent again: the attach and the terminal's own size
 callback both said the same size, and herdr 0.8.2 dropped the repaint
 after that transient pair (0.9.0 says it repaints after transient

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,7 +191,11 @@ rather than drawing a remote screen over a PTY. herdr streams
 repaint, which the pane decodes (`HerdrTerminal` in Domain,
 `HerdrTerminalChannel` in DataAccess) into a local SwiftTerm view;
 keystrokes go back as `terminal.input`, resizes as `terminal.resize` and
-the wheel as `terminal.scroll`. Rules that follow from that shape:
+the wheel as `terminal.scroll`. The channel reads its client through
+the pipe's readability handler, never a blocking read: every mounted
+pane keeps a client, most of them silent, and reads that wait on each
+other left a fresh attach blank until some other pane's agent spoke.
+Rules that follow from that shape:
 
 - **Frames carry the screen, never the modes.** Cursor moves, colours
   and synchronised updates arrive; the private modes an agent set

--- a/App/RootView+SessionTabs.swift
+++ b/App/RootView+SessionTabs.swift
@@ -255,6 +255,14 @@ extension RootView {
                         + "` joins this session from a terminal")
             }
             .padding(Self.stripSpacing)
+            // The strip's own Reattach: the pane's menu offers it too,
+            // but a pane showing only a cursor gives no hint that a
+            // right-click on it would help. The shape makes the empty
+            // run of the strip take the click, not only its glyphs.
+            .contentShape(Rectangle())
+            .contextMenu {
+                Button("Reattach") { dependencies.dashboard.reattachRequests[session.name, default: 0] += 1 }
+            }
             Divider()
         }
     }

--- a/App/RootView+UtilityTabs.swift
+++ b/App/RootView+UtilityTabs.swift
@@ -26,6 +26,7 @@ extension RootView {
             fixedAppearance: dependencies.service.launchAppearance(worktreePath: worktreePath),
             onPasteFiles: pasteFiles,
             onCopyAllOutput: readAll,
+            reattachRequest: dependencies.dashboard.reattachRequests[session.name] ?? 0,
         )
         // A hair of room either side: the agent's own frames draw to
         // their last column, which sat against the pane's edges.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ updates.
   fact, watching checks and queued merges until they settle.
 - Fetch and Fetch and Reset on a repository follow its default branch
   when it has moved on GitHub, switching the checkout to the new one.
+- Reattaches a pane that shows nothing by itself, once, and offers
+  Reattach in the pane when that does not draw either; a right-click
+  on the pane or on the session strip above it offers it any time.
 - Asks Copilot to review a pull request, or to review it again after
   a push, from the Copilot icon in the conversation's header; it dims
   while a request is still waiting on it.

--- a/Sources/AgentIDEData/HerdrTerminalChannel.swift
+++ b/Sources/AgentIDEData/HerdrTerminalChannel.swift
@@ -1,5 +1,6 @@
 import AgentIDEDomain
 import Foundation
+import Synchronization
 
 /// A live `herdr terminal session control` client over pipes: JSON
 /// command lines go in on standard input, parsed frame events stream
@@ -39,29 +40,41 @@ public actor HerdrTerminalChannel {
 
         let reading = output.fileHandleForReading
         return AsyncStream { continuation in
-            let pump = Task {
-                var line = [UInt8]()
-                do {
-                    // Lines split at the byte level; each is ASCII
-                    // JSON (frame bytes travel as base64), so the
-                    // string round trip is lossless.
-                    for try await byte in reading.bytes {
-                        if byte == UInt8(ascii: "\n") {
-                            let text = String(bytes: line, encoding: .utf8) ?? ""
-                            if let event = HerdrTerminal.parse(line: text) {
-                                continuation.yield(event)
-                            }
-                            line.removeAll(keepingCapacity: true)
-                        } else {
-                            line.append(byte)
-                        }
-                    }
-                } catch {
-                    // A read error ends the stream like an exit.
+            // Event-driven, never a blocking read: `FileHandle.bytes`
+            // serialises its reads across every handle in the
+            // process, so one idle client held every later attach
+            // at nothing until it spoke. The handler runs on the
+            // handle's own serial queue, and the buffer's lock only
+            // says so to the compiler.
+            let line = Mutex([UInt8]())
+            reading.readabilityHandler = { handle in
+                let data = handle.availableData
+                guard data.isEmpty == false else {
+                    // End of the pipe: the client is gone.
+                    handle.readabilityHandler = nil
+                    continuation.finish()
+                    return
                 }
-                continuation.finish()
+
+                // Lines split at the byte level; each is ASCII JSON
+                // (frame bytes travel as base64), so the string round
+                // trip is lossless.
+                for byte in data {
+                    guard byte == UInt8(ascii: "\n") else {
+                        line.withLock { $0.append(byte) }
+                        continue
+                    }
+
+                    let text = line.withLock { pending in
+                        defer { pending.removeAll(keepingCapacity: true) }
+                        return String(bytes: pending, encoding: .utf8) ?? ""
+                    }
+                    if let event = HerdrTerminal.parse(line: text) {
+                        continuation.yield(event)
+                    }
+                }
             }
-            continuation.onTermination = { _ in pump.cancel() }
+            continuation.onTermination = { _ in reading.readabilityHandler = nil }
         }
     }
 

--- a/Sources/DashboardFeature/DashboardModel.swift
+++ b/Sources/DashboardFeature/DashboardModel.swift
@@ -91,6 +91,10 @@ public final class DashboardModel {
     /// which every row's summary read observes.
     public var pullRequestCacheGeneration = 0
 
+    /// How many times each session's strip has asked its pane to
+    /// discard the herdr client and attach afresh, by session name.
+    public var reattachRequests: [String: Int] = [:]
+
     /// Whether the machine is on battery, which slows every safety
     /// interval. The app's composition wires the machine's own
     /// answer in; left alone it says plugged in, so a test is never

--- a/Sources/TerminalUI/StalledPaneOverlay.swift
+++ b/Sources/TerminalUI/StalledPaneOverlay.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// What a pane draws over itself once it has shown nothing through
+/// the deadline and a silent reattach: what is wrong in a line, and
+/// the one button that puts it right.
+struct StalledPaneOverlay: View {
+    // MARK: Internal
+
+    let reattach: () -> Void
+
+    var body: some View {
+        VStack(spacing: Self.spacing) {
+            Text("This pane has drawn nothing from herdr")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Button("Reattach", action: reattach)
+                .buttonStyle(.glass)
+                .hoverHelp("Discard the herdr client and attach afresh; the session itself keeps running")
+        }
+        .padding(Self.padding)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: Self.corner))
+    }
+
+    // MARK: Private
+
+    private static let spacing: CGFloat = 8
+    private static let padding: CGFloat = 16
+    private static let corner: CGFloat = 10
+}

--- a/Sources/TerminalUI/TerminalPaneView.swift
+++ b/Sources/TerminalUI/TerminalPaneView.swift
@@ -21,7 +21,9 @@ public struct TerminalPaneView: View {
     /// give up keyboard focus or it swallows keystrokes and pastes
     /// meant for the visible one. `onProcessTerminated` fires on the
     /// main actor when the client exits, letting owners show a
-    /// restart affordance instead of a dead pane.
+    /// restart affordance instead of a dead pane. Each raise of
+    /// `reattachRequest` discards the client and attaches afresh,
+    /// for an owner's own Reattach beside the pane's.
     @preconcurrency
     public init(
         command: [String],
@@ -31,6 +33,7 @@ public struct TerminalPaneView: View {
         onPasteFiles: (([URL]) -> Bool)? = nil,
         onCopyAllOutput: (() async -> String?)? = nil,
         onProcessTerminated: (@MainActor () -> Void)? = nil,
+        reattachRequest: Int = 0,
     ) {
         transport = .control(command: command)
         self.reflowsCopies = reflowsCopies
@@ -39,6 +42,7 @@ public struct TerminalPaneView: View {
         self.onPasteFiles = onPasteFiles
         self.onCopyAllOutput = onCopyAllOutput
         self.onProcessTerminated = onProcessTerminated
+        ownerReattachRequest = reattachRequest
     }
 
     /// Creates a terminal running the user's login shell in a
@@ -59,21 +63,32 @@ public struct TerminalPaneView: View {
         onPasteFiles = nil
         onCopyAllOutput = nil
         self.onProcessTerminated = onProcessTerminated
+        ownerReattachRequest = 0
     }
 
     // MARK: Public
 
     public var body: some View {
-        TerminalRepresentable(
-            transport: transport,
-            reflowsCopies: reflowsCopies,
-            isActive: isActive,
-            fixedAppearance: fixedAppearance,
-            onPasteFiles: onPasteFiles,
-            onCopyAllOutput: onCopyAllOutput,
-            clearRequest: clearShellRequest,
-            onProcessTerminated: onProcessTerminated,
-        )
+        ZStack {
+            TerminalRepresentable(
+                transport: transport,
+                reflowsCopies: reflowsCopies,
+                isActive: isActive,
+                fixedAppearance: fixedAppearance,
+                onPasteFiles: onPasteFiles,
+                onCopyAllOutput: onCopyAllOutput,
+                clearRequest: clearShellRequest,
+                onProcessTerminated: onProcessTerminated,
+                onStalled: { isStalled = $0 },
+                reattachRequest: ownerReattachRequest + reattachRequest,
+            )
+            // Only once recovery has been tried and failed: a pane
+            // still showing nothing offers the one thing that fixes
+            // it, where a relaunch used to be the only way.
+            if isStalled, isActive {
+                StalledPaneOverlay { reattachRequest += 1 }
+            }
+        }
     }
 
     // MARK: Private
@@ -84,7 +99,13 @@ public struct TerminalPaneView: View {
     @AppStorage("clearShellRequest")
     private var clearShellRequest = 0
 
+    /// Whether the pane has drawn nothing through the deadline and a
+    /// reattach, and how many times Reattach has been pressed since.
+    @State private var isStalled = false
+    @State private var reattachRequest = 0
+
     private let transport: TerminalTransport
+    private let ownerReattachRequest: Int
     private let reflowsCopies: Bool
     private let isActive: Bool
 
@@ -131,6 +152,8 @@ struct TerminalRepresentable: NSViewRepresentable {
     let onCopyAllOutput: (() async -> String?)?
     let clearRequest: Int
     let onProcessTerminated: (@MainActor () -> Void)?
+    let onStalled: (Bool) -> Void
+    let reattachRequest: Int
 
     /// Detaches the coordinator's client with the view.
     static func dismantleNSView(_: PaneTerminalView, coordinator: Coordinator) {
@@ -153,6 +176,10 @@ struct TerminalRepresentable: NSViewRepresentable {
                     coordinator?.reattach(in: view)
                 }
             }
+            context.coordinator.onStalled = onStalled
+            // The owner's count outlives this view: a fresh
+            // coordinator takes it as the baseline, not as a press.
+            context.coordinator.seenReattachRequest = reattachRequest
         } else {
             view.processDelegate = context.coordinator
         }
@@ -183,6 +210,10 @@ struct TerminalRepresentable: NSViewRepresentable {
         // while drawing nothing until it is shown again.
         view.isHidden = isActive == false
         context.coordinator.updateFocus(isActive: isActive, of: view)
+        if reattachRequest != context.coordinator.seenReattachRequest {
+            context.coordinator.seenReattachRequest = reattachRequest
+            context.coordinator.reattach(in: view)
+        }
         if case .shell = transport, isActive {
             context.coordinator.clearIfRequested(clearRequest, in: view)
         }

--- a/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
+++ b/Sources/TerminalUI/TerminalRepresentable+Coordinator.swift
@@ -60,6 +60,15 @@ extension TerminalRepresentable {
         /// until recovery has been tried and failed.
         var heldFailure: String?
 
+        /// Whether the pane still shows nothing after the deadline
+        /// and a reattach, when it draws Reattach over itself.
+        var isStalled = false
+        var onStalled: ((Bool) -> Void)?
+
+        /// The last Reattach pressed on the pane, so a repaint never
+        /// reattaches twice for one press.
+        var seenReattachRequest = 0
+
         /// The Option-drag selector, owned by its event monitor.
         weak var blockSelector: BlockSelector?
 
@@ -147,6 +156,7 @@ extension TerminalRepresentable {
                 return
             }
 
+            setStalled(false)
             reattachments += 1
             discardClient(of: view)
             startWhenSized(transport, in: view)

--- a/Sources/TerminalUI/TerminalRepresentable.Coordinator+Conversation.swift
+++ b/Sources/TerminalUI/TerminalRepresentable.Coordinator+Conversation.swift
@@ -59,6 +59,9 @@ extension TerminalRepresentable.Coordinator {
             heldFailure = nil
             view?.feed(byteArray: bytes[...])
             blockSelector?.follow()
+            if isStalled, let view, Self.isScreenBlank(view.getTerminal()) == false {
+                setStalled(false)
+            }
 
         case let .closed(reason):
             exitReason = reason
@@ -137,18 +140,32 @@ extension TerminalRepresentable.Coordinator {
         return reason.contains(" exited") || reason.contains("not found")
     }
 
-    /// The deadline fired before any frame. A client that is running
-    /// yet drew nothing is discarded and attached afresh, once and
-    /// silently: every pane once went blank at the same time with
-    /// its sessions running on, and only a relaunch brought them
-    /// back. Only a pane still blank after that is reported, with
-    /// enough state to name the failing layer.
+    /// Whether every visible row shows nothing: the blank pane with
+    /// a cursor is a frame that painted an empty screen, which a
+    /// frame count never saw. A cell never written is a NUL, which
+    /// is not whitespace to Swift but is nothing on screen.
+    static func isScreenBlank(_ terminal: Terminal) -> Bool {
+        (0 ..< terminal.rows).allSatisfy { row in
+            terminal.getLine(row: row)?
+                .translateToString(trimRight: true)
+                .allSatisfy { $0.isWhitespace || $0 == "\0" } ?? true
+        }
+    }
+
+    /// The deadline fired. A client that is running yet has drawn
+    /// nothing, no frame or only an empty screen, is discarded and
+    /// attached afresh, once and silently: every pane once went
+    /// blank at the same time with its sessions running on, and only
+    /// a relaunch brought them back. Only a pane still blank after
+    /// that is reported, with enough state to name the failing
+    /// layer, and then offers Reattach over itself.
     private func reportIfBlank() {
-        guard framesSeen == 0, tornDown == false else {
+        guard tornDown == false, let view, framesSeen == 0 || Self.isScreenBlank(view.getTerminal()) else {
             return
         }
 
         let ended = channel
+        let what = framesSeen == 0 ? "no frames" : "a blank screen after \(framesSeen) frames"
         Task { [weak self] in
             let running = await ended?.isRunning() ?? false
             let chain = await ended?.launchChainSnapshot() ?? "gone"
@@ -157,17 +174,28 @@ extension TerminalRepresentable.Coordinator {
                 return
             }
 
-            if running, reattachments < Self.automaticReattachments, let view {
+            if running, reattachments < Self.automaticReattachments {
                 PerformanceLog.recordMessage(
-                    "Terminal: no frames after \(Self.frameTimeoutSeconds)s" + state + "; reattaching",
+                    "Terminal: " + what + " after \(Self.frameTimeoutSeconds)s" + state + "; reattaching",
                     isError: false,
                 )
                 reattach(in: view)
                 return
             }
 
-            report("no frames after \(Self.frameTimeoutSeconds)s"
-                + (reattachments > 0 ? " and none after reattaching" : "") + state)
+            report(what + " after \(Self.frameTimeoutSeconds)s"
+                + (reattachments > 0 ? ", after reattaching" : "") + state)
+            setStalled(true)
         }
+    }
+
+    /// Tells the pane whether to draw its Reattach.
+    func setStalled(_ stalled: Bool) {
+        guard isStalled != stalled else {
+            return
+        }
+
+        isStalled = stalled
+        onStalled?(stalled)
     }
 }

--- a/Tests/AgentIDEDataTests/HerdrTerminalChannelReaderTests.swift
+++ b/Tests/AgentIDEDataTests/HerdrTerminalChannelReaderTests.swift
@@ -1,0 +1,53 @@
+import AgentIDEData
+import AgentIDEDomain
+import Foundation
+import Testing
+
+/// The channel's reading must not wait on any other channel: a pane
+/// whose client sits silent (an idle agent) is the normal case, and
+/// a fresh attach beside it has to draw at once.
+struct HerdrTerminalChannelReaderTests {
+    @Test
+    func `a fresh client is read while other clients stay silent`() async throws {
+        let silent = (0 ..< 3).map { _ in HerdrTerminalChannel(command: ["sleep", "300"]) }
+        var drains = [Task<Void, Never>]()
+        for channel in silent {
+            let stream = try await channel.start()
+            drains.append(Task {
+                // Drained the way a pane drains its client.
+                for await _ in stream {
+                    // Nothing to keep.
+                }
+            })
+        }
+        let closed = #"{"type":"terminal.closed","reason":"done"}"#
+        let live = HerdrTerminalChannel(command: ["sh", "-c", "printf '%s\\n' '" + closed + "'; sleep 300"])
+        let stream = try await live.start()
+        let arrived = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await event in stream {
+                    if case .closed = event {
+                        return true
+                    }
+                }
+                return false
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(3))
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+        // Awaited, so no `sleep` child outlives the test.
+        await live.stop()
+        for channel in silent {
+            await channel.stop()
+        }
+        for drain in drains {
+            drain.cancel()
+        }
+        #expect(arrived, "the live client's first line should arrive while three clients say nothing")
+    }
+}

--- a/Tests/TerminalUITests/BlankScreenTests.swift
+++ b/Tests/TerminalUITests/BlankScreenTests.swift
@@ -1,0 +1,22 @@
+import AppKit
+@testable import TerminalUI
+import Testing
+
+/// A blank screen is one with nothing on any visible row.
+@MainActor
+struct BlankScreenTests {
+    @Test
+    func `a screen is blank until something is drawn on it`() {
+        let view = PaneTerminalView(frame: NSRect(x: 0, y: 0, width: 400, height: 200))
+        let terminal = view.getTerminal()
+        #expect(TerminalRepresentable.Coordinator.isScreenBlank(terminal))
+        view.feed(text: "   \r\n")
+        #expect(TerminalRepresentable.Coordinator.isScreenBlank(terminal))
+        // Spaces written past cells never touched: the untouched
+        // cells are NULs, and the row still shows nothing.
+        view.feed(text: "\u{1B}[3;20H  ")
+        #expect(TerminalRepresentable.Coordinator.isScreenBlank(terminal))
+        view.feed(text: "hello")
+        #expect(TerminalRepresentable.Coordinator.isScreenBlank(terminal) == false)
+    }
+}


### PR DESCRIPTION
- Reattach blank panes silently after five seconds using screen inspection, not frame count, while preserving session strip right-click option
- Make herdr client reads route through readability handler to handle silent pipes and idle agents event-drivenly